### PR TITLE
[BPK-2744] Improve the lockfile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2198,1317 +2198,45 @@
       "version": "file:backpack/packages/bpk-component-accordion",
       "dev": true,
       "requires": {
-        "bpk-animate-height": "^1.1.112",
-        "bpk-component-icon": "^3.31.4",
-        "bpk-mixins": "^17.24.4",
+        "bpk-animate-height": "^1.1.114",
+        "bpk-component-icon": "^3.31.5",
+        "bpk-mixins": "^17.24.5",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
       },
       "dependencies": {
         "bpk-animate-height": {
-          "version": "1.1.112",
-          "resolved": "https://registry.npmjs.org/bpk-animate-height/-/bpk-animate-height-1.1.112.tgz",
-          "integrity": "sha512-xX5wT7YKYgFbwRlOZVQXhqNKm7d1tlnp8Pk5sCf1CKVzgZO+be9W7GgZ9HF6wTUoWuMIAt/31f3fP80mDwlvFg==",
+          "version": "1.1.114",
+          "bundled": true,
           "dev": true,
           "requires": {
             "prop-types": "^15.6.2"
           }
         },
         "bpk-component-icon": {
-          "version": "3.31.4",
-          "resolved": "https://registry.npmjs.org/bpk-component-icon/-/bpk-component-icon-3.31.4.tgz",
-          "integrity": "sha512-DAiwhBYyyFmy2jonUFxEtxLpj2RlN17EDgd1zwZGpjfIhryyA+vL4XlSr8EkfPjZ6z+I6NWwbfmEUqDZgrn7Ag==",
+          "version": "3.31.5",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "bpk-mixins": "^17.24.4",
+            "bpk-mixins": "^17.24.5",
             "bpk-react-utils": "^2.7.9",
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4",
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5",
             "prop-types": "^15.6.2"
           }
         },
         "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
+          "version": "17.24.5",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        }
-      }
-    },
-    "bpk-component-autosuggest": {
-      "version": "file:backpack/packages/bpk-component-autosuggest",
-      "dev": true,
-      "requires": {
-        "bpk-component-input": "^4.1.26",
-        "bpk-mixins": "^17.24.4",
-        "bpk-react-utils": "^2.7.9",
-        "prop-types": "^15.6.2",
-        "react-autosuggest": "^9.4.2"
-      },
-      "dependencies": {
-        "bpk-component-input": {
-          "version": "4.1.26",
-          "resolved": "https://registry.npmjs.org/bpk-component-input/-/bpk-component-input-4.1.26.tgz",
-          "integrity": "sha512-+5P8u4+tmf+pABR9fhqDvMcVDaThFZgiEk9yPOcv0m9rgPZMzWXxOcEpN7Wzr2fdW6P/kCAtFA0jwUKtuzEyWQ==",
-          "dev": true,
-          "requires": {
-            "bpk-component-icon": "^3.31.4",
-            "bpk-mixins": "^17.24.4",
-            "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        }
-      }
-    },
-    "bpk-component-badge": {
-      "version": "file:backpack/packages/bpk-component-badge",
-      "dev": true,
-      "requires": {
-        "bpk-mixins": "^17.24.4",
-        "bpk-react-utils": "^2.7.9",
-        "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        }
-      }
-    },
-    "bpk-component-banner-alert": {
-      "version": "file:backpack/packages/bpk-component-banner-alert",
-      "dev": true,
-      "requires": {
-        "bpk-animate-height": "^1.1.112",
-        "bpk-component-close-button": "^1.0.141",
-        "bpk-component-icon": "^3.31.4",
-        "bpk-mixins": "^17.24.4",
-        "bpk-react-utils": "^2.7.9",
-        "bpk-tokens": "^27.6.4",
-        "prop-types": "^15.6.2",
-        "react-transition-group": "^2.5.3"
-      },
-      "dependencies": {
-        "bpk-animate-height": {
-          "version": "1.1.112",
-          "resolved": "https://registry.npmjs.org/bpk-animate-height/-/bpk-animate-height-1.1.112.tgz",
-          "integrity": "sha512-xX5wT7YKYgFbwRlOZVQXhqNKm7d1tlnp8Pk5sCf1CKVzgZO+be9W7GgZ9HF6wTUoWuMIAt/31f3fP80mDwlvFg==",
-          "dev": true,
-          "requires": {
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-component-close-button": {
-          "version": "1.0.141",
-          "resolved": "https://registry.npmjs.org/bpk-component-close-button/-/bpk-component-close-button-1.0.141.tgz",
-          "integrity": "sha512-Yd2kQnwuEQ3Myoqk2z/NDVIxB3YebCZrtgFJlQ/C6otp3sH3lbWLg4INREQqAyK1ZU5GK96qhvneubMA1tPLqQ==",
-          "dev": true,
-          "requires": {
-            "bpk-component-icon": "^3.31.4",
-            "bpk-mixins": "^17.24.4",
-            "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-component-icon": {
-          "version": "3.31.4",
-          "resolved": "https://registry.npmjs.org/bpk-component-icon/-/bpk-component-icon-3.31.4.tgz",
-          "integrity": "sha512-DAiwhBYyyFmy2jonUFxEtxLpj2RlN17EDgd1zwZGpjfIhryyA+vL4XlSr8EkfPjZ6z+I6NWwbfmEUqDZgrn7Ag==",
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.4",
-            "bpk-react-utils": "^2.7.9",
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        },
-        "bpk-tokens": {
-          "version": "27.6.4",
-          "resolved": "https://registry.npmjs.org/bpk-tokens/-/bpk-tokens-27.6.4.tgz",
-          "integrity": "sha512-/7BXdfw5Ft2UxkpLlme4x2TXoTEtITeJX1IzxqdgKZF0+fb+WT4SywoO0g9iM/nfQ1893ZEdNkG25u49v43dsQ==",
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
-          },
-          "dependencies": {
-            "color": {
-              "version": "3.1.2",
-              "resolved": "https://registry.npmjs.org/color/-/color-3.1.2.tgz",
-              "integrity": "sha512-vXTJhHebByxZn3lDvDJYw4lR5+uB3vuoHsuYA5AKuxRVn5wzzIfQKGLBmgdVRHKTJYeK5rvJcHnrd0Li49CFpg==",
-              "dev": true,
-              "requires": {
-                "color-convert": "^1.9.1",
-                "color-string": "^1.5.2"
-              }
-            }
-          }
-        }
-      }
-    },
-    "bpk-component-barchart": {
-      "version": "file:backpack/packages/bpk-component-barchart",
-      "dev": true,
-      "requires": {
-        "bpk-component-mobile-scroll-container": "^1.1.81",
-        "bpk-mixins": "^17.24.4",
-        "bpk-react-utils": "^2.7.9",
-        "bpk-tokens": "^27.6.4",
-        "d3-path": "^1.0.5",
-        "d3-scale": "^2.1.0",
-        "lodash.debounce": "^4.0.8",
-        "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-component-mobile-scroll-container": {
-          "version": "1.1.81",
-          "resolved": "https://registry.npmjs.org/bpk-component-mobile-scroll-container/-/bpk-component-mobile-scroll-container-1.1.81.tgz",
-          "integrity": "sha512-j+UYBa/vMZjqcCaz2cwoQWdcg3Tvt33iNdLNzrI/MWb92wqxW+BQ6PDazAX9L4VklzzEIAkOGS/76/DyIu57mg==",
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.4",
-            "bpk-react-utils": "^2.7.9",
-            "lodash.debounce": "^4.0.8",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        },
-        "bpk-tokens": {
-          "version": "27.6.4",
-          "resolved": "https://registry.npmjs.org/bpk-tokens/-/bpk-tokens-27.6.4.tgz",
-          "integrity": "sha512-/7BXdfw5Ft2UxkpLlme4x2TXoTEtITeJX1IzxqdgKZF0+fb+WT4SywoO0g9iM/nfQ1893ZEdNkG25u49v43dsQ==",
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
-          },
-          "dependencies": {
-            "color": {
-              "version": "3.1.2",
-              "resolved": "https://registry.npmjs.org/color/-/color-3.1.2.tgz",
-              "integrity": "sha512-vXTJhHebByxZn3lDvDJYw4lR5+uB3vuoHsuYA5AKuxRVn5wzzIfQKGLBmgdVRHKTJYeK5rvJcHnrd0Li49CFpg==",
-              "dev": true,
-              "requires": {
-                "color-convert": "^1.9.1",
-                "color-string": "^1.5.2"
-              }
-            }
-          }
-        }
-      }
-    },
-    "bpk-component-blockquote": {
-      "version": "file:backpack/packages/bpk-component-blockquote",
-      "dev": true,
-      "requires": {
-        "bpk-mixins": "^17.24.4",
-        "bpk-react-utils": "^2.7.9",
-        "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        }
-      }
-    },
-    "bpk-component-breadcrumb": {
-      "version": "file:backpack/packages/bpk-component-breadcrumb",
-      "dev": true,
-      "requires": {
-        "bpk-component-icon": "^3.31.4",
-        "bpk-component-link": "^1.2.75",
-        "bpk-component-text": "^1.1.6",
-        "bpk-mixins": "^17.24.4",
-        "bpk-react-utils": "^2.7.9",
-        "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-component-icon": {
-          "version": "3.31.4",
-          "resolved": "https://registry.npmjs.org/bpk-component-icon/-/bpk-component-icon-3.31.4.tgz",
-          "integrity": "sha512-DAiwhBYyyFmy2jonUFxEtxLpj2RlN17EDgd1zwZGpjfIhryyA+vL4XlSr8EkfPjZ6z+I6NWwbfmEUqDZgrn7Ag==",
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.4",
-            "bpk-react-utils": "^2.7.9",
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-component-link": {
-          "version": "1.2.75",
-          "resolved": "https://registry.npmjs.org/bpk-component-link/-/bpk-component-link-1.2.75.tgz",
-          "integrity": "sha512-qoosptvwz8ZjxRt2WvoERb2E71zrBhs5+USNjy6FtDl+cXndmMOsINB1JiAmMB9TO6PgUZJkj7FBN7Vm7rZ+bQ==",
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.4",
-            "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-component-text": {
-          "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/bpk-component-text/-/bpk-component-text-1.1.6.tgz",
-          "integrity": "sha512-U4wp5+Fz1Rd9LeJphQRKwKx2ekIbzGj0SFdvjDkVOkG120YVtVb4YQN/3xEl/zb7Csku5HLvkJIJK4C+wR22nQ==",
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.4",
-            "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        }
-      }
-    },
-    "bpk-component-breakpoint": {
-      "version": "file:backpack/packages/bpk-component-breakpoint",
-      "dev": true,
-      "requires": {
-        "bpk-mixins": "^17.24.4",
-        "prop-types": "^15.6.2",
-        "react-responsive": "^5.0.0"
-      },
-      "dependencies": {
-        "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
-          }
-        }
-      }
-    },
-    "bpk-component-button": {
-      "version": "file:backpack/packages/bpk-component-button",
-      "dev": true,
-      "requires": {
-        "bpk-mixins": "^17.24.4",
-        "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
-          }
-        }
-      }
-    },
-    "bpk-component-calendar": {
-      "version": "file:backpack/packages/bpk-component-calendar",
-      "dev": true,
-      "requires": {
-        "bpk-component-icon": "^3.31.4",
-        "bpk-component-select": "^2.3.7",
-        "bpk-mixins": "^17.24.4",
-        "bpk-react-utils": "^2.7.9",
-        "bpk-tokens": "^27.6.4",
-        "date-fns": "^1.29.0",
-        "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-component-icon": {
-          "version": "3.31.4",
-          "resolved": "https://registry.npmjs.org/bpk-component-icon/-/bpk-component-icon-3.31.4.tgz",
-          "integrity": "sha512-DAiwhBYyyFmy2jonUFxEtxLpj2RlN17EDgd1zwZGpjfIhryyA+vL4XlSr8EkfPjZ6z+I6NWwbfmEUqDZgrn7Ag==",
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.4",
-            "bpk-react-utils": "^2.7.9",
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-component-select": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/bpk-component-select/-/bpk-component-select-2.3.7.tgz",
-          "integrity": "sha512-5A3duQQ58GmdgHfI8GCvbMA8b8IzyUh+b+7mRQVR0NBCqY2HUL1rrjly95ejfZx1OhUWfEwwYU3fAOFgpj6o3A==",
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.4",
-            "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        },
-        "bpk-tokens": {
-          "version": "27.6.4",
-          "resolved": "https://registry.npmjs.org/bpk-tokens/-/bpk-tokens-27.6.4.tgz",
-          "integrity": "sha512-/7BXdfw5Ft2UxkpLlme4x2TXoTEtITeJX1IzxqdgKZF0+fb+WT4SywoO0g9iM/nfQ1893ZEdNkG25u49v43dsQ==",
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
-          },
-          "dependencies": {
-            "color": {
-              "version": "3.1.2",
-              "resolved": "https://registry.npmjs.org/color/-/color-3.1.2.tgz",
-              "integrity": "sha512-vXTJhHebByxZn3lDvDJYw4lR5+uB3vuoHsuYA5AKuxRVn5wzzIfQKGLBmgdVRHKTJYeK5rvJcHnrd0Li49CFpg==",
-              "dev": true,
-              "requires": {
-                "color-convert": "^1.9.1",
-                "color-string": "^1.5.2"
-              }
-            }
-          }
-        }
-      }
-    },
-    "bpk-component-card": {
-      "version": "file:backpack/packages/bpk-component-card",
-      "dev": true,
-      "requires": {
-        "bpk-mixins": "^17.24.4",
-        "bpk-react-utils": "^2.7.9",
-        "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        }
-      }
-    },
-    "bpk-component-checkbox": {
-      "version": "file:backpack/packages/bpk-component-checkbox",
-      "dev": true,
-      "requires": {
-        "bpk-component-icon": "^3.31.4",
-        "bpk-mixins": "^17.24.4",
-        "bpk-react-utils": "^2.7.9",
-        "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-component-icon": {
-          "version": "3.31.4",
-          "resolved": "https://registry.npmjs.org/bpk-component-icon/-/bpk-component-icon-3.31.4.tgz",
-          "integrity": "sha512-DAiwhBYyyFmy2jonUFxEtxLpj2RlN17EDgd1zwZGpjfIhryyA+vL4XlSr8EkfPjZ6z+I6NWwbfmEUqDZgrn7Ag==",
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.4",
-            "bpk-react-utils": "^2.7.9",
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        }
-      }
-    },
-    "bpk-component-chip": {
-      "version": "file:backpack/packages/bpk-component-chip",
-      "dev": true,
-      "requires": {
-        "bpk-component-close-button": "^1.0.141",
-        "bpk-mixins": "^17.24.4",
-        "bpk-react-utils": "^2.7.9",
-        "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-component-close-button": {
-          "version": "1.0.141",
-          "resolved": "https://registry.npmjs.org/bpk-component-close-button/-/bpk-component-close-button-1.0.141.tgz",
-          "integrity": "sha512-Yd2kQnwuEQ3Myoqk2z/NDVIxB3YebCZrtgFJlQ/C6otp3sH3lbWLg4INREQqAyK1ZU5GK96qhvneubMA1tPLqQ==",
-          "dev": true,
-          "requires": {
-            "bpk-component-icon": "^3.31.4",
-            "bpk-mixins": "^17.24.4",
-            "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        }
-      }
-    },
-    "bpk-component-close-button": {
-      "version": "file:backpack/packages/bpk-component-close-button",
-      "dev": true,
-      "requires": {
-        "bpk-component-icon": "^3.31.4",
-        "bpk-mixins": "^17.24.4",
-        "bpk-react-utils": "^2.7.9",
-        "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-component-icon": {
-          "version": "3.31.4",
-          "resolved": "https://registry.npmjs.org/bpk-component-icon/-/bpk-component-icon-3.31.4.tgz",
-          "integrity": "sha512-DAiwhBYyyFmy2jonUFxEtxLpj2RlN17EDgd1zwZGpjfIhryyA+vL4XlSr8EkfPjZ6z+I6NWwbfmEUqDZgrn7Ag==",
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.4",
-            "bpk-react-utils": "^2.7.9",
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        }
-      }
-    },
-    "bpk-component-code": {
-      "version": "file:backpack/packages/bpk-component-code",
-      "dev": true,
-      "requires": {
-        "bpk-mixins": "^17.24.4",
-        "bpk-react-utils": "^2.7.9",
-        "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        }
-      }
-    },
-    "bpk-component-content-container": {
-      "version": "file:backpack/packages/bpk-component-content-container",
-      "dev": true,
-      "requires": {
-        "bpk-mixins": "^17.24.4",
-        "bpk-react-utils": "^2.7.9",
-        "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        }
-      }
-    },
-    "bpk-component-datepicker": {
-      "version": "file:backpack/packages/bpk-component-datepicker",
-      "dev": true,
-      "requires": {
-        "bpk-component-breakpoint": "^1.1.74",
-        "bpk-component-calendar": "^5.0.26",
-        "bpk-component-input": "^4.1.26",
-        "bpk-component-modal": "^1.8.73",
-        "bpk-component-popover": "^2.2.49",
-        "bpk-mixins": "^17.24.4",
-        "bpk-react-utils": "^2.7.9",
-        "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-component-breakpoint": {
-          "version": "1.1.74",
-          "resolved": "https://registry.npmjs.org/bpk-component-breakpoint/-/bpk-component-breakpoint-1.1.74.tgz",
-          "integrity": "sha512-4C5vPMoBnKKXXC/C2KZg3Csz+c+nxmrJqGaTmEA5XlTG6GyomX4ltOmEtsG4x+mDK+qJYSg/HsxbZHIIxGHx/w==",
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.4",
-            "prop-types": "^15.6.2",
-            "react-responsive": "^5.0.0"
-          }
-        },
-        "bpk-component-calendar": {
-          "version": "5.0.26",
-          "resolved": "https://registry.npmjs.org/bpk-component-calendar/-/bpk-component-calendar-5.0.26.tgz",
-          "integrity": "sha512-eBo5tfZyTczqZn0EH5Xv1Weahf1S/hR92PpZlJV3GPs7yMrYsf0C+Bxn1edkvCKZu4lX83bl2Er6zfPAgfkUdg==",
-          "dev": true,
-          "requires": {
-            "bpk-component-icon": "^3.31.4",
-            "bpk-component-select": "^2.3.7",
-            "bpk-mixins": "^17.24.4",
-            "bpk-react-utils": "^2.7.9",
-            "bpk-tokens": "^27.6.4",
-            "date-fns": "^1.29.0",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-component-input": {
-          "version": "4.1.26",
-          "resolved": "https://registry.npmjs.org/bpk-component-input/-/bpk-component-input-4.1.26.tgz",
-          "integrity": "sha512-+5P8u4+tmf+pABR9fhqDvMcVDaThFZgiEk9yPOcv0m9rgPZMzWXxOcEpN7Wzr2fdW6P/kCAtFA0jwUKtuzEyWQ==",
-          "dev": true,
-          "requires": {
-            "bpk-component-icon": "^3.31.4",
-            "bpk-mixins": "^17.24.4",
-            "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-component-modal": {
-          "version": "1.8.73",
-          "resolved": "https://registry.npmjs.org/bpk-component-modal/-/bpk-component-modal-1.8.73.tgz",
-          "integrity": "sha512-P3XSsRB8QzPnUnNNKXTj9mBSua976Kfsl7R2gSQbb+Jclm1GBboxx/ma4oqND2ywAHEPyv8cePWv2TwN/J7E/g==",
-          "dev": true,
-          "requires": {
-            "bpk-component-close-button": "^1.0.141",
-            "bpk-component-icon": "^3.31.4",
-            "bpk-component-link": "^1.2.75",
-            "bpk-mixins": "^17.24.4",
-            "bpk-react-utils": "^2.7.9",
-            "bpk-scrim-utils": "^3.2.75",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-component-popover": {
-          "version": "2.2.49",
-          "resolved": "https://registry.npmjs.org/bpk-component-popover/-/bpk-component-popover-2.2.49.tgz",
-          "integrity": "sha512-BSnRBLjK6V9he2MQescsfU+bONFKzo8IDE75c5cLRIvXTa+NWxtYh+yB0jh1lz3A8ycLHpNnFcDHYb5icOQ84A==",
-          "dev": true,
-          "requires": {
-            "@skyscanner/popper.js": "^1.12.9-beta.1",
-            "a11y-focus-scope": "^1.1.3",
-            "a11y-focus-store": "^1.0.0",
-            "bpk-component-close-button": "^1.0.141",
-            "bpk-component-link": "^1.2.75",
-            "bpk-component-text": "^1.1.6",
-            "bpk-mixins": "^17.24.4",
-            "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        },
-        "bpk-scrim-utils": {
-          "version": "3.2.75",
-          "resolved": "https://registry.npmjs.org/bpk-scrim-utils/-/bpk-scrim-utils-3.2.75.tgz",
-          "integrity": "sha512-8CSMp/znOPIza3/3jBCdHPNQF68AxpizJ87VLiXz/ILy1o9dNjsEW6AnzDuhuy1U38sAc2JGeIxOwCWIJPZfQw==",
-          "dev": true,
-          "requires": {
-            "a11y-focus-scope": "^1.1.3",
-            "a11y-focus-store": "^1.0.0",
-            "bpk-mixins": "^17.24.4",
-            "bpk-react-utils": "^2.7.9"
-          }
-        }
-      }
-    },
-    "bpk-component-description-list": {
-      "version": "file:backpack/packages/bpk-component-description-list",
-      "dev": true,
-      "requires": {
-        "bpk-mixins": "^17.24.4",
-        "bpk-react-utils": "^2.7.9",
-        "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        }
-      }
-    },
-    "bpk-component-dialog": {
-      "version": "file:backpack/packages/bpk-component-dialog",
-      "dev": true,
-      "requires": {
-        "bpk-component-modal": "^1.8.73",
-        "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-component-modal": {
-          "version": "1.8.73",
-          "resolved": "https://registry.npmjs.org/bpk-component-modal/-/bpk-component-modal-1.8.73.tgz",
-          "integrity": "sha512-P3XSsRB8QzPnUnNNKXTj9mBSua976Kfsl7R2gSQbb+Jclm1GBboxx/ma4oqND2ywAHEPyv8cePWv2TwN/J7E/g==",
-          "dev": true,
-          "requires": {
-            "bpk-component-close-button": "^1.0.141",
-            "bpk-component-icon": "^3.31.4",
-            "bpk-component-link": "^1.2.75",
-            "bpk-mixins": "^17.24.4",
-            "bpk-react-utils": "^2.7.9",
-            "bpk-scrim-utils": "^3.2.75",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-scrim-utils": {
-          "version": "3.2.75",
-          "resolved": "https://registry.npmjs.org/bpk-scrim-utils/-/bpk-scrim-utils-3.2.75.tgz",
-          "integrity": "sha512-8CSMp/znOPIza3/3jBCdHPNQF68AxpizJ87VLiXz/ILy1o9dNjsEW6AnzDuhuy1U38sAc2JGeIxOwCWIJPZfQw==",
-          "dev": true,
-          "requires": {
-            "a11y-focus-scope": "^1.1.3",
-            "a11y-focus-store": "^1.0.0",
-            "bpk-mixins": "^17.24.4",
-            "bpk-react-utils": "^2.7.9"
-          }
-        }
-      }
-    },
-    "bpk-component-drawer": {
-      "version": "file:backpack/packages/bpk-component-drawer",
-      "dev": true,
-      "requires": {
-        "bpk-component-close-button": "^1.0.141",
-        "bpk-component-icon": "^3.31.4",
-        "bpk-component-link": "^1.2.75",
-        "bpk-mixins": "^17.24.4",
-        "bpk-react-utils": "^2.7.9",
-        "bpk-scrim-utils": "^3.2.75",
-        "bpk-tokens": "^27.6.4",
-        "prop-types": "^15.6.2",
-        "react-transition-group": "^2.5.3"
-      },
-      "dependencies": {
-        "bpk-component-close-button": {
-          "version": "1.0.141",
-          "resolved": "https://registry.npmjs.org/bpk-component-close-button/-/bpk-component-close-button-1.0.141.tgz",
-          "integrity": "sha512-Yd2kQnwuEQ3Myoqk2z/NDVIxB3YebCZrtgFJlQ/C6otp3sH3lbWLg4INREQqAyK1ZU5GK96qhvneubMA1tPLqQ==",
-          "dev": true,
-          "requires": {
-            "bpk-component-icon": "^3.31.4",
-            "bpk-mixins": "^17.24.4",
-            "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-component-icon": {
-          "version": "3.31.4",
-          "resolved": "https://registry.npmjs.org/bpk-component-icon/-/bpk-component-icon-3.31.4.tgz",
-          "integrity": "sha512-DAiwhBYyyFmy2jonUFxEtxLpj2RlN17EDgd1zwZGpjfIhryyA+vL4XlSr8EkfPjZ6z+I6NWwbfmEUqDZgrn7Ag==",
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.4",
-            "bpk-react-utils": "^2.7.9",
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-component-link": {
-          "version": "1.2.75",
-          "resolved": "https://registry.npmjs.org/bpk-component-link/-/bpk-component-link-1.2.75.tgz",
-          "integrity": "sha512-qoosptvwz8ZjxRt2WvoERb2E71zrBhs5+USNjy6FtDl+cXndmMOsINB1JiAmMB9TO6PgUZJkj7FBN7Vm7rZ+bQ==",
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.4",
-            "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        },
-        "bpk-scrim-utils": {
-          "version": "3.2.75",
-          "resolved": "https://registry.npmjs.org/bpk-scrim-utils/-/bpk-scrim-utils-3.2.75.tgz",
-          "integrity": "sha512-8CSMp/znOPIza3/3jBCdHPNQF68AxpizJ87VLiXz/ILy1o9dNjsEW6AnzDuhuy1U38sAc2JGeIxOwCWIJPZfQw==",
-          "dev": true,
-          "requires": {
-            "a11y-focus-scope": "^1.1.3",
-            "a11y-focus-store": "^1.0.0",
-            "bpk-mixins": "^17.24.4",
-            "bpk-react-utils": "^2.7.9"
-          }
-        },
-        "bpk-tokens": {
-          "version": "27.6.4",
-          "resolved": "https://registry.npmjs.org/bpk-tokens/-/bpk-tokens-27.6.4.tgz",
-          "integrity": "sha512-/7BXdfw5Ft2UxkpLlme4x2TXoTEtITeJX1IzxqdgKZF0+fb+WT4SywoO0g9iM/nfQ1893ZEdNkG25u49v43dsQ==",
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
-          },
-          "dependencies": {
-            "color": {
-              "version": "3.1.2",
-              "resolved": "https://registry.npmjs.org/color/-/color-3.1.2.tgz",
-              "integrity": "sha512-vXTJhHebByxZn3lDvDJYw4lR5+uB3vuoHsuYA5AKuxRVn5wzzIfQKGLBmgdVRHKTJYeK5rvJcHnrd0Li49CFpg==",
-              "dev": true,
-              "requires": {
-                "color-convert": "^1.9.1",
-                "color-string": "^1.5.2"
-              }
-            }
-          }
-        }
-      }
-    },
-    "bpk-component-fieldset": {
-      "version": "file:backpack/packages/bpk-component-fieldset",
-      "dev": true,
-      "requires": {
-        "bpk-component-form-validation": "^2.0.26",
-        "bpk-component-label": "^3.2.144",
-        "bpk-mixins": "^17.24.4",
-        "bpk-react-utils": "^2.7.9",
-        "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-component-form-validation": {
-          "version": "2.0.26",
-          "resolved": "https://registry.npmjs.org/bpk-component-form-validation/-/bpk-component-form-validation-2.0.26.tgz",
-          "integrity": "sha512-APA045h/x0cWVmyUKkVfzJR7R6L2un8EngRcr4MrhN12EC3Ppoc58WilzfkWYf2gq7uOt1HDZyXVbyxiWn0Naw==",
-          "dev": true,
-          "requires": {
-            "bpk-animate-height": "^1.1.112",
-            "bpk-mixins": "^17.24.4",
-            "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-component-label": {
-          "version": "3.2.144",
-          "resolved": "https://registry.npmjs.org/bpk-component-label/-/bpk-component-label-3.2.144.tgz",
-          "integrity": "sha512-78mIbPwaeOwidu76SlPVo4fJG6d7kfSQ2JGlvZ4yU70it793xmj/ll0E2+PcAaAWoeNTVwreQmctg/RkwgNTRQ==",
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.4",
-            "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        }
-      }
-    },
-    "bpk-component-form-validation": {
-      "version": "file:backpack/packages/bpk-component-form-validation",
-      "dev": true,
-      "requires": {
-        "bpk-animate-height": "^1.1.112",
-        "bpk-mixins": "^17.24.4",
-        "bpk-react-utils": "^2.7.9",
-        "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-animate-height": {
-          "version": "1.1.112",
-          "resolved": "https://registry.npmjs.org/bpk-animate-height/-/bpk-animate-height-1.1.112.tgz",
-          "integrity": "sha512-xX5wT7YKYgFbwRlOZVQXhqNKm7d1tlnp8Pk5sCf1CKVzgZO+be9W7GgZ9HF6wTUoWuMIAt/31f3fP80mDwlvFg==",
-          "dev": true,
-          "requires": {
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        }
-      }
-    },
-    "bpk-component-grid": {
-      "version": "file:backpack/packages/bpk-component-grid",
-      "dev": true,
-      "requires": {
-        "bpk-mixins": "^17.24.4",
-        "bpk-react-utils": "^2.7.9",
-        "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        }
-      }
-    },
-    "bpk-component-grid-toggle": {
-      "version": "file:backpack/packages/bpk-component-grid-toggle",
-      "dev": true,
-      "requires": {
-        "bpk-component-link": "^1.2.75",
-        "bpk-mixins": "^17.24.4",
-        "bpk-react-utils": "^2.7.9",
-        "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-component-link": {
-          "version": "1.2.75",
-          "resolved": "https://registry.npmjs.org/bpk-component-link/-/bpk-component-link-1.2.75.tgz",
-          "integrity": "sha512-qoosptvwz8ZjxRt2WvoERb2E71zrBhs5+USNjy6FtDl+cXndmMOsINB1JiAmMB9TO6PgUZJkj7FBN7Vm7rZ+bQ==",
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.4",
-            "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        }
-      }
-    },
-    "bpk-component-horizontal-nav": {
-      "version": "file:backpack/packages/bpk-component-horizontal-nav",
-      "dev": true,
-      "requires": {
-        "bpk-component-mobile-scroll-container": "^1.1.81",
-        "bpk-mixins": "^17.24.4",
-        "bpk-react-utils": "^2.7.9",
-        "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-component-mobile-scroll-container": {
-          "version": "1.1.81",
-          "resolved": "https://registry.npmjs.org/bpk-component-mobile-scroll-container/-/bpk-component-mobile-scroll-container-1.1.81.tgz",
-          "integrity": "sha512-j+UYBa/vMZjqcCaz2cwoQWdcg3Tvt33iNdLNzrI/MWb92wqxW+BQ6PDazAX9L4VklzzEIAkOGS/76/DyIu57mg==",
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.4",
-            "bpk-react-utils": "^2.7.9",
-            "lodash.debounce": "^4.0.8",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        }
-      }
-    },
-    "bpk-component-icon": {
-      "version": "file:backpack/packages/bpk-component-icon",
-      "dev": true,
-      "requires": {
-        "bpk-mixins": "^17.24.4",
-        "bpk-react-utils": "^2.7.9",
-        "bpk-svgs": "^6.9.2",
-        "bpk-tokens": "^27.6.4",
-        "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
@@ -3518,15 +2246,13 @@
           }
         },
         "bpk-svgs": {
-          "version": "6.9.2",
-          "resolved": "https://registry.npmjs.org/bpk-svgs/-/bpk-svgs-6.9.2.tgz",
-          "integrity": "sha512-gicoSPPzsQVc0eBUtpn0vGfs/azztQIsA5IDeJaW50G1MHst9C7KBUdegnf64oRwjuVRZbdXsTz5I7h1UqgXKA==",
+          "version": "6.9.3",
+          "bundled": true,
           "dev": true
         },
         "bpk-tokens": {
-          "version": "27.6.4",
-          "resolved": "https://registry.npmjs.org/bpk-tokens/-/bpk-tokens-27.6.4.tgz",
-          "integrity": "sha512-/7BXdfw5Ft2UxkpLlme4x2TXoTEtITeJX1IzxqdgKZF0+fb+WT4SywoO0g9iM/nfQ1893ZEdNkG25u49v43dsQ==",
+          "version": "27.6.5",
+          "bundled": true,
           "dev": true,
           "requires": {
             "color": "^3.0.0"
@@ -3546,77 +2272,200 @@
         }
       }
     },
-    "bpk-component-image": {
-      "version": "file:backpack/packages/bpk-component-image",
+    "bpk-component-autosuggest": {
+      "version": "file:backpack/packages/bpk-component-autosuggest",
       "dev": true,
       "requires": {
-        "bpk-component-spinner": "^2.2.106",
-        "bpk-mixins": "^17.24.4",
+        "bpk-component-input": "^4.1.27",
+        "bpk-mixins": "^17.24.5",
         "bpk-react-utils": "^2.7.9",
+        "prop-types": "^15.6.2",
+        "react-autosuggest": "^9.4.2"
+      },
+      "dependencies": {
+        "bpk-component-icon": {
+          "version": "3.31.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-input": {
+          "version": "4.1.27",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-component-icon": "^3.31.5",
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          },
+          "dependencies": {
+            "color": {
+              "version": "3.1.2",
+              "resolved": "https://registry.npmjs.org/color/-/color-3.1.2.tgz",
+              "integrity": "sha512-vXTJhHebByxZn3lDvDJYw4lR5+uB3vuoHsuYA5AKuxRVn5wzzIfQKGLBmgdVRHKTJYeK5rvJcHnrd0Li49CFpg==",
+              "dev": true,
+              "requires": {
+                "color-convert": "^1.9.1",
+                "color-string": "^1.5.2"
+              }
+            }
+          }
+        }
+      }
+    },
+    "bpk-component-badge": {
+      "version": "file:backpack/packages/bpk-component-badge",
+      "dev": true,
+      "requires": {
+        "bpk-mixins": "^17.24.5",
+        "bpk-react-utils": "^2.7.9",
+        "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          },
+          "dependencies": {
+            "color": {
+              "version": "3.1.2",
+              "resolved": "https://registry.npmjs.org/color/-/color-3.1.2.tgz",
+              "integrity": "sha512-vXTJhHebByxZn3lDvDJYw4lR5+uB3vuoHsuYA5AKuxRVn5wzzIfQKGLBmgdVRHKTJYeK5rvJcHnrd0Li49CFpg==",
+              "dev": true,
+              "requires": {
+                "color-convert": "^1.9.1",
+                "color-string": "^1.5.2"
+              }
+            }
+          }
+        }
+      }
+    },
+    "bpk-component-banner-alert": {
+      "version": "file:backpack/packages/bpk-component-banner-alert",
+      "dev": true,
+      "requires": {
+        "bpk-animate-height": "^1.1.114",
+        "bpk-component-close-button": "^1.0.142",
+        "bpk-component-icon": "^3.31.5",
+        "bpk-mixins": "^17.24.5",
+        "bpk-react-utils": "^2.7.9",
+        "bpk-tokens": "^27.6.5",
         "prop-types": "^15.6.2",
         "react-transition-group": "^2.5.3"
       },
       "dependencies": {
-        "bpk-component-spinner": {
-          "version": "2.2.106",
-          "resolved": "https://registry.npmjs.org/bpk-component-spinner/-/bpk-component-spinner-2.2.106.tgz",
-          "integrity": "sha512-iOd+i+VMT0lN35FPhr9bEvet205lD911cf7Nu75tAgrBOL/n8B23p4KWkJU8WOB6pccUZ1gC9EClQ2UDSMOXFQ==",
+        "bpk-animate-height": {
+          "version": "1.1.114",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "bpk-mixins": "^17.24.4",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-close-button": {
+          "version": "1.0.142",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-component-icon": "^3.31.5",
+            "bpk-mixins": "^17.24.5",
             "bpk-react-utils": "^2.7.9",
-            "bpk-svgs": "^6.9.2",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-icon": {
+          "version": "3.31.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5",
             "prop-types": "^15.6.2"
           }
         },
         "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
+          "version": "17.24.5",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        }
-      }
-    },
-    "bpk-component-infinite-scroll": {
-      "version": "file:backpack/packages/bpk-component-infinite-scroll",
-      "dev": true,
-      "requires": {
-        "bpk-mixins": "^17.24.4",
-        "bpk-react-utils": "^2.7.9",
-        "intersection-observer": "^0.7.0",
-        "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
@@ -3625,302 +2474,58 @@
             "recompose": "^0.30.0"
           }
         },
-        "intersection-observer": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/intersection-observer/-/intersection-observer-0.7.0.tgz",
-          "integrity": "sha512-Id0Fij0HsB/vKWGeBe9PxeY45ttRiBmhFyyt/geBdDHBYNctMRTE3dC1U3ujzz3lap+hVXlEcVaB56kZP/eEUg==",
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
           "dev": true
-        }
-      }
-    },
-    "bpk-component-input": {
-      "version": "file:backpack/packages/bpk-component-input",
-      "dev": true,
-      "requires": {
-        "bpk-component-icon": "^3.31.4",
-        "bpk-mixins": "^17.24.4",
-        "bpk-react-utils": "^2.7.9",
-        "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-component-icon": {
-          "version": "3.31.4",
-          "resolved": "https://registry.npmjs.org/bpk-component-icon/-/bpk-component-icon-3.31.4.tgz",
-          "integrity": "sha512-DAiwhBYyyFmy2jonUFxEtxLpj2RlN17EDgd1zwZGpjfIhryyA+vL4XlSr8EkfPjZ6z+I6NWwbfmEUqDZgrn7Ag==",
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.4",
-            "bpk-react-utils": "^2.7.9",
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4",
-            "prop-types": "^15.6.2"
-          }
         },
-        "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
+            "color": "^3.0.0"
           }
         }
       }
     },
-    "bpk-component-label": {
-      "version": "file:backpack/packages/bpk-component-label",
+    "bpk-component-barchart": {
+      "version": "file:backpack/packages/bpk-component-barchart",
       "dev": true,
       "requires": {
-        "bpk-mixins": "^17.24.4",
+        "bpk-component-mobile-scroll-container": "^1.1.83",
+        "bpk-mixins": "^17.24.5",
         "bpk-react-utils": "^2.7.9",
-        "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        }
-      }
-    },
-    "bpk-component-link": {
-      "version": "file:backpack/packages/bpk-component-link",
-      "dev": true,
-      "requires": {
-        "bpk-mixins": "^17.24.4",
-        "bpk-react-utils": "^2.7.9",
-        "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        }
-      }
-    },
-    "bpk-component-list": {
-      "version": "file:backpack/packages/bpk-component-list",
-      "dev": true,
-      "requires": {
-        "bpk-mixins": "^17.24.4",
-        "bpk-react-utils": "^2.7.9",
-        "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        }
-      }
-    },
-    "bpk-component-loading-button": {
-      "version": "file:backpack/packages/bpk-component-loading-button",
-      "dev": true,
-      "requires": {
-        "bpk-component-button": "^2.4.1",
-        "bpk-component-icon": "^3.31.4",
-        "bpk-component-spinner": "^2.2.106",
-        "bpk-mixins": "^17.24.4",
-        "bpk-react-utils": "^2.7.9",
-        "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-component-button": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/bpk-component-button/-/bpk-component-button-2.4.1.tgz",
-          "integrity": "sha512-4jJ5wxgquUUVGHpblXf0yWlpVFNtmDo0DjLMkGL5U4HxFIgc0XZp911KjIzUVeCh+3eGASeAthQgLCruQghzOg==",
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.4",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-component-icon": {
-          "version": "3.31.4",
-          "resolved": "https://registry.npmjs.org/bpk-component-icon/-/bpk-component-icon-3.31.4.tgz",
-          "integrity": "sha512-DAiwhBYyyFmy2jonUFxEtxLpj2RlN17EDgd1zwZGpjfIhryyA+vL4XlSr8EkfPjZ6z+I6NWwbfmEUqDZgrn7Ag==",
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.4",
-            "bpk-react-utils": "^2.7.9",
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-component-spinner": {
-          "version": "2.2.106",
-          "resolved": "https://registry.npmjs.org/bpk-component-spinner/-/bpk-component-spinner-2.2.106.tgz",
-          "integrity": "sha512-iOd+i+VMT0lN35FPhr9bEvet205lD911cf7Nu75tAgrBOL/n8B23p4KWkJU8WOB6pccUZ1gC9EClQ2UDSMOXFQ==",
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.4",
-            "bpk-react-utils": "^2.7.9",
-            "bpk-svgs": "^6.9.2",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        }
-      }
-    },
-    "bpk-component-map": {
-      "version": "file:backpack/packages/bpk-component-map",
-      "dev": true,
-      "requires": {
-        "bpk-component-spinner": "^2.2.106",
-        "bpk-mixins": "^17.24.4",
-        "bpk-react-utils": "^2.7.9",
-        "prop-types": "^15.5.8",
-        "react-google-maps": "^9.4.5"
-      },
-      "dependencies": {
-        "bpk-component-spinner": {
-          "version": "2.2.106",
-          "resolved": "https://registry.npmjs.org/bpk-component-spinner/-/bpk-component-spinner-2.2.106.tgz",
-          "integrity": "sha512-iOd+i+VMT0lN35FPhr9bEvet205lD911cf7Nu75tAgrBOL/n8B23p4KWkJU8WOB6pccUZ1gC9EClQ2UDSMOXFQ==",
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.4",
-            "bpk-react-utils": "^2.7.9",
-            "bpk-svgs": "^6.9.2",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        }
-      }
-    },
-    "bpk-component-mobile-scroll-container": {
-      "version": "file:backpack/packages/bpk-component-mobile-scroll-container",
-      "dev": true,
-      "requires": {
-        "bpk-mixins": "^17.24.4",
-        "bpk-react-utils": "^2.7.9",
+        "bpk-tokens": "^27.6.5",
+        "d3-path": "^1.0.5",
+        "d3-scale": "^2.1.0",
         "lodash.debounce": "^4.0.8",
         "prop-types": "^15.6.2"
       },
       "dependencies": {
-        "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
+        "bpk-component-mobile-scroll-container": {
+          "version": "1.1.83",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "lodash.debounce": "^4.0.8",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
@@ -3928,72 +2533,955 @@
             "react-transition-group": "^2.5.3",
             "recompose": "^0.30.0"
           }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
         }
       }
     },
-    "bpk-component-modal": {
-      "version": "file:backpack/packages/bpk-component-modal",
+    "bpk-component-blockquote": {
+      "version": "file:backpack/packages/bpk-component-blockquote",
       "dev": true,
       "requires": {
-        "bpk-component-close-button": "^1.0.141",
-        "bpk-component-icon": "^3.31.4",
-        "bpk-component-link": "^1.2.75",
-        "bpk-mixins": "^17.24.4",
+        "bpk-mixins": "^17.24.5",
         "bpk-react-utils": "^2.7.9",
-        "bpk-scrim-utils": "^3.2.75",
         "prop-types": "^15.6.2"
       },
       "dependencies": {
-        "bpk-component-close-button": {
-          "version": "1.0.141",
-          "resolved": "https://registry.npmjs.org/bpk-component-close-button/-/bpk-component-close-button-1.0.141.tgz",
-          "integrity": "sha512-Yd2kQnwuEQ3Myoqk2z/NDVIxB3YebCZrtgFJlQ/C6otp3sH3lbWLg4INREQqAyK1ZU5GK96qhvneubMA1tPLqQ==",
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "bpk-component-icon": "^3.31.4",
-            "bpk-mixins": "^17.24.4",
-            "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
           }
         },
-        "bpk-component-icon": {
-          "version": "3.31.4",
-          "resolved": "https://registry.npmjs.org/bpk-component-icon/-/bpk-component-icon-3.31.4.tgz",
-          "integrity": "sha512-DAiwhBYyyFmy2jonUFxEtxLpj2RlN17EDgd1zwZGpjfIhryyA+vL4XlSr8EkfPjZ6z+I6NWwbfmEUqDZgrn7Ag==",
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "bpk-mixins": "^17.24.4",
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
+      }
+    },
+    "bpk-component-breadcrumb": {
+      "version": "file:backpack/packages/bpk-component-breadcrumb",
+      "dev": true,
+      "requires": {
+        "bpk-component-icon": "^3.31.5",
+        "bpk-component-link": "^1.2.76",
+        "bpk-component-text": "^1.1.7",
+        "bpk-mixins": "^17.24.5",
+        "bpk-react-utils": "^2.7.9",
+        "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-component-icon": {
+          "version": "3.31.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
             "bpk-react-utils": "^2.7.9",
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4",
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5",
             "prop-types": "^15.6.2"
           }
         },
         "bpk-component-link": {
-          "version": "1.2.75",
-          "resolved": "https://registry.npmjs.org/bpk-component-link/-/bpk-component-link-1.2.75.tgz",
-          "integrity": "sha512-qoosptvwz8ZjxRt2WvoERb2E71zrBhs5+USNjy6FtDl+cXndmMOsINB1JiAmMB9TO6PgUZJkj7FBN7Vm7rZ+bQ==",
+          "version": "1.2.76",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "bpk-mixins": "^17.24.4",
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-text": {
+          "version": "1.1.7",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
             "bpk-react-utils": "^2.7.9",
             "prop-types": "^15.6.2"
           }
         },
         "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
+          "version": "17.24.5",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
+      }
+    },
+    "bpk-component-breakpoint": {
+      "version": "file:backpack/packages/bpk-component-breakpoint",
+      "dev": true,
+      "requires": {
+        "bpk-mixins": "^17.24.5",
+        "prop-types": "^15.6.2",
+        "react-responsive": "^5.0.0"
+      },
+      "dependencies": {
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
+      }
+    },
+    "bpk-component-button": {
+      "version": "file:backpack/packages/bpk-component-button",
+      "dev": true,
+      "requires": {
+        "bpk-mixins": "^17.24.5",
+        "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
+      }
+    },
+    "bpk-component-calendar": {
+      "version": "file:backpack/packages/bpk-component-calendar",
+      "dev": true,
+      "requires": {
+        "bpk-component-icon": "^3.31.5",
+        "bpk-component-select": "^2.3.8",
+        "bpk-mixins": "^17.24.5",
+        "bpk-react-utils": "^2.7.9",
+        "bpk-tokens": "^27.6.5",
+        "date-fns": "^1.29.0",
+        "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-component-icon": {
+          "version": "3.31.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-select": {
+          "version": "2.3.8",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
+      }
+    },
+    "bpk-component-card": {
+      "version": "file:backpack/packages/bpk-component-card",
+      "dev": true,
+      "requires": {
+        "bpk-mixins": "^17.24.5",
+        "bpk-react-utils": "^2.7.9",
+        "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
+      }
+    },
+    "bpk-component-checkbox": {
+      "version": "file:backpack/packages/bpk-component-checkbox",
+      "dev": true,
+      "requires": {
+        "bpk-component-icon": "^3.31.5",
+        "bpk-mixins": "^17.24.5",
+        "bpk-react-utils": "^2.7.9",
+        "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-component-icon": {
+          "version": "3.31.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
+      }
+    },
+    "bpk-component-chip": {
+      "version": "file:backpack/packages/bpk-component-chip",
+      "dev": true,
+      "requires": {
+        "bpk-component-close-button": "^1.0.142",
+        "bpk-mixins": "^17.24.5",
+        "bpk-react-utils": "^2.7.9",
+        "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-component-close-button": {
+          "version": "1.0.142",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-component-icon": "^3.31.5",
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-icon": {
+          "version": "3.31.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
+      }
+    },
+    "bpk-component-close-button": {
+      "version": "file:backpack/packages/bpk-component-close-button",
+      "dev": true,
+      "requires": {
+        "bpk-component-icon": "^3.31.5",
+        "bpk-mixins": "^17.24.5",
+        "bpk-react-utils": "^2.7.9",
+        "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-component-icon": {
+          "version": "3.31.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
+      }
+    },
+    "bpk-component-code": {
+      "version": "file:backpack/packages/bpk-component-code",
+      "dev": true,
+      "requires": {
+        "bpk-mixins": "^17.24.5",
+        "bpk-react-utils": "^2.7.9",
+        "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
+      }
+    },
+    "bpk-component-content-container": {
+      "version": "file:backpack/packages/bpk-component-content-container",
+      "dev": true,
+      "requires": {
+        "bpk-mixins": "^17.24.5",
+        "bpk-react-utils": "^2.7.9",
+        "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
+      }
+    },
+    "bpk-component-datepicker": {
+      "version": "file:backpack/packages/bpk-component-datepicker",
+      "dev": true,
+      "requires": {
+        "bpk-component-breakpoint": "^1.1.75",
+        "bpk-component-calendar": "^5.0.28",
+        "bpk-component-input": "^4.1.27",
+        "bpk-component-modal": "^1.8.75",
+        "bpk-component-popover": "^2.2.51",
+        "bpk-mixins": "^17.24.5",
+        "bpk-react-utils": "^2.7.9",
+        "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-component-breakpoint": {
+          "version": "1.1.75",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "prop-types": "^15.6.2",
+            "react-responsive": "^5.0.0"
+          }
+        },
+        "bpk-component-calendar": {
+          "version": "5.0.28",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-component-icon": "^3.31.5",
+            "bpk-component-select": "^2.3.8",
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "bpk-tokens": "^27.6.5",
+            "date-fns": "^1.29.0",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-close-button": {
+          "version": "1.0.142",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-component-icon": "^3.31.5",
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-icon": {
+          "version": "3.31.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-input": {
+          "version": "4.1.27",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-component-icon": "^3.31.5",
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-link": {
+          "version": "1.2.76",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-modal": {
+          "version": "1.8.75",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-component-close-button": "^1.0.142",
+            "bpk-component-icon": "^3.31.5",
+            "bpk-component-link": "^1.2.76",
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "bpk-scrim-utils": "^3.2.76",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-popover": {
+          "version": "2.2.51",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@skyscanner/popper.js": "^1.12.9-beta.1",
+            "a11y-focus-scope": "^1.1.3",
+            "a11y-focus-store": "^1.0.0",
+            "bpk-component-close-button": "^1.0.142",
+            "bpk-component-link": "^1.2.76",
+            "bpk-component-text": "^1.1.7",
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-select": {
+          "version": "2.3.8",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-text": {
+          "version": "1.1.7",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
+      }
+    },
+    "bpk-component-description-list": {
+      "version": "file:backpack/packages/bpk-component-description-list",
+      "dev": true,
+      "requires": {
+        "bpk-mixins": "^17.24.5",
+        "bpk-react-utils": "^2.7.9",
+        "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
+      }
+    },
+    "bpk-component-dialog": {
+      "version": "file:backpack/packages/bpk-component-dialog",
+      "dev": true,
+      "requires": {
+        "bpk-component-modal": "^1.8.75",
+        "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-component-close-button": {
+          "version": "1.0.142",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-component-icon": "^3.31.5",
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-icon": {
+          "version": "3.31.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-link": {
+          "version": "1.2.76",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-modal": {
+          "version": "1.8.75",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-component-close-button": "^1.0.142",
+            "bpk-component-icon": "^3.31.5",
+            "bpk-component-link": "^1.2.76",
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "bpk-scrim-utils": "^3.2.76",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
+      }
+    },
+    "bpk-component-drawer": {
+      "version": "file:backpack/packages/bpk-component-drawer",
+      "dev": true,
+      "requires": {
+        "bpk-component-close-button": "^1.0.142",
+        "bpk-component-icon": "^3.31.5",
+        "bpk-component-link": "^1.2.76",
+        "bpk-mixins": "^17.24.5",
+        "bpk-react-utils": "^2.7.9",
+        "bpk-scrim-utils": "^3.2.76",
+        "bpk-tokens": "^27.6.5",
+        "prop-types": "^15.6.2",
+        "react-transition-group": "^2.5.3"
+      },
+      "dependencies": {
+        "bpk-component-close-button": {
+          "version": "1.0.142",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-component-icon": "^3.31.5",
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-icon": {
+          "version": "3.31.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-link": {
+          "version": "1.2.76",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
@@ -4003,15 +3491,925 @@
           }
         },
         "bpk-scrim-utils": {
-          "version": "3.2.75",
-          "resolved": "https://registry.npmjs.org/bpk-scrim-utils/-/bpk-scrim-utils-3.2.75.tgz",
-          "integrity": "sha512-8CSMp/znOPIza3/3jBCdHPNQF68AxpizJ87VLiXz/ILy1o9dNjsEW6AnzDuhuy1U38sAc2JGeIxOwCWIJPZfQw==",
+          "version": "3.2.76",
+          "bundled": true,
           "dev": true,
           "requires": {
             "a11y-focus-scope": "^1.1.3",
             "a11y-focus-store": "^1.0.0",
-            "bpk-mixins": "^17.24.4",
+            "bpk-mixins": "^17.24.5",
             "bpk-react-utils": "^2.7.9"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
+      }
+    },
+    "bpk-component-fieldset": {
+      "version": "file:backpack/packages/bpk-component-fieldset",
+      "dev": true,
+      "requires": {
+        "bpk-component-form-validation": "^2.0.28",
+        "bpk-component-label": "^3.2.145",
+        "bpk-mixins": "^17.24.5",
+        "bpk-react-utils": "^2.7.9",
+        "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-animate-height": {
+          "version": "1.1.114",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-form-validation": {
+          "version": "2.0.28",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-animate-height": "^1.1.114",
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-label": {
+          "version": "3.2.145",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
+      }
+    },
+    "bpk-component-form-validation": {
+      "version": "file:backpack/packages/bpk-component-form-validation",
+      "dev": true,
+      "requires": {
+        "bpk-animate-height": "^1.1.114",
+        "bpk-mixins": "^17.24.5",
+        "bpk-react-utils": "^2.7.9",
+        "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-animate-height": {
+          "version": "1.1.114",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
+      }
+    },
+    "bpk-component-grid": {
+      "version": "file:backpack/packages/bpk-component-grid",
+      "dev": true,
+      "requires": {
+        "bpk-mixins": "^17.24.5",
+        "bpk-react-utils": "^2.7.9",
+        "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
+      }
+    },
+    "bpk-component-grid-toggle": {
+      "version": "file:backpack/packages/bpk-component-grid-toggle",
+      "dev": true,
+      "requires": {
+        "bpk-component-link": "^1.2.76",
+        "bpk-mixins": "^17.24.5",
+        "bpk-react-utils": "^2.7.9",
+        "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-component-link": {
+          "version": "1.2.76",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
+      }
+    },
+    "bpk-component-horizontal-nav": {
+      "version": "file:backpack/packages/bpk-component-horizontal-nav",
+      "dev": true,
+      "requires": {
+        "bpk-component-mobile-scroll-container": "^1.1.83",
+        "bpk-mixins": "^17.24.5",
+        "bpk-react-utils": "^2.7.9",
+        "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-component-mobile-scroll-container": {
+          "version": "1.1.83",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "lodash.debounce": "^4.0.8",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
+      }
+    },
+    "bpk-component-icon": {
+      "version": "file:backpack/packages/bpk-component-icon",
+      "dev": true,
+      "requires": {
+        "bpk-mixins": "^17.24.5",
+        "bpk-react-utils": "^2.7.9",
+        "bpk-svgs": "^6.9.3",
+        "bpk-tokens": "^27.6.5",
+        "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
+      }
+    },
+    "bpk-component-image": {
+      "version": "file:backpack/packages/bpk-component-image",
+      "dev": true,
+      "requires": {
+        "bpk-component-spinner": "^2.2.107",
+        "bpk-mixins": "^17.24.5",
+        "bpk-react-utils": "^2.7.9",
+        "prop-types": "^15.6.2",
+        "react-transition-group": "^2.5.3"
+      },
+      "dependencies": {
+        "bpk-component-spinner": {
+          "version": "2.2.107",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "bpk-svgs": "^6.9.3",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
+      }
+    },
+    "bpk-component-infinite-scroll": {
+      "version": "file:backpack/packages/bpk-component-infinite-scroll",
+      "dev": true,
+      "requires": {
+        "bpk-mixins": "^17.24.5",
+        "bpk-react-utils": "^2.7.9",
+        "intersection-observer": "^0.7.0",
+        "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        },
+        "intersection-observer": {
+          "version": "0.7.0",
+          "bundled": true,
+          "dev": true
+        }
+      }
+    },
+    "bpk-component-input": {
+      "version": "file:backpack/packages/bpk-component-input",
+      "dev": true,
+      "requires": {
+        "bpk-component-icon": "^3.31.5",
+        "bpk-mixins": "^17.24.5",
+        "bpk-react-utils": "^2.7.9",
+        "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-component-icon": {
+          "version": "3.31.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
+      }
+    },
+    "bpk-component-label": {
+      "version": "file:backpack/packages/bpk-component-label",
+      "dev": true,
+      "requires": {
+        "bpk-mixins": "^17.24.5",
+        "bpk-react-utils": "^2.7.9",
+        "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
+      }
+    },
+    "bpk-component-link": {
+      "version": "file:backpack/packages/bpk-component-link",
+      "dev": true,
+      "requires": {
+        "bpk-mixins": "^17.24.5",
+        "bpk-react-utils": "^2.7.9",
+        "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
+      }
+    },
+    "bpk-component-list": {
+      "version": "file:backpack/packages/bpk-component-list",
+      "dev": true,
+      "requires": {
+        "bpk-mixins": "^17.24.5",
+        "bpk-react-utils": "^2.7.9",
+        "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
+      }
+    },
+    "bpk-component-loading-button": {
+      "version": "file:backpack/packages/bpk-component-loading-button",
+      "dev": true,
+      "requires": {
+        "bpk-component-button": "^2.4.3",
+        "bpk-component-icon": "^3.31.5",
+        "bpk-component-spinner": "^2.2.107",
+        "bpk-mixins": "^17.24.5",
+        "bpk-react-utils": "^2.7.9",
+        "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-component-button": {
+          "version": "2.4.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-icon": {
+          "version": "3.31.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-spinner": {
+          "version": "2.2.107",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "bpk-svgs": "^6.9.3",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
+      }
+    },
+    "bpk-component-map": {
+      "version": "file:backpack/packages/bpk-component-map",
+      "dev": true,
+      "requires": {
+        "bpk-component-spinner": "^2.2.107",
+        "bpk-mixins": "^17.24.5",
+        "bpk-react-utils": "^2.7.9",
+        "prop-types": "^15.5.8",
+        "react-google-maps": "^9.4.5"
+      },
+      "dependencies": {
+        "bpk-component-spinner": {
+          "version": "2.2.107",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "bpk-svgs": "^6.9.3",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
+      }
+    },
+    "bpk-component-mobile-scroll-container": {
+      "version": "file:backpack/packages/bpk-component-mobile-scroll-container",
+      "dev": true,
+      "requires": {
+        "bpk-mixins": "^17.24.5",
+        "bpk-react-utils": "^2.7.9",
+        "lodash.debounce": "^4.0.8",
+        "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
+      }
+    },
+    "bpk-component-modal": {
+      "version": "file:backpack/packages/bpk-component-modal",
+      "dev": true,
+      "requires": {
+        "bpk-component-close-button": "^1.0.142",
+        "bpk-component-icon": "^3.31.5",
+        "bpk-component-link": "^1.2.76",
+        "bpk-mixins": "^17.24.5",
+        "bpk-react-utils": "^2.7.9",
+        "bpk-scrim-utils": "^3.2.76",
+        "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-component-close-button": {
+          "version": "1.0.142",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-component-icon": "^3.31.5",
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-icon": {
+          "version": "3.31.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-link": {
+          "version": "1.2.76",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-scrim-utils": {
+          "version": "3.2.76",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "a11y-focus-scope": "^1.1.3",
+            "a11y-focus-store": "^1.0.0",
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
           }
         }
       }
@@ -4020,68 +4418,88 @@
       "version": "file:backpack/packages/bpk-component-navigation-bar",
       "dev": true,
       "requires": {
-        "bpk-component-close-button": "^1.0.141",
-        "bpk-component-link": "^1.2.75",
-        "bpk-component-text": "^1.1.6",
-        "bpk-mixins": "^17.24.4",
+        "bpk-component-close-button": "^1.0.142",
+        "bpk-component-link": "^1.2.76",
+        "bpk-component-text": "^1.1.7",
+        "bpk-mixins": "^17.24.5",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
       },
       "dependencies": {
         "bpk-component-close-button": {
-          "version": "1.0.141",
-          "resolved": "https://registry.npmjs.org/bpk-component-close-button/-/bpk-component-close-button-1.0.141.tgz",
-          "integrity": "sha512-Yd2kQnwuEQ3Myoqk2z/NDVIxB3YebCZrtgFJlQ/C6otp3sH3lbWLg4INREQqAyK1ZU5GK96qhvneubMA1tPLqQ==",
+          "version": "1.0.142",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "bpk-component-icon": "^3.31.4",
-            "bpk-mixins": "^17.24.4",
+            "bpk-component-icon": "^3.31.5",
+            "bpk-mixins": "^17.24.5",
             "bpk-react-utils": "^2.7.9",
             "prop-types": "^15.6.2"
           }
         },
-        "bpk-component-link": {
-          "version": "1.2.75",
-          "resolved": "https://registry.npmjs.org/bpk-component-link/-/bpk-component-link-1.2.75.tgz",
-          "integrity": "sha512-qoosptvwz8ZjxRt2WvoERb2E71zrBhs5+USNjy6FtDl+cXndmMOsINB1JiAmMB9TO6PgUZJkj7FBN7Vm7rZ+bQ==",
+        "bpk-component-icon": {
+          "version": "3.31.5",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "bpk-mixins": "^17.24.4",
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-link": {
+          "version": "1.2.76",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
             "bpk-react-utils": "^2.7.9",
             "prop-types": "^15.6.2"
           }
         },
         "bpk-component-text": {
-          "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/bpk-component-text/-/bpk-component-text-1.1.6.tgz",
-          "integrity": "sha512-U4wp5+Fz1Rd9LeJphQRKwKx2ekIbzGj0SFdvjDkVOkG120YVtVb4YQN/3xEl/zb7Csku5HLvkJIJK4C+wR22nQ==",
+          "version": "1.1.7",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "bpk-mixins": "^17.24.4",
+            "bpk-mixins": "^17.24.5",
             "bpk-react-utils": "^2.7.9",
             "prop-types": "^15.6.2"
           }
         },
         "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
+          "version": "17.24.5",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
             "prop-types": "^15.6.2",
             "react-transition-group": "^2.5.3",
             "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
           }
         }
       }
@@ -4090,27 +4508,25 @@
       "version": "file:backpack/packages/bpk-component-navigation-stack",
       "dev": true,
       "requires": {
-        "bpk-mixins": "^17.24.4",
+        "bpk-mixins": "^17.24.5",
         "bpk-react-utils": "^2.7.9",
-        "bpk-tokens": "^27.6.4",
+        "bpk-tokens": "^27.6.5",
         "prop-types": "^15.6.2",
         "react-transition-group": "^2.5.3"
       },
       "dependencies": {
         "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
+          "version": "17.24.5",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
@@ -4119,25 +4535,17 @@
             "recompose": "^0.30.0"
           }
         },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
         "bpk-tokens": {
-          "version": "27.6.4",
-          "resolved": "https://registry.npmjs.org/bpk-tokens/-/bpk-tokens-27.6.4.tgz",
-          "integrity": "sha512-/7BXdfw5Ft2UxkpLlme4x2TXoTEtITeJX1IzxqdgKZF0+fb+WT4SywoO0g9iM/nfQ1893ZEdNkG25u49v43dsQ==",
+          "version": "27.6.5",
+          "bundled": true,
           "dev": true,
           "requires": {
             "color": "^3.0.0"
-          },
-          "dependencies": {
-            "color": {
-              "version": "3.1.2",
-              "resolved": "https://registry.npmjs.org/color/-/color-3.1.2.tgz",
-              "integrity": "sha512-vXTJhHebByxZn3lDvDJYw4lR5+uB3vuoHsuYA5AKuxRVn5wzzIfQKGLBmgdVRHKTJYeK5rvJcHnrd0Li49CFpg==",
-              "dev": true,
-              "requires": {
-                "color-convert": "^1.9.1",
-                "color-string": "^1.5.2"
-              }
-            }
           }
         }
       }
@@ -4146,52 +4554,48 @@
       "version": "file:backpack/packages/bpk-component-nudger",
       "dev": true,
       "requires": {
-        "bpk-component-button": "^2.4.1",
-        "bpk-component-icon": "^3.31.4",
-        "bpk-mixins": "^17.24.4",
+        "bpk-component-button": "^2.4.3",
+        "bpk-component-icon": "^3.31.5",
+        "bpk-mixins": "^17.24.5",
         "bpk-react-utils": "^2.7.9",
-        "bpk-tokens": "^27.6.4",
+        "bpk-tokens": "^27.6.5",
         "lodash.clamp": "^4.0.3",
         "prop-types": "^15.6.2"
       },
       "dependencies": {
         "bpk-component-button": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/bpk-component-button/-/bpk-component-button-2.4.1.tgz",
-          "integrity": "sha512-4jJ5wxgquUUVGHpblXf0yWlpVFNtmDo0DjLMkGL5U4HxFIgc0XZp911KjIzUVeCh+3eGASeAthQgLCruQghzOg==",
+          "version": "2.4.3",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "bpk-mixins": "^17.24.4",
+            "bpk-mixins": "^17.24.5",
             "prop-types": "^15.6.2"
           }
         },
         "bpk-component-icon": {
-          "version": "3.31.4",
-          "resolved": "https://registry.npmjs.org/bpk-component-icon/-/bpk-component-icon-3.31.4.tgz",
-          "integrity": "sha512-DAiwhBYyyFmy2jonUFxEtxLpj2RlN17EDgd1zwZGpjfIhryyA+vL4XlSr8EkfPjZ6z+I6NWwbfmEUqDZgrn7Ag==",
+          "version": "3.31.5",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "bpk-mixins": "^17.24.4",
+            "bpk-mixins": "^17.24.5",
             "bpk-react-utils": "^2.7.9",
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4",
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5",
             "prop-types": "^15.6.2"
           }
         },
         "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
+          "version": "17.24.5",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
@@ -4200,25 +4604,17 @@
             "recompose": "^0.30.0"
           }
         },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
         "bpk-tokens": {
-          "version": "27.6.4",
-          "resolved": "https://registry.npmjs.org/bpk-tokens/-/bpk-tokens-27.6.4.tgz",
-          "integrity": "sha512-/7BXdfw5Ft2UxkpLlme4x2TXoTEtITeJX1IzxqdgKZF0+fb+WT4SywoO0g9iM/nfQ1893ZEdNkG25u49v43dsQ==",
+          "version": "27.6.5",
+          "bundled": true,
           "dev": true,
           "requires": {
             "color": "^3.0.0"
-          },
-          "dependencies": {
-            "color": {
-              "version": "3.1.2",
-              "resolved": "https://registry.npmjs.org/color/-/color-3.1.2.tgz",
-              "integrity": "sha512-vXTJhHebByxZn3lDvDJYw4lR5+uB3vuoHsuYA5AKuxRVn5wzzIfQKGLBmgdVRHKTJYeK5rvJcHnrd0Li49CFpg==",
-              "dev": true,
-              "requires": {
-                "color-convert": "^1.9.1",
-                "color-string": "^1.5.2"
-              }
-            }
           }
         }
       }
@@ -4227,42 +4623,52 @@
       "version": "file:backpack/packages/bpk-component-pagination",
       "dev": true,
       "requires": {
-        "bpk-component-button": "^2.4.1",
-        "bpk-mixins": "^17.24.4",
+        "bpk-component-button": "^2.4.3",
+        "bpk-mixins": "^17.24.5",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
       },
       "dependencies": {
         "bpk-component-button": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/bpk-component-button/-/bpk-component-button-2.4.1.tgz",
-          "integrity": "sha512-4jJ5wxgquUUVGHpblXf0yWlpVFNtmDo0DjLMkGL5U4HxFIgc0XZp911KjIzUVeCh+3eGASeAthQgLCruQghzOg==",
+          "version": "2.4.3",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "bpk-mixins": "^17.24.4",
+            "bpk-mixins": "^17.24.5",
             "prop-types": "^15.6.2"
           }
         },
         "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
+          "version": "17.24.5",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
             "prop-types": "^15.6.2",
             "react-transition-group": "^2.5.3",
             "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
           }
         }
       }
@@ -4271,31 +4677,42 @@
       "version": "file:backpack/packages/bpk-component-panel",
       "dev": true,
       "requires": {
-        "bpk-mixins": "^17.24.4",
+        "bpk-mixins": "^17.24.5",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
       },
       "dependencies": {
         "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
+          "version": "17.24.5",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
             "prop-types": "^15.6.2",
             "react-transition-group": "^2.5.3",
             "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
           }
         }
       }
@@ -4304,75 +4721,81 @@
       "version": "file:backpack/packages/bpk-component-phone-input",
       "dev": true,
       "requires": {
-        "bpk-component-input": "^4.1.26",
-        "bpk-component-label": "^3.2.144",
-        "bpk-component-select": "^2.3.7",
-        "bpk-component-text": "^1.1.6",
-        "bpk-mixins": "^17.24.4",
+        "bpk-component-input": "^4.1.27",
+        "bpk-component-label": "^3.2.145",
+        "bpk-component-select": "^2.3.8",
+        "bpk-component-text": "^1.1.7",
+        "bpk-mixins": "^17.24.5",
         "bpk-react-utils": "^2.7.9",
-        "bpk-tokens": "^27.6.4",
+        "bpk-tokens": "^27.6.5",
         "prop-types": "^15.6.2"
       },
       "dependencies": {
-        "bpk-component-input": {
-          "version": "4.1.26",
-          "resolved": "https://registry.npmjs.org/bpk-component-input/-/bpk-component-input-4.1.26.tgz",
-          "integrity": "sha512-+5P8u4+tmf+pABR9fhqDvMcVDaThFZgiEk9yPOcv0m9rgPZMzWXxOcEpN7Wzr2fdW6P/kCAtFA0jwUKtuzEyWQ==",
+        "bpk-component-icon": {
+          "version": "3.31.5",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "bpk-component-icon": "^3.31.4",
-            "bpk-mixins": "^17.24.4",
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-input": {
+          "version": "4.1.27",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-component-icon": "^3.31.5",
+            "bpk-mixins": "^17.24.5",
             "bpk-react-utils": "^2.7.9",
             "prop-types": "^15.6.2"
           }
         },
         "bpk-component-label": {
-          "version": "3.2.144",
-          "resolved": "https://registry.npmjs.org/bpk-component-label/-/bpk-component-label-3.2.144.tgz",
-          "integrity": "sha512-78mIbPwaeOwidu76SlPVo4fJG6d7kfSQ2JGlvZ4yU70it793xmj/ll0E2+PcAaAWoeNTVwreQmctg/RkwgNTRQ==",
+          "version": "3.2.145",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "bpk-mixins": "^17.24.4",
+            "bpk-mixins": "^17.24.5",
             "bpk-react-utils": "^2.7.9",
             "prop-types": "^15.6.2"
           }
         },
         "bpk-component-select": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/bpk-component-select/-/bpk-component-select-2.3.7.tgz",
-          "integrity": "sha512-5A3duQQ58GmdgHfI8GCvbMA8b8IzyUh+b+7mRQVR0NBCqY2HUL1rrjly95ejfZx1OhUWfEwwYU3fAOFgpj6o3A==",
+          "version": "2.3.8",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "bpk-mixins": "^17.24.4",
+            "bpk-mixins": "^17.24.5",
             "bpk-react-utils": "^2.7.9",
             "prop-types": "^15.6.2"
           }
         },
         "bpk-component-text": {
-          "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/bpk-component-text/-/bpk-component-text-1.1.6.tgz",
-          "integrity": "sha512-U4wp5+Fz1Rd9LeJphQRKwKx2ekIbzGj0SFdvjDkVOkG120YVtVb4YQN/3xEl/zb7Csku5HLvkJIJK4C+wR22nQ==",
+          "version": "1.1.7",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "bpk-mixins": "^17.24.4",
+            "bpk-mixins": "^17.24.5",
             "bpk-react-utils": "^2.7.9",
             "prop-types": "^15.6.2"
           }
         },
         "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
+          "version": "17.24.5",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
@@ -4381,25 +4804,17 @@
             "recompose": "^0.30.0"
           }
         },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
         "bpk-tokens": {
-          "version": "27.6.4",
-          "resolved": "https://registry.npmjs.org/bpk-tokens/-/bpk-tokens-27.6.4.tgz",
-          "integrity": "sha512-/7BXdfw5Ft2UxkpLlme4x2TXoTEtITeJX1IzxqdgKZF0+fb+WT4SywoO0g9iM/nfQ1893ZEdNkG25u49v43dsQ==",
+          "version": "27.6.5",
+          "bundled": true,
           "dev": true,
           "requires": {
             "color": "^3.0.0"
-          },
-          "dependencies": {
-            "color": {
-              "version": "3.1.2",
-              "resolved": "https://registry.npmjs.org/color/-/color-3.1.2.tgz",
-              "integrity": "sha512-vXTJhHebByxZn3lDvDJYw4lR5+uB3vuoHsuYA5AKuxRVn5wzzIfQKGLBmgdVRHKTJYeK5rvJcHnrd0Li49CFpg==",
-              "dev": true,
-              "requires": {
-                "color-convert": "^1.9.1",
-                "color-string": "^1.5.2"
-              }
-            }
           }
         }
       }
@@ -4411,484 +4826,69 @@
         "@skyscanner/popper.js": "^1.12.9-beta.1",
         "a11y-focus-scope": "^1.1.3",
         "a11y-focus-store": "^1.0.0",
-        "bpk-component-close-button": "^1.0.141",
-        "bpk-component-link": "^1.2.75",
-        "bpk-component-text": "^1.1.6",
-        "bpk-mixins": "^17.24.4",
+        "bpk-component-close-button": "^1.0.142",
+        "bpk-component-link": "^1.2.76",
+        "bpk-component-text": "^1.1.7",
+        "bpk-mixins": "^17.24.5",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
       },
       "dependencies": {
         "bpk-component-close-button": {
-          "version": "1.0.141",
-          "resolved": "https://registry.npmjs.org/bpk-component-close-button/-/bpk-component-close-button-1.0.141.tgz",
-          "integrity": "sha512-Yd2kQnwuEQ3Myoqk2z/NDVIxB3YebCZrtgFJlQ/C6otp3sH3lbWLg4INREQqAyK1ZU5GK96qhvneubMA1tPLqQ==",
+          "version": "1.0.142",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "bpk-component-icon": "^3.31.4",
-            "bpk-mixins": "^17.24.4",
+            "bpk-component-icon": "^3.31.5",
+            "bpk-mixins": "^17.24.5",
             "bpk-react-utils": "^2.7.9",
             "prop-types": "^15.6.2"
           }
         },
-        "bpk-component-link": {
-          "version": "1.2.75",
-          "resolved": "https://registry.npmjs.org/bpk-component-link/-/bpk-component-link-1.2.75.tgz",
-          "integrity": "sha512-qoosptvwz8ZjxRt2WvoERb2E71zrBhs5+USNjy6FtDl+cXndmMOsINB1JiAmMB9TO6PgUZJkj7FBN7Vm7rZ+bQ==",
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.4",
-            "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-component-text": {
-          "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/bpk-component-text/-/bpk-component-text-1.1.6.tgz",
-          "integrity": "sha512-U4wp5+Fz1Rd9LeJphQRKwKx2ekIbzGj0SFdvjDkVOkG120YVtVb4YQN/3xEl/zb7Csku5HLvkJIJK4C+wR22nQ==",
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.4",
-            "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        }
-      }
-    },
-    "bpk-component-progress": {
-      "version": "file:backpack/packages/bpk-component-progress",
-      "dev": true,
-      "requires": {
-        "bpk-mixins": "^17.24.4",
-        "bpk-react-utils": "^2.7.9",
-        "bpk-tokens": "^27.6.4",
-        "lodash.clamp": "^4.0.3",
-        "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        },
-        "bpk-tokens": {
-          "version": "27.6.4",
-          "resolved": "https://registry.npmjs.org/bpk-tokens/-/bpk-tokens-27.6.4.tgz",
-          "integrity": "sha512-/7BXdfw5Ft2UxkpLlme4x2TXoTEtITeJX1IzxqdgKZF0+fb+WT4SywoO0g9iM/nfQ1893ZEdNkG25u49v43dsQ==",
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
-          },
-          "dependencies": {
-            "color": {
-              "version": "3.1.2",
-              "resolved": "https://registry.npmjs.org/color/-/color-3.1.2.tgz",
-              "integrity": "sha512-vXTJhHebByxZn3lDvDJYw4lR5+uB3vuoHsuYA5AKuxRVn5wzzIfQKGLBmgdVRHKTJYeK5rvJcHnrd0Li49CFpg==",
-              "dev": true,
-              "requires": {
-                "color-convert": "^1.9.1",
-                "color-string": "^1.5.2"
-              }
-            }
-          }
-        }
-      }
-    },
-    "bpk-component-radio": {
-      "version": "file:backpack/packages/bpk-component-radio",
-      "dev": true,
-      "requires": {
-        "bpk-mixins": "^17.24.4",
-        "bpk-react-utils": "^2.7.9",
-        "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        }
-      }
-    },
-    "bpk-component-router-link": {
-      "version": "file:backpack/packages/bpk-component-router-link",
-      "dev": true,
-      "requires": {
-        "bpk-mixins": "^17.24.4",
-        "bpk-react-utils": "^2.7.9",
-        "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        }
-      }
-    },
-    "bpk-component-rtl-toggle": {
-      "version": "file:backpack/packages/bpk-component-rtl-toggle",
-      "dev": true,
-      "requires": {
-        "bpk-component-link": "^1.2.75",
-        "bpk-react-utils": "^2.7.9",
-        "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-component-link": {
-          "version": "1.2.75",
-          "resolved": "https://registry.npmjs.org/bpk-component-link/-/bpk-component-link-1.2.75.tgz",
-          "integrity": "sha512-qoosptvwz8ZjxRt2WvoERb2E71zrBhs5+USNjy6FtDl+cXndmMOsINB1JiAmMB9TO6PgUZJkj7FBN7Vm7rZ+bQ==",
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.4",
-            "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        }
-      }
-    },
-    "bpk-component-scrollable-calendar": {
-      "version": "file:backpack/packages/bpk-component-scrollable-calendar",
-      "dev": true,
-      "requires": {
-        "bpk-component-calendar": "^5.0.26",
-        "bpk-component-text": "^1.1.6",
-        "bpk-mixins": "^17.24.4",
-        "bpk-react-utils": "^2.7.9",
-        "prop-types": "^15.5.8",
-        "react-window": "^1.5.0"
-      },
-      "dependencies": {
-        "bpk-component-calendar": {
-          "version": "5.0.26",
-          "resolved": "https://registry.npmjs.org/bpk-component-calendar/-/bpk-component-calendar-5.0.26.tgz",
-          "integrity": "sha512-eBo5tfZyTczqZn0EH5Xv1Weahf1S/hR92PpZlJV3GPs7yMrYsf0C+Bxn1edkvCKZu4lX83bl2Er6zfPAgfkUdg==",
-          "dev": true,
-          "requires": {
-            "bpk-component-icon": "^3.31.4",
-            "bpk-component-select": "^2.3.7",
-            "bpk-mixins": "^17.24.4",
-            "bpk-react-utils": "^2.7.9",
-            "bpk-tokens": "^27.6.4",
-            "date-fns": "^1.29.0",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-component-text": {
-          "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/bpk-component-text/-/bpk-component-text-1.1.6.tgz",
-          "integrity": "sha512-U4wp5+Fz1Rd9LeJphQRKwKx2ekIbzGj0SFdvjDkVOkG120YVtVb4YQN/3xEl/zb7Csku5HLvkJIJK4C+wR22nQ==",
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.4",
-            "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        }
-      }
-    },
-    "bpk-component-section-list": {
-      "version": "file:backpack/packages/bpk-component-section-list",
-      "dev": true,
-      "requires": {
-        "bpk-component-icon": "^3.31.4",
-        "bpk-component-text": "^1.1.6",
-        "bpk-mixins": "^17.24.4",
-        "bpk-react-utils": "^2.7.9",
-        "bpk-tokens": "^27.6.4",
-        "prop-types": "^15.6.2"
-      },
-      "dependencies": {
         "bpk-component-icon": {
-          "version": "3.31.4",
-          "resolved": "https://registry.npmjs.org/bpk-component-icon/-/bpk-component-icon-3.31.4.tgz",
-          "integrity": "sha512-DAiwhBYyyFmy2jonUFxEtxLpj2RlN17EDgd1zwZGpjfIhryyA+vL4XlSr8EkfPjZ6z+I6NWwbfmEUqDZgrn7Ag==",
+          "version": "3.31.5",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "bpk-mixins": "^17.24.4",
+            "bpk-mixins": "^17.24.5",
             "bpk-react-utils": "^2.7.9",
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4",
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-link": {
+          "version": "1.2.76",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
             "prop-types": "^15.6.2"
           }
         },
         "bpk-component-text": {
-          "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/bpk-component-text/-/bpk-component-text-1.1.6.tgz",
-          "integrity": "sha512-U4wp5+Fz1Rd9LeJphQRKwKx2ekIbzGj0SFdvjDkVOkG120YVtVb4YQN/3xEl/zb7Csku5HLvkJIJK4C+wR22nQ==",
+          "version": "1.1.7",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "bpk-mixins": "^17.24.4",
+            "bpk-mixins": "^17.24.5",
             "bpk-react-utils": "^2.7.9",
             "prop-types": "^15.6.2"
           }
         },
         "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
+          "version": "17.24.5",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        },
-        "bpk-tokens": {
-          "version": "27.6.4",
-          "resolved": "https://registry.npmjs.org/bpk-tokens/-/bpk-tokens-27.6.4.tgz",
-          "integrity": "sha512-/7BXdfw5Ft2UxkpLlme4x2TXoTEtITeJX1IzxqdgKZF0+fb+WT4SywoO0g9iM/nfQ1893ZEdNkG25u49v43dsQ==",
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
-          },
-          "dependencies": {
-            "color": {
-              "version": "3.1.2",
-              "resolved": "https://registry.npmjs.org/color/-/color-3.1.2.tgz",
-              "integrity": "sha512-vXTJhHebByxZn3lDvDJYw4lR5+uB3vuoHsuYA5AKuxRVn5wzzIfQKGLBmgdVRHKTJYeK5rvJcHnrd0Li49CFpg==",
-              "dev": true,
-              "requires": {
-                "color-convert": "^1.9.1",
-                "color-string": "^1.5.2"
-              }
-            }
-          }
-        }
-      }
-    },
-    "bpk-component-select": {
-      "version": "file:backpack/packages/bpk-component-select",
-      "dev": true,
-      "requires": {
-        "bpk-mixins": "^17.24.4",
-        "bpk-react-utils": "^2.7.9",
-        "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        }
-      }
-    },
-    "bpk-component-slider": {
-      "version": "file:backpack/packages/bpk-component-slider",
-      "dev": true,
-      "requires": {
-        "bpk-mixins": "^17.24.4",
-        "bpk-react-utils": "^2.7.9",
-        "bpk-tokens": "^27.6.4",
-        "prop-types": "^15.6.2",
-        "react-slider": "^0.11.2"
-      },
-      "dependencies": {
-        "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        },
-        "bpk-tokens": {
-          "version": "27.6.4",
-          "resolved": "https://registry.npmjs.org/bpk-tokens/-/bpk-tokens-27.6.4.tgz",
-          "integrity": "sha512-/7BXdfw5Ft2UxkpLlme4x2TXoTEtITeJX1IzxqdgKZF0+fb+WT4SywoO0g9iM/nfQ1893ZEdNkG25u49v43dsQ==",
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
-          },
-          "dependencies": {
-            "color": {
-              "version": "3.1.2",
-              "resolved": "https://registry.npmjs.org/color/-/color-3.1.2.tgz",
-              "integrity": "sha512-vXTJhHebByxZn3lDvDJYw4lR5+uB3vuoHsuYA5AKuxRVn5wzzIfQKGLBmgdVRHKTJYeK5rvJcHnrd0Li49CFpg==",
-              "dev": true,
-              "requires": {
-                "color-convert": "^1.9.1",
-                "color-string": "^1.5.2"
-              }
-            }
-          }
-        }
-      }
-    },
-    "bpk-component-spinner": {
-      "version": "file:backpack/packages/bpk-component-spinner",
-      "dev": true,
-      "requires": {
-        "bpk-mixins": "^17.24.4",
-        "bpk-react-utils": "^2.7.9",
-        "bpk-svgs": "^6.9.2",
-        "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
@@ -4898,10 +4898,502 @@
           }
         },
         "bpk-svgs": {
-          "version": "6.9.2",
-          "resolved": "https://registry.npmjs.org/bpk-svgs/-/bpk-svgs-6.9.2.tgz",
-          "integrity": "sha512-gicoSPPzsQVc0eBUtpn0vGfs/azztQIsA5IDeJaW50G1MHst9C7KBUdegnf64oRwjuVRZbdXsTz5I7h1UqgXKA==",
+          "version": "6.9.3",
+          "bundled": true,
           "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
+      }
+    },
+    "bpk-component-progress": {
+      "version": "file:backpack/packages/bpk-component-progress",
+      "dev": true,
+      "requires": {
+        "bpk-mixins": "^17.24.5",
+        "bpk-react-utils": "^2.7.9",
+        "bpk-tokens": "^27.6.5",
+        "lodash.clamp": "^4.0.3",
+        "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
+      }
+    },
+    "bpk-component-radio": {
+      "version": "file:backpack/packages/bpk-component-radio",
+      "dev": true,
+      "requires": {
+        "bpk-mixins": "^17.24.5",
+        "bpk-react-utils": "^2.7.9",
+        "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
+      }
+    },
+    "bpk-component-router-link": {
+      "version": "file:backpack/packages/bpk-component-router-link",
+      "dev": true,
+      "requires": {
+        "bpk-mixins": "^17.24.5",
+        "bpk-react-utils": "^2.7.9",
+        "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
+      }
+    },
+    "bpk-component-rtl-toggle": {
+      "version": "file:backpack/packages/bpk-component-rtl-toggle",
+      "dev": true,
+      "requires": {
+        "bpk-component-link": "^1.2.76",
+        "bpk-react-utils": "^2.7.9",
+        "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-component-link": {
+          "version": "1.2.76",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
+      }
+    },
+    "bpk-component-scrollable-calendar": {
+      "version": "file:backpack/packages/bpk-component-scrollable-calendar",
+      "dev": true,
+      "requires": {
+        "bpk-component-calendar": "^5.0.28",
+        "bpk-component-text": "^1.1.7",
+        "bpk-mixins": "^17.24.5",
+        "bpk-react-utils": "^2.7.9",
+        "prop-types": "^15.5.8",
+        "react-window": "^1.5.0"
+      },
+      "dependencies": {
+        "bpk-component-calendar": {
+          "version": "5.0.28",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-component-icon": "^3.31.5",
+            "bpk-component-select": "^2.3.8",
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "bpk-tokens": "^27.6.5",
+            "date-fns": "^1.29.0",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-icon": {
+          "version": "3.31.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-select": {
+          "version": "2.3.8",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-text": {
+          "version": "1.1.7",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
+      }
+    },
+    "bpk-component-section-list": {
+      "version": "file:backpack/packages/bpk-component-section-list",
+      "dev": true,
+      "requires": {
+        "bpk-component-icon": "^3.31.5",
+        "bpk-component-text": "^1.1.7",
+        "bpk-mixins": "^17.24.5",
+        "bpk-react-utils": "^2.7.9",
+        "bpk-tokens": "^27.6.5",
+        "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-component-icon": {
+          "version": "3.31.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-text": {
+          "version": "1.1.7",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
+      }
+    },
+    "bpk-component-select": {
+      "version": "file:backpack/packages/bpk-component-select",
+      "dev": true,
+      "requires": {
+        "bpk-mixins": "^17.24.5",
+        "bpk-react-utils": "^2.7.9",
+        "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
+      }
+    },
+    "bpk-component-slider": {
+      "version": "file:backpack/packages/bpk-component-slider",
+      "dev": true,
+      "requires": {
+        "bpk-mixins": "^17.24.5",
+        "bpk-react-utils": "^2.7.9",
+        "bpk-tokens": "^27.6.5",
+        "prop-types": "^15.6.2",
+        "react-slider": "^0.11.2"
+      },
+      "dependencies": {
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
+      }
+    },
+    "bpk-component-spinner": {
+      "version": "file:backpack/packages/bpk-component-spinner",
+      "dev": true,
+      "requires": {
+        "bpk-mixins": "^17.24.5",
+        "bpk-react-utils": "^2.7.9",
+        "bpk-svgs": "^6.9.3",
+        "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
         }
       }
     },
@@ -4909,45 +5401,55 @@
       "version": "file:backpack/packages/bpk-component-star-rating",
       "dev": true,
       "requires": {
-        "bpk-component-icon": "^3.31.4",
-        "bpk-mixins": "^17.24.4",
+        "bpk-component-icon": "^3.31.5",
+        "bpk-mixins": "^17.24.5",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
       },
       "dependencies": {
         "bpk-component-icon": {
-          "version": "3.31.4",
-          "resolved": "https://registry.npmjs.org/bpk-component-icon/-/bpk-component-icon-3.31.4.tgz",
-          "integrity": "sha512-DAiwhBYyyFmy2jonUFxEtxLpj2RlN17EDgd1zwZGpjfIhryyA+vL4XlSr8EkfPjZ6z+I6NWwbfmEUqDZgrn7Ag==",
+          "version": "3.31.5",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "bpk-mixins": "^17.24.4",
+            "bpk-mixins": "^17.24.5",
             "bpk-react-utils": "^2.7.9",
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4",
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5",
             "prop-types": "^15.6.2"
           }
         },
         "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
+          "version": "17.24.5",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
             "prop-types": "^15.6.2",
             "react-transition-group": "^2.5.3",
             "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
           }
         }
       }
@@ -4956,31 +5458,42 @@
       "version": "file:backpack/packages/bpk-component-table",
       "dev": true,
       "requires": {
-        "bpk-mixins": "^17.24.4",
+        "bpk-mixins": "^17.24.5",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
       },
       "dependencies": {
         "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
+          "version": "17.24.5",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
             "prop-types": "^15.6.2",
             "react-transition-group": "^2.5.3",
             "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
           }
         }
       }
@@ -4989,31 +5502,42 @@
       "version": "file:backpack/packages/bpk-component-text",
       "dev": true,
       "requires": {
-        "bpk-mixins": "^17.24.4",
+        "bpk-mixins": "^17.24.5",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
       },
       "dependencies": {
         "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
+          "version": "17.24.5",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
             "prop-types": "^15.6.2",
             "react-transition-group": "^2.5.3",
             "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
           }
         }
       }
@@ -5022,31 +5546,42 @@
       "version": "file:backpack/packages/bpk-component-textarea",
       "dev": true,
       "requires": {
-        "bpk-mixins": "^17.24.4",
+        "bpk-mixins": "^17.24.5",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
       },
       "dependencies": {
         "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
+          "version": "17.24.5",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
             "prop-types": "^15.6.2",
             "react-transition-group": "^2.5.3",
             "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
           }
         }
       }
@@ -5055,50 +5590,46 @@
       "version": "file:backpack/packages/bpk-component-theme-toggle",
       "dev": true,
       "requires": {
-        "bpk-component-label": "^3.2.144",
-        "bpk-component-select": "^2.3.7",
-        "bpk-mixins": "^17.24.4",
+        "bpk-component-label": "^3.2.145",
+        "bpk-component-select": "^2.3.8",
+        "bpk-mixins": "^17.24.5",
         "bpk-react-utils": "^2.7.9",
-        "bpk-tokens": "^27.6.4",
+        "bpk-tokens": "^27.6.5",
         "prop-types": "^15.6.2"
       },
       "dependencies": {
         "bpk-component-label": {
-          "version": "3.2.144",
-          "resolved": "https://registry.npmjs.org/bpk-component-label/-/bpk-component-label-3.2.144.tgz",
-          "integrity": "sha512-78mIbPwaeOwidu76SlPVo4fJG6d7kfSQ2JGlvZ4yU70it793xmj/ll0E2+PcAaAWoeNTVwreQmctg/RkwgNTRQ==",
+          "version": "3.2.145",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "bpk-mixins": "^17.24.4",
+            "bpk-mixins": "^17.24.5",
             "bpk-react-utils": "^2.7.9",
             "prop-types": "^15.6.2"
           }
         },
         "bpk-component-select": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/bpk-component-select/-/bpk-component-select-2.3.7.tgz",
-          "integrity": "sha512-5A3duQQ58GmdgHfI8GCvbMA8b8IzyUh+b+7mRQVR0NBCqY2HUL1rrjly95ejfZx1OhUWfEwwYU3fAOFgpj6o3A==",
+          "version": "2.3.8",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "bpk-mixins": "^17.24.4",
+            "bpk-mixins": "^17.24.5",
             "bpk-react-utils": "^2.7.9",
             "prop-types": "^15.6.2"
           }
         },
         "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
+          "version": "17.24.5",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
@@ -5107,25 +5638,17 @@
             "recompose": "^0.30.0"
           }
         },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
         "bpk-tokens": {
-          "version": "27.6.4",
-          "resolved": "https://registry.npmjs.org/bpk-tokens/-/bpk-tokens-27.6.4.tgz",
-          "integrity": "sha512-/7BXdfw5Ft2UxkpLlme4x2TXoTEtITeJX1IzxqdgKZF0+fb+WT4SywoO0g9iM/nfQ1893ZEdNkG25u49v43dsQ==",
+          "version": "27.6.5",
+          "bundled": true,
           "dev": true,
           "requires": {
             "color": "^3.0.0"
-          },
-          "dependencies": {
-            "color": {
-              "version": "3.1.2",
-              "resolved": "https://registry.npmjs.org/color/-/color-3.1.2.tgz",
-              "integrity": "sha512-vXTJhHebByxZn3lDvDJYw4lR5+uB3vuoHsuYA5AKuxRVn5wzzIfQKGLBmgdVRHKTJYeK5rvJcHnrd0Li49CFpg==",
-              "dev": true,
-              "requires": {
-                "color-convert": "^1.9.1",
-                "color-string": "^1.5.2"
-              }
-            }
           }
         }
       }
@@ -5134,31 +5657,42 @@
       "version": "file:backpack/packages/bpk-component-ticket",
       "dev": true,
       "requires": {
-        "bpk-mixins": "^17.24.4",
+        "bpk-mixins": "^17.24.5",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
       },
       "dependencies": {
         "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
+          "version": "17.24.5",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
             "prop-types": "^15.6.2",
             "react-transition-group": "^2.5.3",
             "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
           }
         }
       }
@@ -5168,31 +5702,42 @@
       "dev": true,
       "requires": {
         "@skyscanner/popper.js": "^1.12.9-beta.1",
-        "bpk-mixins": "^17.24.4",
+        "bpk-mixins": "^17.24.5",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
       },
       "dependencies": {
         "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
+          "version": "17.24.5",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
             "prop-types": "^15.6.2",
             "react-transition-group": "^2.5.3",
             "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
           }
         }
       }
@@ -5201,35 +5746,21 @@
       "version": "file:backpack/packages/bpk-mixins",
       "dev": true,
       "requires": {
-        "bpk-svgs": "^6.9.2",
-        "bpk-tokens": "^27.6.4"
+        "bpk-svgs": "^6.9.3",
+        "bpk-tokens": "^27.6.5"
       },
       "dependencies": {
         "bpk-svgs": {
-          "version": "6.9.2",
-          "resolved": "https://registry.npmjs.org/bpk-svgs/-/bpk-svgs-6.9.2.tgz",
-          "integrity": "sha512-gicoSPPzsQVc0eBUtpn0vGfs/azztQIsA5IDeJaW50G1MHst9C7KBUdegnf64oRwjuVRZbdXsTz5I7h1UqgXKA==",
+          "version": "6.9.3",
+          "bundled": true,
           "dev": true
         },
         "bpk-tokens": {
-          "version": "27.6.4",
-          "resolved": "https://registry.npmjs.org/bpk-tokens/-/bpk-tokens-27.6.4.tgz",
-          "integrity": "sha512-/7BXdfw5Ft2UxkpLlme4x2TXoTEtITeJX1IzxqdgKZF0+fb+WT4SywoO0g9iM/nfQ1893ZEdNkG25u49v43dsQ==",
+          "version": "27.6.5",
+          "bundled": true,
           "dev": true,
           "requires": {
             "color": "^3.0.0"
-          },
-          "dependencies": {
-            "color": {
-              "version": "3.1.2",
-              "resolved": "https://registry.npmjs.org/color/-/color-3.1.2.tgz",
-              "integrity": "sha512-vXTJhHebByxZn3lDvDJYw4lR5+uB3vuoHsuYA5AKuxRVn5wzzIfQKGLBmgdVRHKTJYeK5rvJcHnrd0Li49CFpg==",
-              "dev": true,
-              "requires": {
-                "color-convert": "^1.9.1",
-                "color-string": "^1.5.2"
-              }
-            }
           }
         }
       }
@@ -5244,44 +5775,86 @@
         "recompose": "^0.30.0"
       }
     },
+    "bpk-scrim-utils": {
+      "version": "3.2.76",
+      "resolved": "https://registry.npmjs.org/bpk-scrim-utils/-/bpk-scrim-utils-3.2.76.tgz",
+      "integrity": "sha512-aDl5SN+smHgLXYf2IzjOKnmgNlxQVZ8tNR/uxlpzld5Uigl55eBlzJ+IfMVZlMIHmN0esm8xX2qpnEhG0jTkyw==",
+      "dev": true,
+      "requires": {
+        "a11y-focus-scope": "^1.1.3",
+        "a11y-focus-store": "^1.0.0",
+        "bpk-mixins": "^17.24.5",
+        "bpk-react-utils": "^2.7.9"
+      },
+      "dependencies": {
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.5.tgz",
+          "integrity": "sha512-qxpqlGH3V1+s1mOG5J6/wA5Qg9b4UHYfmDXBYKyf/A2cJZSZZgzI+JiTaEAuyluz9xF2s2hYWskrjttyc8Leeg==",
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
+          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "resolved": "https://registry.npmjs.org/bpk-svgs/-/bpk-svgs-6.9.3.tgz",
+          "integrity": "sha512-OV/VTXqq2NmnJqqToY74RoLAapa+LPEHS/lI0gYnJYb/CUx1vBAp19qerRQfWb8ca6bNbpIol6YHIktSR83frg==",
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "resolved": "https://registry.npmjs.org/bpk-tokens/-/bpk-tokens-27.6.5.tgz",
+          "integrity": "sha512-wALtOBOSwSkN7t6GI3J3zamynysYD8eD8rwzN4xc7oTqVzKarVxLWi/CPHo5Xa2eByyIwhyGREcAkgKpY5Fr0w==",
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
+      }
+    },
     "bpk-stylesheets": {
       "version": "file:backpack/packages/bpk-stylesheets",
       "dev": true,
       "requires": {
-        "bpk-mixins": "^17.24.4",
-        "bpk-tokens": "^27.6.4",
+        "bpk-mixins": "^17.24.5",
+        "bpk-tokens": "^27.6.5",
         "normalize.css": "4.2.0"
       },
       "dependencies": {
         "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
+          "version": "17.24.5",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
           }
         },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
         "bpk-tokens": {
-          "version": "27.6.4",
-          "resolved": "https://registry.npmjs.org/bpk-tokens/-/bpk-tokens-27.6.4.tgz",
-          "integrity": "sha512-/7BXdfw5Ft2UxkpLlme4x2TXoTEtITeJX1IzxqdgKZF0+fb+WT4SywoO0g9iM/nfQ1893ZEdNkG25u49v43dsQ==",
+          "version": "27.6.5",
+          "bundled": true,
           "dev": true,
           "requires": {
             "color": "^3.0.0"
-          },
-          "dependencies": {
-            "color": {
-              "version": "3.1.2",
-              "resolved": "https://registry.npmjs.org/color/-/color-3.1.2.tgz",
-              "integrity": "sha512-vXTJhHebByxZn3lDvDJYw4lR5+uB3vuoHsuYA5AKuxRVn5wzzIfQKGLBmgdVRHKTJYeK5rvJcHnrd0Li49CFpg==",
-              "dev": true,
-              "requires": {
-                "color-convert": "^1.9.1",
-                "color-string": "^1.5.2"
-              }
-            }
           }
         }
       }
@@ -5294,29 +5867,16 @@
       "version": "file:backpack/packages/bpk-theming",
       "dev": true,
       "requires": {
-        "bpk-tokens": "^27.6.4",
+        "bpk-tokens": "^27.6.5",
         "prop-types": "^15.6.2"
       },
       "dependencies": {
         "bpk-tokens": {
-          "version": "27.6.4",
-          "resolved": "https://registry.npmjs.org/bpk-tokens/-/bpk-tokens-27.6.4.tgz",
-          "integrity": "sha512-/7BXdfw5Ft2UxkpLlme4x2TXoTEtITeJX1IzxqdgKZF0+fb+WT4SywoO0g9iM/nfQ1893ZEdNkG25u49v43dsQ==",
+          "version": "27.6.5",
+          "bundled": true,
           "dev": true,
           "requires": {
             "color": "^3.0.0"
-          },
-          "dependencies": {
-            "color": {
-              "version": "3.1.2",
-              "resolved": "https://registry.npmjs.org/color/-/color-3.1.2.tgz",
-              "integrity": "sha512-vXTJhHebByxZn3lDvDJYw4lR5+uB3vuoHsuYA5AKuxRVn5wzzIfQKGLBmgdVRHKTJYeK5rvJcHnrd0Li49CFpg==",
-              "dev": true,
-              "requires": {
-                "color-convert": "^1.9.1",
-                "color-string": "^1.5.2"
-              }
-            }
           }
         }
       }
@@ -5330,8 +5890,7 @@
       "dependencies": {
         "color": {
           "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/color/-/color-3.1.1.tgz",
-          "integrity": "sha512-PvUltIXRjehRKPSy89VnDWFKY58xyhTLyxIg21vwQBI6qLwZNPmC8k3C1uytIgFKEpOIzN4y32iPm8231zFHIg==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "color-convert": "^1.9.1",
@@ -5340,8 +5899,7 @@
         },
         "color-string": {
           "version": "1.5.3",
-          "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.3.tgz",
-          "integrity": "sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "color-name": "^1.0.0",
@@ -5987,6 +6545,16 @@
       "requires": {
         "map-visit": "^1.0.0",
         "object-visit": "^1.0.0"
+      }
+    },
+    "color": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/color/-/color-3.1.2.tgz",
+      "integrity": "sha512-vXTJhHebByxZn3lDvDJYw4lR5+uB3vuoHsuYA5AKuxRVn5wzzIfQKGLBmgdVRHKTJYeK5rvJcHnrd0Li49CFpg==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^1.9.1",
+        "color-string": "^1.5.2"
       }
     },
     "color-convert": {
@@ -9479,8 +10047,7 @@
           "version": "2.1.1",
           "resolved": false,
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -9504,15 +10071,13 @@
           "version": "1.0.0",
           "resolved": false,
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": false,
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -9529,22 +10094,19 @@
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": false,
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -9675,8 +10237,7 @@
           "version": "2.0.3",
           "resolved": false,
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -9690,7 +10251,6 @@
           "resolved": false,
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -9707,7 +10267,6 @@
           "resolved": false,
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -9716,15 +10275,13 @@
           "version": "0.0.8",
           "resolved": false,
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "resolved": false,
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -9745,7 +10302,6 @@
           "resolved": false,
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -9834,8 +10390,7 @@
           "version": "1.0.1",
           "resolved": false,
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -9849,7 +10404,6 @@
           "resolved": false,
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -9945,8 +10499,7 @@
           "version": "5.1.2",
           "resolved": false,
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -9988,7 +10541,6 @@
           "resolved": false,
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -10010,7 +10562,6 @@
           "resolved": false,
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -10059,15 +10610,13 @@
           "version": "1.0.2",
           "resolved": false,
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "resolved": false,
           "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -277,6 +277,7 @@
       "version": "7.5.5",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.5.tgz",
       "integrity": "sha512-28QvEGyQyNkB0/m2B4FU7IEZGK2NUrcMtT6BZEFALTguLk+AUT6ofsHtPk5QyjAdUkpMJ+/Em+quwz4HOt30AQ==",
+      "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.2"
       },
@@ -284,7 +285,8 @@
         "regenerator-runtime": {
           "version": "0.13.3",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
-          "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
+          "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
+          "dev": true
         }
       }
     },
@@ -537,6 +539,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/a11y-focus-scope/-/a11y-focus-scope-1.1.3.tgz",
       "integrity": "sha1-95U4TU3UDM7BxKFg700TNx0BWug=",
+      "dev": true,
       "requires": {
         "focusin": "^2.0.0",
         "tabbable": "^1.0.0"
@@ -545,7 +548,8 @@
     "a11y-focus-store": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/a11y-focus-store/-/a11y-focus-store-1.0.0.tgz",
-      "integrity": "sha1-rlJWHLhq5sKQTBpKvy5YIL9TBbA="
+      "integrity": "sha1-rlJWHLhq5sKQTBpKvy5YIL9TBbA=",
+      "dev": true
     },
     "abab": {
       "version": "1.0.4",
@@ -1189,7 +1193,8 @@
     "asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
+      "dev": true
     },
     "asn1": {
       "version": "0.2.4",
@@ -2483,1329 +2488,87 @@
       "version": "file:backpack/packages/bpk-component-accordion",
       "dev": true,
       "requires": {
-        "bpk-animate-height": "^1.1.113",
-        "bpk-component-icon": "^3.31.5",
-        "bpk-mixins": "^17.24.5",
+        "bpk-animate-height": "^1.1.112",
+        "bpk-component-icon": "^3.31.4",
+        "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-animate-height": {
-          "version": "1.1.113",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-component-checkbox": {
-          "version": "1.4.110",
-          "bundled": true,
-          "requires": {
-            "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
-          },
-          "dependencies": {
-            "bpk-component-icon": {
-              "version": "3.31.4",
-              "bundled": true,
-              "requires": {
-                "bpk-mixins": "^17.24.4",
-                "bpk-react-utils": "^2.7.9",
-                "bpk-svgs": "^6.9.2",
-                "bpk-tokens": "^27.6.4",
-                "prop-types": "^15.6.2"
-              }
-            },
-            "bpk-mixins": {
-              "version": "17.24.4",
-              "bundled": true,
-              "requires": {
-                "bpk-svgs": "^6.9.2",
-                "bpk-tokens": "^27.6.4"
-              }
-            },
-            "bpk-react-utils": {
-              "version": "2.7.9",
-              "bundled": true,
-              "requires": {
-                "object-assign": "^4.1.1",
-                "prop-types": "^15.6.2"
-              }
-            },
-            "bpk-svgs": {
-              "version": "6.9.3",
-              "bundled": true
-            },
-            "bpk-tokens": {
-              "version": "27.6.5",
-              "bundled": true
-            },
-            "js-tokens": {
-              "version": "4.0.0",
-              "bundled": true
-            },
-            "loose-envify": {
-              "version": "1.4.0",
-              "bundled": true,
-              "requires": {
-                "js-tokens": "^3.0.0 || ^4.0.0"
-              }
-            },
-            "object-assign": {
-              "version": "4.1.1",
-              "bundled": true
-            },
-            "prop-types": {
-              "version": "15.6.2",
-              "bundled": true,
-              "requires": {
-                "loose-envify": "^1.3.1",
-                "object-assign": "^4.1.1"
-              }
-            }
-          }
-        },
-        "bpk-component-icon": {
-          "version": "3.31.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.5",
-            "bpk-react-utils": "^2.7.9",
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          },
-          "dependencies": {
-            "@babel/runtime": {
-              "version": "7.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "regenerator-runtime": "^0.12.0"
-              }
-            },
-            "asap": {
-              "version": "2.0.6",
-              "bundled": true,
-              "dev": true
-            },
-            "change-emitter": {
-              "version": "0.1.6",
-              "bundled": true,
-              "dev": true
-            },
-            "core-js": {
-              "version": "1.2.7",
-              "bundled": true,
-              "dev": true
-            },
-            "dom-helpers": {
-              "version": "3.4.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "@babel/runtime": "^7.1.2"
-              },
-              "dependencies": {
-                "@babel/runtime": {
-                  "version": "7.5.5",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "regenerator-runtime": "^0.13.2"
-                  }
-                },
-                "regenerator-runtime": {
-                  "version": "0.13.3",
-                  "bundled": true,
-                  "dev": true
-                }
-              }
-            },
-            "encoding": {
-              "version": "0.1.12",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "iconv-lite": "~0.4.13"
-              }
-            },
-            "fbjs": {
-              "version": "0.8.17",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "core-js": "^1.0.0",
-                "isomorphic-fetch": "^2.1.1",
-                "loose-envify": "^1.0.0",
-                "object-assign": "^4.1.0",
-                "promise": "^7.1.1",
-                "setimmediate": "^1.0.5",
-                "ua-parser-js": "^0.7.18"
-              }
-            },
-            "hoist-non-react-statics": {
-              "version": "2.5.5",
-              "bundled": true,
-              "dev": true
-            },
-            "iconv-lite": {
-              "version": "0.4.24",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "safer-buffer": ">= 2.1.2 < 3"
-              }
-            },
-            "is-stream": {
-              "version": "1.1.0",
-              "bundled": true,
-              "dev": true
-            },
-            "isomorphic-fetch": {
-              "version": "2.2.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "node-fetch": "^1.0.1",
-                "whatwg-fetch": ">=0.10.0"
-              }
-            },
-            "js-tokens": {
-              "version": "4.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "loose-envify": {
-              "version": "1.4.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "js-tokens": "^3.0.0 || ^4.0.0"
-              }
-            },
-            "node-fetch": {
-              "version": "1.7.3",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "encoding": "^0.1.11",
-                "is-stream": "^1.0.1"
-              }
-            },
-            "object-assign": {
-              "version": "4.1.1",
-              "bundled": true,
-              "dev": true
-            },
-            "promise": {
-              "version": "7.3.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "asap": "~2.0.3"
-              }
-            },
-            "prop-types": {
-              "version": "15.6.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "loose-envify": "^1.3.1",
-                "object-assign": "^4.1.1"
-              }
-            },
-            "react-lifecycles-compat": {
-              "version": "3.0.4",
-              "bundled": true,
-              "dev": true
-            },
-            "react-transition-group": {
-              "version": "2.9.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "dom-helpers": "^3.4.0",
-                "loose-envify": "^1.4.0",
-                "prop-types": "^15.6.2",
-                "react-lifecycles-compat": "^3.0.4"
-              }
-            },
-            "recompose": {
-              "version": "0.30.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "@babel/runtime": "^7.0.0",
-                "change-emitter": "^0.1.2",
-                "fbjs": "^0.8.1",
-                "hoist-non-react-statics": "^2.3.1",
-                "react-lifecycles-compat": "^3.0.2",
-                "symbol-observable": "^1.0.4"
-              }
-            },
-            "regenerator-runtime": {
-              "version": "0.12.1",
-              "bundled": true,
-              "dev": true
-            },
-            "safer-buffer": {
-              "version": "2.1.2",
-              "bundled": true,
-              "dev": true
-            },
-            "setimmediate": {
-              "version": "1.0.5",
-              "bundled": true,
-              "dev": true
-            },
-            "symbol-observable": {
-              "version": "1.2.0",
-              "bundled": true,
-              "dev": true
-            },
-            "ua-parser-js": {
-              "version": "0.7.18",
-              "bundled": true,
-              "dev": true
-            },
-            "whatwg-fetch": {
-              "version": "3.0.0",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
-          }
-        },
-        "js-tokens": {
-          "version": "4.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "loose-envify": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "js-tokens": "^3.0.0 || ^4.0.0"
-          }
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "prop-types": {
-          "version": "15.6.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.3.1",
-            "object-assign": "^4.1.1"
-          }
-        }
       }
     },
     "bpk-component-autosuggest": {
       "version": "file:backpack/packages/bpk-component-autosuggest",
       "dev": true,
       "requires": {
-        "bpk-component-input": "^4.1.27",
-        "bpk-mixins": "^17.24.5",
+        "bpk-component-input": "^4.1.26",
+        "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2",
         "react-autosuggest": "^9.4.2"
-      },
-      "dependencies": {
-        "bpk-component-icon": {
-          "version": "3.31.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.5",
-            "bpk-react-utils": "^2.7.9",
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-component-input": {
-          "version": "4.1.27",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-component-icon": "^3.31.5",
-            "bpk-mixins": "^17.24.5",
-            "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
-          }
-        },
-        "js-tokens": {
-          "version": "4.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "loose-envify": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "js-tokens": "^3.0.0 || ^4.0.0"
-          }
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "prop-types": {
-          "version": "15.6.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.3.1",
-            "object-assign": "^4.1.1"
-          }
-        },
-        "react-autosuggest": {
-          "version": "9.4.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "prop-types": "^15.5.10",
-            "react-autowhatever": "^10.1.2",
-            "shallow-equal": "^1.0.0"
-          }
-        },
-        "react-autowhatever": {
-          "version": "10.1.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "prop-types": "^15.5.8",
-            "react-themeable": "^1.1.0",
-            "section-iterator": "^2.0.0"
-          }
-        },
-        "react-themeable": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "object-assign": "^3.0.0"
-          },
-          "dependencies": {
-            "object-assign": {
-              "version": "3.0.0",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "react-transition-group": {
-          "version": "2.9.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "dom-helpers": "^3.4.0",
-            "loose-envify": "^1.4.0",
-            "prop-types": "^15.6.2",
-            "react-lifecycles-compat": "^3.0.4"
-          }
-        },
-        "recompose": {
-          "version": "0.30.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "^7.0.0",
-            "change-emitter": "^0.1.2",
-            "fbjs": "^0.8.1",
-            "hoist-non-react-statics": "^2.3.1",
-            "react-lifecycles-compat": "^3.0.2",
-            "symbol-observable": "^1.0.4"
-          }
-        },
-        "section-iterator": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "shallow-equal": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        }
       }
     },
     "bpk-component-badge": {
       "version": "file:backpack/packages/bpk-component-badge",
       "dev": true,
       "requires": {
-        "bpk-mixins": "^17.24.5",
+        "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-component-icon": {
-          "version": "3.31.5",
-          "bundled": true
-        },
-        "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
-          }
-        },
-        "js-tokens": {
-          "version": "4.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "loose-envify": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "js-tokens": "^3.0.0 || ^4.0.0"
-          }
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "prop-types": {
-          "version": "15.6.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.3.1",
-            "object-assign": "^4.1.1"
-          }
-        },
-        "react-transition-group": {
-          "version": "2.9.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "dom-helpers": "^3.4.0",
-            "loose-envify": "^1.4.0",
-            "prop-types": "^15.6.2",
-            "react-lifecycles-compat": "^3.0.4"
-          }
-        },
-        "recompose": {
-          "version": "0.30.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "^7.0.0",
-            "change-emitter": "^0.1.2",
-            "fbjs": "^0.8.1",
-            "hoist-non-react-statics": "^2.3.1",
-            "react-lifecycles-compat": "^3.0.2",
-            "symbol-observable": "^1.0.4"
-          }
-        }
       }
     },
     "bpk-component-banner-alert": {
       "version": "file:backpack/packages/bpk-component-banner-alert",
       "dev": true,
       "requires": {
-        "bpk-animate-height": "^1.1.113",
-        "bpk-component-close-button": "^1.0.142",
-        "bpk-component-icon": "^3.31.5",
-        "bpk-mixins": "^17.24.5",
+        "bpk-animate-height": "^1.1.112",
+        "bpk-component-close-button": "^1.0.141",
+        "bpk-component-icon": "^3.31.4",
+        "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
-        "bpk-tokens": "^27.6.5",
+        "bpk-tokens": "^27.6.4",
         "prop-types": "^15.6.2",
         "react-transition-group": "^2.5.3"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.5.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "regenerator-runtime": "^0.13.2"
-          }
-        },
-        "bpk-animate-height": {
-          "version": "1.1.113",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-component-close-button": {
-          "version": "1.0.142",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-component-icon": "^3.31.5",
-            "bpk-mixins": "^17.24.5",
-            "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-component-icon": {
-          "version": "3.31.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.5",
-            "bpk-react-utils": "^2.7.9",
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
-          }
-        },
-        "dom-helpers": {
-          "version": "3.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "^7.1.2"
-          }
-        },
-        "js-tokens": {
-          "version": "4.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "loose-envify": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "js-tokens": "^3.0.0 || ^4.0.0"
-          }
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "prop-types": {
-          "version": "15.6.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.3.1",
-            "object-assign": "^4.1.1"
-          }
-        },
-        "react-lifecycles-compat": {
-          "version": "3.0.4",
-          "bundled": true,
-          "dev": true
-        },
-        "react-transition-group": {
-          "version": "2.9.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "dom-helpers": "^3.4.0",
-            "loose-envify": "^1.4.0",
-            "prop-types": "^15.6.2",
-            "react-lifecycles-compat": "^3.0.4"
-          }
-        },
-        "recompose": {
-          "version": "0.30.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "^7.0.0",
-            "change-emitter": "^0.1.2",
-            "fbjs": "^0.8.1",
-            "hoist-non-react-statics": "^2.3.1",
-            "react-lifecycles-compat": "^3.0.2",
-            "symbol-observable": "^1.0.4"
-          }
-        },
-        "regenerator-runtime": {
-          "version": "0.13.3",
-          "bundled": true,
-          "dev": true
-        }
       }
     },
     "bpk-component-barchart": {
       "version": "file:backpack/packages/bpk-component-barchart",
       "dev": true,
       "requires": {
-        "bpk-component-mobile-scroll-container": "^1.1.82",
-        "bpk-mixins": "^17.24.5",
+        "bpk-component-mobile-scroll-container": "^1.1.81",
+        "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
-        "bpk-tokens": "^27.6.5",
+        "bpk-tokens": "^27.6.4",
         "d3-path": "^1.0.5",
         "d3-scale": "^2.1.0",
         "lodash.debounce": "^4.0.8",
         "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-component-breakpoint": {
-          "version": "1.1.75",
-          "bundled": true
-        },
-        "bpk-component-content-container": {
-          "version": "1.3.81",
-          "bundled": true,
-          "requires": {
-            "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
-          },
-          "dependencies": {
-            "bpk-mixins": {
-              "version": "17.24.4",
-              "bundled": true,
-              "requires": {
-                "bpk-svgs": "^6.9.2",
-                "bpk-tokens": "^27.6.4"
-              }
-            },
-            "bpk-react-utils": {
-              "version": "2.7.9",
-              "bundled": true,
-              "requires": {
-                "object-assign": "^4.1.1",
-                "prop-types": "^15.6.2"
-              }
-            },
-            "bpk-svgs": {
-              "version": "6.9.3",
-              "bundled": true
-            },
-            "bpk-tokens": {
-              "version": "27.6.5",
-              "bundled": true
-            },
-            "js-tokens": {
-              "version": "4.0.0",
-              "bundled": true
-            },
-            "loose-envify": {
-              "version": "1.4.0",
-              "bundled": true,
-              "requires": {
-                "js-tokens": "^3.0.0 || ^4.0.0"
-              }
-            },
-            "object-assign": {
-              "version": "4.1.1",
-              "bundled": true
-            },
-            "prop-types": {
-              "version": "15.6.2",
-              "bundled": true,
-              "requires": {
-                "loose-envify": "^1.3.1",
-                "object-assign": "^4.1.1"
-              }
-            }
-          }
-        },
-        "bpk-component-mobile-scroll-container": {
-          "version": "1.1.82",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.5",
-            "bpk-react-utils": "^2.7.9",
-            "lodash.debounce": "^4.0.8",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-component-rtl-toggle": {
-          "version": "1.1.95",
-          "bundled": true,
-          "requires": {
-            "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
-          },
-          "dependencies": {
-            "bpk-component-link": {
-              "version": "1.2.75",
-              "bundled": true,
-              "requires": {
-                "bpk-mixins": "^17.24.4",
-                "bpk-react-utils": "^2.7.9",
-                "prop-types": "^15.6.2"
-              }
-            },
-            "bpk-mixins": {
-              "version": "17.24.5",
-              "bundled": true,
-              "requires": {
-                "bpk-svgs": "^6.9.3",
-                "bpk-tokens": "^27.6.5"
-              }
-            },
-            "bpk-react-utils": {
-              "version": "2.7.9",
-              "bundled": true,
-              "requires": {
-                "object-assign": "^4.1.1",
-                "prop-types": "^15.6.2"
-              }
-            },
-            "bpk-svgs": {
-              "version": "6.9.3",
-              "bundled": true
-            },
-            "bpk-tokens": {
-              "version": "27.6.5",
-              "bundled": true
-            },
-            "js-tokens": {
-              "version": "4.0.0",
-              "bundled": true
-            },
-            "loose-envify": {
-              "version": "1.4.0",
-              "bundled": true,
-              "requires": {
-                "js-tokens": "^3.0.0 || ^4.0.0"
-              }
-            },
-            "object-assign": {
-              "version": "4.1.1",
-              "bundled": true
-            },
-            "prop-types": {
-              "version": "15.6.2",
-              "bundled": true,
-              "requires": {
-                "loose-envify": "^1.3.1",
-                "object-assign": "^4.1.1"
-              }
-            }
-          }
-        },
-        "bpk-component-text": {
-          "version": "1.1.7",
-          "bundled": true,
-          "requires": {
-            "bpk-react-utils": "^2.7.9"
-          },
-          "dependencies": {
-            "bpk-react-utils": {
-              "version": "2.7.9",
-              "bundled": true
-            }
-          }
-        },
-        "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
-          }
-        },
-        "d3-array": {
-          "version": "1.2.4",
-          "bundled": true,
-          "dev": true
-        },
-        "d3-collection": {
-          "version": "1.0.7",
-          "bundled": true,
-          "dev": true
-        },
-        "d3-color": {
-          "version": "1.2.3",
-          "bundled": true,
-          "dev": true
-        },
-        "d3-format": {
-          "version": "1.3.2",
-          "bundled": true,
-          "dev": true
-        },
-        "d3-interpolate": {
-          "version": "1.3.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "d3-color": "1"
-          }
-        },
-        "d3-path": {
-          "version": "1.0.7",
-          "bundled": true,
-          "dev": true
-        },
-        "d3-scale": {
-          "version": "2.1.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "d3-array": "^1.2.0",
-            "d3-collection": "1",
-            "d3-format": "1",
-            "d3-interpolate": "1",
-            "d3-time": "1",
-            "d3-time-format": "2"
-          }
-        },
-        "d3-time": {
-          "version": "1.0.10",
-          "bundled": true,
-          "dev": true
-        },
-        "d3-time-format": {
-          "version": "2.1.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "d3-time": "1"
-          }
-        },
-        "js-tokens": {
-          "version": "4.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "lodash.debounce": {
-          "version": "4.0.8",
-          "bundled": true,
-          "dev": true
-        },
-        "loose-envify": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "js-tokens": "^3.0.0 || ^4.0.0"
-          }
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "prop-types": {
-          "version": "15.6.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.3.1",
-            "object-assign": "^4.1.1"
-          }
-        },
-        "react-transition-group": {
-          "version": "2.9.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "dom-helpers": "^3.4.0",
-            "loose-envify": "^1.4.0",
-            "prop-types": "^15.6.2",
-            "react-lifecycles-compat": "^3.0.4"
-          }
-        },
-        "recompose": {
-          "version": "0.30.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "^7.0.0",
-            "change-emitter": "^0.1.2",
-            "fbjs": "^0.8.1",
-            "hoist-non-react-statics": "^2.3.1",
-            "react-lifecycles-compat": "^3.0.2",
-            "symbol-observable": "^1.0.4"
-          }
-        }
       }
     },
     "bpk-component-blockquote": {
       "version": "file:backpack/packages/bpk-component-blockquote",
       "dev": true,
       "requires": {
-        "bpk-mixins": "^17.24.5",
+        "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
-          }
-        },
-        "js-tokens": {
-          "version": "4.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "loose-envify": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "js-tokens": "^3.0.0 || ^4.0.0"
-          }
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "prop-types": {
-          "version": "15.6.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.3.1",
-            "object-assign": "^4.1.1"
-          }
-        },
-        "react-transition-group": {
-          "version": "2.9.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "dom-helpers": "^3.4.0",
-            "loose-envify": "^1.4.0",
-            "prop-types": "^15.6.2",
-            "react-lifecycles-compat": "^3.0.4"
-          }
-        },
-        "recompose": {
-          "version": "0.30.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "^7.0.0",
-            "change-emitter": "^0.1.2",
-            "fbjs": "^0.8.1",
-            "hoist-non-react-statics": "^2.3.1",
-            "react-lifecycles-compat": "^3.0.2",
-            "symbol-observable": "^1.0.4"
-          }
-        }
       }
     },
     "bpk-component-breadcrumb": {
       "version": "file:backpack/packages/bpk-component-breadcrumb",
       "dev": true,
       "requires": {
-        "bpk-component-icon": "^3.31.5",
-        "bpk-component-link": "^1.2.76",
-        "bpk-component-text": "^1.1.7",
-        "bpk-mixins": "^17.24.5",
+        "bpk-component-icon": "^3.31.4",
+        "bpk-component-link": "^1.2.75",
+        "bpk-component-text": "^1.1.6",
+        "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-component-icon": {
-          "version": "3.31.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.5",
-            "bpk-react-utils": "^2.7.9",
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-component-link": {
-          "version": "1.2.76",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.5",
-            "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-component-text": {
-          "version": "1.1.7",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.5",
-            "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
-          }
-        },
-        "js-tokens": {
-          "version": "4.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "loose-envify": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "js-tokens": "^3.0.0 || ^4.0.0"
-          }
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "prop-types": {
-          "version": "15.6.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.3.1",
-            "object-assign": "^4.1.1"
-          }
-        },
-        "react-transition-group": {
-          "version": "2.9.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "dom-helpers": "^3.4.0",
-            "loose-envify": "^1.4.0",
-            "prop-types": "^15.6.2",
-            "react-lifecycles-compat": "^3.0.4"
-          }
-        },
-        "recompose": {
-          "version": "0.30.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "^7.0.0",
-            "change-emitter": "^0.1.2",
-            "fbjs": "^0.8.1",
-            "hoist-non-react-statics": "^2.3.1",
-            "react-lifecycles-compat": "^3.0.2",
-            "symbol-observable": "^1.0.4"
-          }
-        }
       }
     },
     "bpk-component-breakpoint": {
       "version": "file:backpack/packages/bpk-component-breakpoint",
       "dev": true,
       "requires": {
-        "bpk-mixins": "^17.24.5",
+        "bpk-mixins": "^17.24.4",
         "prop-types": "^15.6.2",
         "react-responsive": "^5.0.0"
       }
@@ -3814,7 +2577,7 @@
       "version": "file:backpack/packages/bpk-component-button",
       "dev": true,
       "requires": {
-        "bpk-mixins": "^17.24.5",
+        "bpk-mixins": "^17.24.4",
         "prop-types": "^15.6.2"
       }
     },
@@ -3822,11 +2585,11 @@
       "version": "file:backpack/packages/bpk-component-calendar",
       "dev": true,
       "requires": {
-        "bpk-component-icon": "^3.31.5",
-        "bpk-component-select": "^2.3.8",
-        "bpk-mixins": "^17.24.5",
+        "bpk-component-icon": "^3.31.4",
+        "bpk-component-select": "^2.3.7",
+        "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
-        "bpk-tokens": "^27.6.5",
+        "bpk-tokens": "^27.6.4",
         "date-fns": "^1.29.0",
         "prop-types": "^15.6.2"
       }
@@ -3835,341 +2598,37 @@
       "version": "file:backpack/packages/bpk-component-card",
       "dev": true,
       "requires": {
-        "bpk-mixins": "^17.24.5",
+        "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
-          }
-        },
-        "js-tokens": {
-          "version": "4.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "loose-envify": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "js-tokens": "^3.0.0 || ^4.0.0"
-          }
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "prop-types": {
-          "version": "15.6.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.3.1",
-            "object-assign": "^4.1.1"
-          }
-        },
-        "react-transition-group": {
-          "version": "2.9.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "dom-helpers": "^3.4.0",
-            "loose-envify": "^1.4.0",
-            "prop-types": "^15.6.2",
-            "react-lifecycles-compat": "^3.0.4"
-          }
-        },
-        "recompose": {
-          "version": "0.30.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "^7.0.0",
-            "change-emitter": "^0.1.2",
-            "fbjs": "^0.8.1",
-            "hoist-non-react-statics": "^2.3.1",
-            "react-lifecycles-compat": "^3.0.2",
-            "symbol-observable": "^1.0.4"
-          }
-        }
       }
     },
     "bpk-component-checkbox": {
       "version": "file:backpack/packages/bpk-component-checkbox",
       "dev": true,
       "requires": {
-        "bpk-component-icon": "^3.31.5",
-        "bpk-mixins": "^17.24.5",
+        "bpk-component-icon": "^3.31.4",
+        "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-component-icon": {
-          "version": "3.31.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.5",
-            "bpk-react-utils": "^2.7.9",
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
-          }
-        },
-        "js-tokens": {
-          "version": "4.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "loose-envify": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "js-tokens": "^3.0.0 || ^4.0.0"
-          }
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "prop-types": {
-          "version": "15.6.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.3.1",
-            "object-assign": "^4.1.1"
-          }
-        },
-        "react-transition-group": {
-          "version": "2.9.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "dom-helpers": "^3.4.0",
-            "loose-envify": "^1.4.0",
-            "prop-types": "^15.6.2",
-            "react-lifecycles-compat": "^3.0.4"
-          }
-        },
-        "recompose": {
-          "version": "0.30.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "^7.0.0",
-            "change-emitter": "^0.1.2",
-            "fbjs": "^0.8.1",
-            "hoist-non-react-statics": "^2.3.1",
-            "react-lifecycles-compat": "^3.0.2",
-            "symbol-observable": "^1.0.4"
-          }
-        }
       }
     },
     "bpk-component-chip": {
       "version": "file:backpack/packages/bpk-component-chip",
       "dev": true,
       "requires": {
-        "bpk-component-close-button": "^1.0.142",
-        "bpk-mixins": "^17.24.5",
+        "bpk-component-close-button": "^1.0.141",
+        "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-component-close-button": {
-          "version": "1.0.142",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-component-icon": "^3.31.5",
-            "bpk-mixins": "^17.24.5",
-            "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-component-icon": {
-          "version": "3.31.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.5",
-            "bpk-react-utils": "^2.7.9",
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5",
-            "prop-types": "^15.6.2"
-          },
-          "dependencies": {
-            "bpk-mixins": {
-              "version": "17.24.5",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "bpk-svgs": "^6.9.3",
-                "bpk-tokens": "^27.6.5"
-              }
-            }
-          }
-        },
-        "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
-          }
-        },
-        "js-tokens": {
-          "version": "4.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "loose-envify": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "js-tokens": "^3.0.0 || ^4.0.0"
-          }
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "prop-types": {
-          "version": "15.6.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.3.1",
-            "object-assign": "^4.1.1"
-          }
-        },
-        "react-transition-group": {
-          "version": "2.9.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "dom-helpers": "^3.4.0",
-            "loose-envify": "^1.4.0",
-            "prop-types": "^15.6.2",
-            "react-lifecycles-compat": "^3.0.4"
-          }
-        },
-        "recompose": {
-          "version": "0.30.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "^7.0.0",
-            "change-emitter": "^0.1.2",
-            "fbjs": "^0.8.1",
-            "hoist-non-react-statics": "^2.3.1",
-            "react-lifecycles-compat": "^3.0.2",
-            "symbol-observable": "^1.0.4"
-          }
-        }
       }
     },
     "bpk-component-close-button": {
       "version": "file:backpack/packages/bpk-component-close-button",
       "dev": true,
       "requires": {
-        "bpk-component-icon": "^3.31.5",
-        "bpk-mixins": "^17.24.5",
+        "bpk-component-icon": "^3.31.4",
+        "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
       }
@@ -4178,1513 +2637,124 @@
       "version": "file:backpack/packages/bpk-component-code",
       "dev": true,
       "requires": {
-        "bpk-mixins": "^17.24.5",
+        "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
-          }
-        },
-        "js-tokens": {
-          "version": "4.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "loose-envify": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "js-tokens": "^3.0.0 || ^4.0.0"
-          }
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "prop-types": {
-          "version": "15.6.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.3.1",
-            "object-assign": "^4.1.1"
-          }
-        },
-        "react-transition-group": {
-          "version": "2.9.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "dom-helpers": "^3.4.0",
-            "loose-envify": "^1.4.0",
-            "prop-types": "^15.6.2",
-            "react-lifecycles-compat": "^3.0.4"
-          }
-        },
-        "recompose": {
-          "version": "0.30.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "^7.0.0",
-            "change-emitter": "^0.1.2",
-            "fbjs": "^0.8.1",
-            "hoist-non-react-statics": "^2.3.1",
-            "react-lifecycles-compat": "^3.0.2",
-            "symbol-observable": "^1.0.4"
-          }
-        }
       }
     },
     "bpk-component-content-container": {
       "version": "file:backpack/packages/bpk-component-content-container",
       "dev": true,
       "requires": {
-        "bpk-mixins": "^17.24.5",
+        "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
-          }
-        },
-        "js-tokens": {
-          "version": "4.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "loose-envify": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "js-tokens": "^3.0.0 || ^4.0.0"
-          }
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "prop-types": {
-          "version": "15.6.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.3.1",
-            "object-assign": "^4.1.1"
-          }
-        },
-        "react-transition-group": {
-          "version": "2.9.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "dom-helpers": "^3.4.0",
-            "loose-envify": "^1.4.0",
-            "prop-types": "^15.6.2",
-            "react-lifecycles-compat": "^3.0.4"
-          }
-        },
-        "recompose": {
-          "version": "0.30.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "^7.0.0",
-            "change-emitter": "^0.1.2",
-            "fbjs": "^0.8.1",
-            "hoist-non-react-statics": "^2.3.1",
-            "react-lifecycles-compat": "^3.0.2",
-            "symbol-observable": "^1.0.4"
-          }
-        }
       }
     },
     "bpk-component-datepicker": {
       "version": "file:backpack/packages/bpk-component-datepicker",
       "dev": true,
       "requires": {
-        "bpk-component-breakpoint": "^1.1.75",
-        "bpk-component-calendar": "^5.0.27",
-        "bpk-component-input": "^4.1.27",
-        "bpk-component-modal": "^1.8.74",
-        "bpk-component-popover": "^2.2.50",
-        "bpk-mixins": "^17.24.5",
+        "bpk-component-breakpoint": "^1.1.74",
+        "bpk-component-calendar": "^5.0.26",
+        "bpk-component-input": "^4.1.26",
+        "bpk-component-modal": "^1.8.73",
+        "bpk-component-popover": "^2.2.49",
+        "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-component-breakpoint": {
-          "version": "1.1.75",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.5",
-            "prop-types": "^15.6.2",
-            "react-responsive": "^5.0.0"
-          }
-        },
-        "bpk-component-calendar": {
-          "version": "5.0.27",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-component-icon": "^3.31.5",
-            "bpk-component-select": "^2.3.8",
-            "bpk-mixins": "^17.24.5",
-            "bpk-react-utils": "^2.7.9",
-            "bpk-tokens": "^27.6.5",
-            "date-fns": "^1.29.0",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-component-close-button": {
-          "version": "1.0.142",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-component-icon": "^3.31.5",
-            "bpk-mixins": "^17.24.5",
-            "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
-          },
-          "dependencies": {
-            "bpk-mixins": {
-              "version": "17.24.5",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "bpk-svgs": "^6.9.3",
-                "bpk-tokens": "^27.6.5"
-              }
-            }
-          }
-        },
-        "bpk-component-icon": {
-          "version": "3.31.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.5",
-            "bpk-react-utils": "^2.7.9",
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5",
-            "prop-types": "^15.6.2"
-          },
-          "dependencies": {
-            "bpk-mixins": {
-              "version": "17.24.5",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "bpk-svgs": "^6.9.3",
-                "bpk-tokens": "^27.6.5"
-              }
-            }
-          }
-        },
-        "bpk-component-input": {
-          "version": "4.1.27",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-component-icon": "^3.31.5",
-            "bpk-mixins": "^17.24.5",
-            "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-component-link": {
-          "version": "1.2.76",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.5",
-            "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
-          },
-          "dependencies": {
-            "bpk-mixins": {
-              "version": "17.24.5",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "bpk-svgs": "^6.9.3",
-                "bpk-tokens": "^27.6.5"
-              }
-            }
-          }
-        },
-        "bpk-component-modal": {
-          "version": "1.8.74",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-component-close-button": "^1.0.142",
-            "bpk-component-icon": "^3.31.5",
-            "bpk-component-link": "^1.2.76",
-            "bpk-mixins": "^17.24.5",
-            "bpk-react-utils": "^2.7.9",
-            "bpk-scrim-utils": "^3.2.76",
-            "prop-types": "^15.6.2"
-          },
-          "dependencies": {
-            "bpk-scrim-utils": {
-              "version": "3.2.76",
-              "resolved": "https://registry.npmjs.org/bpk-scrim-utils/-/bpk-scrim-utils-3.2.76.tgz",
-              "integrity": "sha512-aDl5SN+smHgLXYf2IzjOKnmgNlxQVZ8tNR/uxlpzld5Uigl55eBlzJ+IfMVZlMIHmN0esm8xX2qpnEhG0jTkyw==",
-              "dev": true,
-              "requires": {
-                "a11y-focus-scope": "^1.1.3",
-                "a11y-focus-store": "^1.0.0",
-                "bpk-mixins": "^17.24.5",
-                "bpk-react-utils": "^2.7.9"
-              }
-            }
-          }
-        },
-        "bpk-component-popover": {
-          "version": "2.2.50",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "@skyscanner/popper.js": "^1.12.9-beta.1",
-            "a11y-focus-scope": "^1.1.3",
-            "a11y-focus-store": "^1.0.0",
-            "bpk-component-close-button": "^1.0.142",
-            "bpk-component-link": "^1.2.76",
-            "bpk-component-text": "^1.1.7",
-            "bpk-mixins": "^17.24.5",
-            "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-component-select": {
-          "version": "2.3.8",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.5",
-            "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
-          },
-          "dependencies": {
-            "bpk-mixins": {
-              "version": "17.24.5",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "bpk-svgs": "^6.9.3",
-                "bpk-tokens": "^27.6.5"
-              }
-            }
-          }
-        },
-        "bpk-component-text": {
-          "version": "1.1.7",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.5",
-            "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
-          },
-          "dependencies": {
-            "bpk-mixins": {
-              "version": "17.24.5",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "bpk-svgs": "^6.9.3",
-                "bpk-tokens": "^27.6.5"
-              }
-            }
-          }
-        },
-        "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
-          "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "bundled": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        },
-        "bpk-scrim-utils": {
-          "version": "3.2.75",
-          "bundled": true,
-          "requires": {
-            "a11y-focus-scope": "^1.1.3",
-            "a11y-focus-store": "^1.0.0",
-            "bpk-mixins": "^17.24.4",
-            "bpk-react-utils": "^2.7.9"
-          }
-        },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "requires": {
-            "color": "^3.0.0"
-          }
-        },
-        "js-tokens": {
-          "version": "4.0.0",
-          "bundled": true
-        },
-        "loose-envify": {
-          "version": "1.4.0",
-          "bundled": true,
-          "requires": {
-            "js-tokens": "^3.0.0 || ^4.0.0"
-          }
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true
-        },
-        "prop-types": {
-          "version": "15.6.2",
-          "bundled": true,
-          "requires": {
-            "loose-envify": "^1.3.1",
-            "object-assign": "^4.1.1"
-          }
-        },
-        "react-transition-group": {
-          "version": "2.9.0",
-          "bundled": true,
-          "requires": {
-            "dom-helpers": "^3.4.0",
-            "loose-envify": "^1.4.0",
-            "prop-types": "^15.6.2",
-            "react-lifecycles-compat": "^3.0.4"
-          }
-        },
-        "recompose": {
-          "version": "0.30.0",
-          "bundled": true,
-          "requires": {
-            "@babel/runtime": "^7.0.0",
-            "change-emitter": "^0.1.2",
-            "fbjs": "^0.8.1",
-            "hoist-non-react-statics": "^2.3.1",
-            "react-lifecycles-compat": "^3.0.2",
-            "symbol-observable": "^1.0.4"
-          }
-        }
       }
     },
     "bpk-component-description-list": {
       "version": "file:backpack/packages/bpk-component-description-list",
       "dev": true,
       "requires": {
-        "bpk-mixins": "^17.24.5",
+        "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
-          }
-        },
-        "js-tokens": {
-          "version": "4.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "loose-envify": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "js-tokens": "^3.0.0 || ^4.0.0"
-          }
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "prop-types": {
-          "version": "15.6.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.3.1",
-            "object-assign": "^4.1.1"
-          }
-        },
-        "react-transition-group": {
-          "version": "2.9.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "dom-helpers": "^3.4.0",
-            "loose-envify": "^1.4.0",
-            "prop-types": "^15.6.2",
-            "react-lifecycles-compat": "^3.0.4"
-          }
-        },
-        "recompose": {
-          "version": "0.30.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "^7.0.0",
-            "change-emitter": "^0.1.2",
-            "fbjs": "^0.8.1",
-            "hoist-non-react-statics": "^2.3.1",
-            "react-lifecycles-compat": "^3.0.2",
-            "symbol-observable": "^1.0.4"
-          }
-        }
       }
     },
     "bpk-component-dialog": {
       "version": "file:backpack/packages/bpk-component-dialog",
       "dev": true,
       "requires": {
-        "bpk-component-modal": "^1.8.74",
+        "bpk-component-modal": "^1.8.73",
         "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-component-button": {
-          "version": "2.4.2",
-          "bundled": true
-        },
-        "bpk-component-close-button": {
-          "version": "1.0.142",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-component-icon": "^3.31.5",
-            "bpk-mixins": "^17.24.5",
-            "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
-          },
-          "dependencies": {
-            "bpk-component-icon": {
-              "version": "3.31.5",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "bpk-mixins": "^17.24.5",
-                "bpk-react-utils": "^2.7.9",
-                "bpk-svgs": "^6.9.3",
-                "bpk-tokens": "^27.6.5",
-                "prop-types": "^15.6.2"
-              }
-            },
-            "bpk-react-utils": {
-              "version": "2.7.9",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "object-assign": "^4.1.1",
-                "prop-types": "^15.6.2",
-                "react-transition-group": "^2.5.3",
-                "recompose": "^0.30.0"
-              }
-            }
-          }
-        },
-        "bpk-component-icon": {
-          "version": "3.31.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.5",
-            "bpk-react-utils": "^2.7.9",
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-component-link": {
-          "version": "1.2.76",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.5",
-            "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-component-modal": {
-          "version": "1.8.74",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-component-close-button": "^1.0.142",
-            "bpk-component-icon": "^3.31.5",
-            "bpk-component-link": "^1.2.76",
-            "bpk-mixins": "^17.24.5",
-            "bpk-react-utils": "^2.7.9",
-            "bpk-scrim-utils": "^3.2.76",
-            "prop-types": "^15.6.2"
-          },
-          "dependencies": {
-            "bpk-scrim-utils": {
-              "version": "3.2.76",
-              "resolved": "https://registry.npmjs.org/bpk-scrim-utils/-/bpk-scrim-utils-3.2.76.tgz",
-              "integrity": "sha512-aDl5SN+smHgLXYf2IzjOKnmgNlxQVZ8tNR/uxlpzld5Uigl55eBlzJ+IfMVZlMIHmN0esm8xX2qpnEhG0jTkyw==",
-              "dev": true,
-              "requires": {
-                "a11y-focus-scope": "^1.1.3",
-                "a11y-focus-store": "^1.0.0",
-                "bpk-mixins": "^17.24.5",
-                "bpk-react-utils": "^2.7.9"
-              }
-            }
-          }
-        },
-        "bpk-component-text": {
-          "version": "1.1.7",
-          "bundled": true,
-          "requires": {
-            "bpk-react-utils": "^2.7.9"
-          },
-          "dependencies": {
-            "bpk-react-utils": {
-              "version": "2.7.9",
-              "bundled": true
-            }
-          }
-        },
-        "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
-          "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "bundled": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        },
-        "bpk-scrim-utils": {
-          "version": "3.2.75",
-          "bundled": true,
-          "requires": {
-            "a11y-focus-scope": "^1.1.3",
-            "a11y-focus-store": "^1.0.0",
-            "bpk-mixins": "^17.24.4",
-            "bpk-react-utils": "^2.7.9"
-          }
-        },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "requires": {
-            "color": "^3.0.0"
-          }
-        },
-        "js-tokens": {
-          "version": "4.0.0",
-          "bundled": true
-        },
-        "loose-envify": {
-          "version": "1.4.0",
-          "bundled": true,
-          "requires": {
-            "js-tokens": "^3.0.0 || ^4.0.0"
-          }
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true
-        },
-        "prop-types": {
-          "version": "15.6.2",
-          "bundled": true,
-          "requires": {
-            "loose-envify": "^1.3.1",
-            "object-assign": "^4.1.1"
-          }
-        },
-        "react-transition-group": {
-          "version": "2.9.0",
-          "bundled": true,
-          "requires": {
-            "dom-helpers": "^3.4.0",
-            "loose-envify": "^1.4.0",
-            "prop-types": "^15.6.2",
-            "react-lifecycles-compat": "^3.0.4"
-          }
-        },
-        "recompose": {
-          "version": "0.30.0",
-          "bundled": true,
-          "requires": {
-            "@babel/runtime": "^7.0.0",
-            "change-emitter": "^0.1.2",
-            "fbjs": "^0.8.1",
-            "hoist-non-react-statics": "^2.3.1",
-            "react-lifecycles-compat": "^3.0.2",
-            "symbol-observable": "^1.0.4"
-          }
-        }
       }
     },
     "bpk-component-drawer": {
       "version": "file:backpack/packages/bpk-component-drawer",
       "dev": true,
       "requires": {
-        "bpk-component-close-button": "^1.0.142",
-        "bpk-component-icon": "^3.31.5",
-        "bpk-component-link": "^1.2.76",
-        "bpk-mixins": "^17.24.5",
+        "bpk-component-close-button": "^1.0.141",
+        "bpk-component-icon": "^3.31.4",
+        "bpk-component-link": "^1.2.75",
+        "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
-        "bpk-scrim-utils": "^3.2.76",
-        "bpk-tokens": "^27.6.5",
+        "bpk-scrim-utils": "^3.2.75",
+        "bpk-tokens": "^27.6.4",
         "prop-types": "^15.6.2",
         "react-transition-group": "^2.5.3"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.5.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "regenerator-runtime": "^0.13.2"
-          }
-        },
-        "bpk-component-button": {
-          "version": "2.4.2",
-          "bundled": true
-        },
-        "bpk-component-close-button": {
-          "version": "1.0.142",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-component-icon": "^3.31.5",
-            "bpk-mixins": "^17.24.5",
-            "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-component-icon": {
-          "version": "3.31.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.5",
-            "bpk-react-utils": "^2.7.9",
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-component-link": {
-          "version": "1.2.76",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.5",
-            "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-component-text": {
-          "version": "1.1.7",
-          "bundled": true,
-          "requires": {
-            "bpk-react-utils": "^2.7.9"
-          },
-          "dependencies": {
-            "bpk-react-utils": {
-              "version": "2.7.9",
-              "bundled": true
-            }
-          }
-        },
-        "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
-          }
-        },
-        "dom-helpers": {
-          "version": "3.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "^7.1.2"
-          }
-        },
-        "js-tokens": {
-          "version": "4.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "loose-envify": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "js-tokens": "^3.0.0 || ^4.0.0"
-          }
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "prop-types": {
-          "version": "15.6.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.3.1",
-            "object-assign": "^4.1.1"
-          }
-        },
-        "react-lifecycles-compat": {
-          "version": "3.0.4",
-          "bundled": true,
-          "dev": true
-        },
-        "react-transition-group": {
-          "version": "2.9.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "dom-helpers": "^3.4.0",
-            "loose-envify": "^1.4.0",
-            "prop-types": "^15.6.2",
-            "react-lifecycles-compat": "^3.0.4"
-          }
-        },
-        "recompose": {
-          "version": "0.30.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "^7.0.0",
-            "change-emitter": "^0.1.2",
-            "fbjs": "^0.8.1",
-            "hoist-non-react-statics": "^2.3.1",
-            "react-lifecycles-compat": "^3.0.2",
-            "symbol-observable": "^1.0.4"
-          }
-        },
-        "regenerator-runtime": {
-          "version": "0.13.3",
-          "bundled": true,
-          "dev": true
-        }
       }
     },
     "bpk-component-fieldset": {
       "version": "file:backpack/packages/bpk-component-fieldset",
       "dev": true,
       "requires": {
-        "bpk-component-form-validation": "^2.0.27",
-        "bpk-component-label": "^3.2.145",
-        "bpk-mixins": "^17.24.5",
+        "bpk-component-form-validation": "^2.0.26",
+        "bpk-component-label": "^3.2.144",
+        "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-animate-height": {
-          "version": "1.1.113",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-component-checkbox": {
-          "version": "1.4.110",
-          "bundled": true,
-          "requires": {
-            "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
-          },
-          "dependencies": {
-            "bpk-component-icon": {
-              "version": "3.31.4",
-              "bundled": true,
-              "requires": {
-                "bpk-mixins": "^17.24.4",
-                "bpk-react-utils": "^2.7.9",
-                "bpk-svgs": "^6.9.2",
-                "bpk-tokens": "^27.6.4",
-                "prop-types": "^15.6.2"
-              }
-            },
-            "bpk-mixins": {
-              "version": "17.24.4",
-              "bundled": true,
-              "requires": {
-                "bpk-svgs": "^6.9.2",
-                "bpk-tokens": "^27.6.4"
-              }
-            },
-            "bpk-react-utils": {
-              "version": "2.7.9",
-              "bundled": true,
-              "requires": {
-                "object-assign": "^4.1.1",
-                "prop-types": "^15.6.2"
-              }
-            },
-            "bpk-svgs": {
-              "version": "6.9.3",
-              "bundled": true
-            },
-            "bpk-tokens": {
-              "version": "27.6.5",
-              "bundled": true
-            },
-            "js-tokens": {
-              "version": "4.0.0",
-              "bundled": true
-            },
-            "loose-envify": {
-              "version": "1.4.0",
-              "bundled": true,
-              "requires": {
-                "js-tokens": "^3.0.0 || ^4.0.0"
-              }
-            },
-            "object-assign": {
-              "version": "4.1.1",
-              "bundled": true
-            },
-            "prop-types": {
-              "version": "15.6.2",
-              "bundled": true,
-              "requires": {
-                "loose-envify": "^1.3.1",
-                "object-assign": "^4.1.1"
-              }
-            }
-          }
-        },
-        "bpk-component-form-validation": {
-          "version": "2.0.27",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-animate-height": "^1.1.113",
-            "bpk-mixins": "^17.24.5",
-            "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-component-input": {
-          "version": "4.1.27",
-          "bundled": true
-        },
-        "bpk-component-label": {
-          "version": "3.2.145",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.5",
-            "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-component-select": {
-          "version": "2.3.8",
-          "bundled": true
-        },
-        "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
-          }
-        },
-        "js-tokens": {
-          "version": "4.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "loose-envify": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "js-tokens": "^3.0.0 || ^4.0.0"
-          }
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "prop-types": {
-          "version": "15.6.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.3.1",
-            "object-assign": "^4.1.1"
-          }
-        },
-        "react-transition-group": {
-          "version": "2.9.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "dom-helpers": "^3.4.0",
-            "loose-envify": "^1.4.0",
-            "prop-types": "^15.6.2",
-            "react-lifecycles-compat": "^3.0.4"
-          }
-        },
-        "recompose": {
-          "version": "0.30.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "^7.0.0",
-            "change-emitter": "^0.1.2",
-            "fbjs": "^0.8.1",
-            "hoist-non-react-statics": "^2.3.1",
-            "react-lifecycles-compat": "^3.0.2",
-            "symbol-observable": "^1.0.4"
-          }
-        }
       }
     },
     "bpk-component-form-validation": {
       "version": "file:backpack/packages/bpk-component-form-validation",
       "dev": true,
       "requires": {
-        "bpk-animate-height": "^1.1.113",
-        "bpk-mixins": "^17.24.5",
+        "bpk-animate-height": "^1.1.112",
+        "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        },
-        "react-transition-group": {
-          "version": "2.9.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "dom-helpers": "^3.4.0",
-            "loose-envify": "^1.4.0",
-            "prop-types": "^15.6.2",
-            "react-lifecycles-compat": "^3.0.4"
-          }
-        },
-        "recompose": {
-          "version": "0.30.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "^7.0.0",
-            "change-emitter": "^0.1.2",
-            "fbjs": "^0.8.1",
-            "hoist-non-react-statics": "^2.3.1",
-            "react-lifecycles-compat": "^3.0.2",
-            "symbol-observable": "^1.0.4"
-          }
-        }
       }
     },
     "bpk-component-grid": {
       "version": "file:backpack/packages/bpk-component-grid",
       "dev": true,
       "requires": {
-        "bpk-mixins": "^17.24.5",
+        "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
-          }
-        },
-        "js-tokens": {
-          "version": "4.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "loose-envify": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "js-tokens": "^3.0.0 || ^4.0.0"
-          }
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "prop-types": {
-          "version": "15.6.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.3.1",
-            "object-assign": "^4.1.1"
-          }
-        },
-        "react-transition-group": {
-          "version": "2.9.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "dom-helpers": "^3.4.0",
-            "loose-envify": "^1.4.0",
-            "prop-types": "^15.6.2",
-            "react-lifecycles-compat": "^3.0.4"
-          }
-        },
-        "recompose": {
-          "version": "0.30.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "^7.0.0",
-            "change-emitter": "^0.1.2",
-            "fbjs": "^0.8.1",
-            "hoist-non-react-statics": "^2.3.1",
-            "react-lifecycles-compat": "^3.0.2",
-            "symbol-observable": "^1.0.4"
-          }
-        }
       }
     },
     "bpk-component-grid-toggle": {
       "version": "file:backpack/packages/bpk-component-grid-toggle",
       "dev": true,
       "requires": {
-        "bpk-component-link": "^1.2.76",
-        "bpk-mixins": "^17.24.5",
+        "bpk-component-link": "^1.2.75",
+        "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-component-link": {
-          "version": "1.2.76",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.5",
-            "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
-          }
-        },
-        "js-tokens": {
-          "version": "4.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "loose-envify": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "js-tokens": "^3.0.0 || ^4.0.0"
-          }
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "prop-types": {
-          "version": "15.6.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.3.1",
-            "object-assign": "^4.1.1"
-          }
-        },
-        "react-transition-group": {
-          "version": "2.9.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "dom-helpers": "^3.4.0",
-            "loose-envify": "^1.4.0",
-            "prop-types": "^15.6.2",
-            "react-lifecycles-compat": "^3.0.4"
-          }
-        },
-        "recompose": {
-          "version": "0.30.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "^7.0.0",
-            "change-emitter": "^0.1.2",
-            "fbjs": "^0.8.1",
-            "hoist-non-react-statics": "^2.3.1",
-            "react-lifecycles-compat": "^3.0.2",
-            "symbol-observable": "^1.0.4"
-          }
-        }
       }
     },
     "bpk-component-horizontal-nav": {
       "version": "file:backpack/packages/bpk-component-horizontal-nav",
       "dev": true,
       "requires": {
-        "bpk-component-mobile-scroll-container": "^1.1.82",
-        "bpk-mixins": "^17.24.5",
+        "bpk-component-mobile-scroll-container": "^1.1.81",
+        "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-component-mobile-scroll-container": {
-          "version": "1.1.82",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.5",
-            "bpk-react-utils": "^2.7.9",
-            "lodash.debounce": "^4.0.8",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
-          }
-        },
-        "js-tokens": {
-          "version": "4.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "loose-envify": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "js-tokens": "^3.0.0 || ^4.0.0"
-          }
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "prop-types": {
-          "version": "15.6.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.3.1",
-            "object-assign": "^4.1.1"
-          }
-        },
-        "react-transition-group": {
-          "version": "2.9.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "dom-helpers": "^3.4.0",
-            "loose-envify": "^1.4.0",
-            "prop-types": "^15.6.2",
-            "react-lifecycles-compat": "^3.0.4"
-          }
-        },
-        "recompose": {
-          "version": "0.30.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "^7.0.0",
-            "change-emitter": "^0.1.2",
-            "fbjs": "^0.8.1",
-            "hoist-non-react-statics": "^2.3.1",
-            "react-lifecycles-compat": "^3.0.2",
-            "symbol-observable": "^1.0.4"
-          }
-        }
       }
     },
     "bpk-component-icon": {
       "version": "file:backpack/packages/bpk-component-icon",
       "dev": true,
       "requires": {
-        "bpk-mixins": "^17.24.5",
+        "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
-        "bpk-svgs": "^6.9.3",
-        "bpk-tokens": "^27.6.5",
+        "bpk-svgs": "^6.9.2",
+        "bpk-tokens": "^27.6.4",
         "prop-types": "^15.6.2"
       }
     },
@@ -5692,343 +2762,29 @@
       "version": "file:backpack/packages/bpk-component-image",
       "dev": true,
       "requires": {
-        "bpk-component-spinner": "^2.2.107",
-        "bpk-mixins": "^17.24.5",
+        "bpk-component-spinner": "^2.2.106",
+        "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2",
         "react-transition-group": "^2.5.3"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.5.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "regenerator-runtime": "^0.13.2"
-          }
-        },
-        "bpk-component-mobile-scroll-container": {
-          "version": "1.1.82",
-          "bundled": true,
-          "requires": {
-            "bpk-react-utils": "^2.7.9"
-          },
-          "dependencies": {
-            "bpk-react-utils": {
-              "version": "2.7.9",
-              "bundled": true
-            }
-          }
-        },
-        "bpk-component-spinner": {
-          "version": "2.2.107",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.5",
-            "bpk-react-utils": "^2.7.9",
-            "bpk-svgs": "^6.9.3",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-component-text": {
-          "version": "1.1.7",
-          "bundled": true,
-          "requires": {
-            "bpk-react-utils": "^2.7.9"
-          },
-          "dependencies": {
-            "bpk-react-utils": {
-              "version": "2.7.9",
-              "bundled": true
-            }
-          }
-        },
-        "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
-          }
-        },
-        "dom-helpers": {
-          "version": "3.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "^7.1.2"
-          }
-        },
-        "js-tokens": {
-          "version": "4.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "loose-envify": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "js-tokens": "^3.0.0 || ^4.0.0"
-          }
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "prop-types": {
-          "version": "15.6.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.3.1",
-            "object-assign": "^4.1.1"
-          }
-        },
-        "react-lifecycles-compat": {
-          "version": "3.0.4",
-          "bundled": true,
-          "dev": true
-        },
-        "react-transition-group": {
-          "version": "2.9.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "dom-helpers": "^3.4.0",
-            "loose-envify": "^1.4.0",
-            "prop-types": "^15.6.2",
-            "react-lifecycles-compat": "^3.0.4"
-          }
-        },
-        "recompose": {
-          "version": "0.30.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "^7.0.0",
-            "change-emitter": "^0.1.2",
-            "fbjs": "^0.8.1",
-            "hoist-non-react-statics": "^2.3.1",
-            "react-lifecycles-compat": "^3.0.2",
-            "symbol-observable": "^1.0.4"
-          }
-        },
-        "regenerator-runtime": {
-          "version": "0.13.3",
-          "bundled": true,
-          "dev": true
-        }
       }
     },
     "bpk-component-infinite-scroll": {
       "version": "file:backpack/packages/bpk-component-infinite-scroll",
       "dev": true,
       "requires": {
-        "bpk-mixins": "^17.24.5",
+        "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
         "intersection-observer": "^0.7.0",
         "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-component-button": {
-          "version": "2.4.2",
-          "bundled": true
-        },
-        "bpk-component-card": {
-          "version": "1.1.90",
-          "bundled": true,
-          "requires": {
-            "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
-          },
-          "dependencies": {
-            "bpk-mixins": {
-              "version": "17.24.4",
-              "bundled": true,
-              "requires": {
-                "bpk-svgs": "^6.9.2",
-                "bpk-tokens": "^27.6.4"
-              }
-            },
-            "bpk-react-utils": {
-              "version": "2.7.9",
-              "bundled": true,
-              "requires": {
-                "object-assign": "^4.1.1",
-                "prop-types": "^15.6.2"
-              }
-            },
-            "bpk-svgs": {
-              "version": "6.9.3",
-              "bundled": true
-            },
-            "bpk-tokens": {
-              "version": "27.6.5",
-              "bundled": true
-            },
-            "js-tokens": {
-              "version": "4.0.0",
-              "bundled": true
-            },
-            "loose-envify": {
-              "version": "1.4.0",
-              "bundled": true,
-              "requires": {
-                "js-tokens": "^3.0.0 || ^4.0.0"
-              }
-            },
-            "object-assign": {
-              "version": "4.1.1",
-              "bundled": true
-            },
-            "prop-types": {
-              "version": "15.6.2",
-              "bundled": true,
-              "requires": {
-                "loose-envify": "^1.3.1",
-                "object-assign": "^4.1.1"
-              }
-            }
-          }
-        },
-        "bpk-component-spinner": {
-          "version": "2.2.107",
-          "bundled": true,
-          "requires": {
-            "bpk-react-utils": "^2.7.9"
-          },
-          "dependencies": {
-            "bpk-react-utils": {
-              "version": "2.7.9",
-              "bundled": true
-            }
-          }
-        },
-        "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
-          }
-        },
-        "intersection-observer": {
-          "version": "0.7.0",
-          "bundled": true,
-          "dev": true
-        },
-        "js-tokens": {
-          "version": "4.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "loose-envify": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "js-tokens": "^3.0.0 || ^4.0.0"
-          }
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "prop-types": {
-          "version": "15.6.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.3.1",
-            "object-assign": "^4.1.1"
-          }
-        },
-        "react-transition-group": {
-          "version": "2.9.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "dom-helpers": "^3.4.0",
-            "loose-envify": "^1.4.0",
-            "prop-types": "^15.6.2",
-            "react-lifecycles-compat": "^3.0.4"
-          }
-        },
-        "recompose": {
-          "version": "0.30.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "^7.0.0",
-            "change-emitter": "^0.1.2",
-            "fbjs": "^0.8.1",
-            "hoist-non-react-statics": "^2.3.1",
-            "react-lifecycles-compat": "^3.0.2",
-            "symbol-observable": "^1.0.4"
-          }
-        }
       }
     },
     "bpk-component-input": {
       "version": "file:backpack/packages/bpk-component-input",
       "dev": true,
       "requires": {
-        "bpk-component-icon": "^3.31.5",
-        "bpk-mixins": "^17.24.5",
+        "bpk-component-icon": "^3.31.4",
+        "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
       }
@@ -6037,7 +2793,7 @@
       "version": "file:backpack/packages/bpk-component-label",
       "dev": true,
       "requires": {
-        "bpk-mixins": "^17.24.5",
+        "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
       }
@@ -6046,7 +2802,7 @@
       "version": "file:backpack/packages/bpk-component-link",
       "dev": true,
       "requires": {
-        "bpk-mixins": "^17.24.5",
+        "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
       }
@@ -6055,2079 +2811,124 @@
       "version": "file:backpack/packages/bpk-component-list",
       "dev": true,
       "requires": {
-        "bpk-mixins": "^17.24.5",
+        "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
-          }
-        },
-        "js-tokens": {
-          "version": "4.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "loose-envify": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "js-tokens": "^3.0.0 || ^4.0.0"
-          }
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "prop-types": {
-          "version": "15.6.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.3.1",
-            "object-assign": "^4.1.1"
-          }
-        },
-        "react-transition-group": {
-          "version": "2.9.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "dom-helpers": "^3.4.0",
-            "loose-envify": "^1.4.0",
-            "prop-types": "^15.6.2",
-            "react-lifecycles-compat": "^3.0.4"
-          }
-        },
-        "recompose": {
-          "version": "0.30.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "^7.0.0",
-            "change-emitter": "^0.1.2",
-            "fbjs": "^0.8.1",
-            "hoist-non-react-statics": "^2.3.1",
-            "react-lifecycles-compat": "^3.0.2",
-            "symbol-observable": "^1.0.4"
-          }
-        }
       }
     },
     "bpk-component-loading-button": {
       "version": "file:backpack/packages/bpk-component-loading-button",
       "dev": true,
       "requires": {
-        "bpk-component-button": "^2.4.2",
-        "bpk-component-icon": "^3.31.5",
-        "bpk-component-spinner": "^2.2.107",
-        "bpk-mixins": "^17.24.5",
+        "bpk-component-button": "^2.4.1",
+        "bpk-component-icon": "^3.31.4",
+        "bpk-component-spinner": "^2.2.106",
+        "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-component-button": {
-          "version": "2.4.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.5",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-component-icon": {
-          "version": "3.31.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.5",
-            "bpk-react-utils": "^2.7.9",
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-component-spinner": {
-          "version": "2.2.107",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.5",
-            "bpk-react-utils": "^2.7.9",
-            "bpk-svgs": "^6.9.3",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
-          }
-        },
-        "js-tokens": {
-          "version": "4.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "loose-envify": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "js-tokens": "^3.0.0 || ^4.0.0"
-          }
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "prop-types": {
-          "version": "15.6.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.3.1",
-            "object-assign": "^4.1.1"
-          }
-        },
-        "react-transition-group": {
-          "version": "2.9.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "dom-helpers": "^3.4.0",
-            "loose-envify": "^1.4.0",
-            "prop-types": "^15.6.2",
-            "react-lifecycles-compat": "^3.0.4"
-          }
-        },
-        "recompose": {
-          "version": "0.30.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "^7.0.0",
-            "change-emitter": "^0.1.2",
-            "fbjs": "^0.8.1",
-            "hoist-non-react-statics": "^2.3.1",
-            "react-lifecycles-compat": "^3.0.2",
-            "symbol-observable": "^1.0.4"
-          }
-        }
       }
     },
     "bpk-component-map": {
       "version": "file:backpack/packages/bpk-component-map",
       "dev": true,
       "requires": {
-        "bpk-component-spinner": "^2.2.107",
-        "bpk-mixins": "^17.24.5",
+        "bpk-component-spinner": "^2.2.106",
+        "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.5.8",
         "react-google-maps": "^9.4.5"
-      },
-      "dependencies": {
-        "asap": {
-          "version": "2.0.6",
-          "bundled": true,
-          "dev": true
-        },
-        "babel-runtime": {
-          "version": "6.26.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "core-js": "^2.4.0",
-            "regenerator-runtime": "^0.11.0"
-          }
-        },
-        "bpk-component-icon": {
-          "version": "3.31.5",
-          "bundled": true
-        },
-        "bpk-component-spinner": {
-          "version": "2.2.107",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.5",
-            "bpk-react-utils": "^2.7.9",
-            "bpk-svgs": "^6.9.3",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-component-text": {
-          "version": "1.1.7",
-          "bundled": true,
-          "requires": {
-            "bpk-react-utils": "^2.7.9"
-          },
-          "dependencies": {
-            "bpk-react-utils": {
-              "version": "2.7.9",
-              "bundled": true
-            }
-          }
-        },
-        "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          },
-          "dependencies": {
-            "recompose": {
-              "version": "0.30.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "@babel/runtime": "^7.0.0",
-                "change-emitter": "^0.1.2",
-                "fbjs": "^0.8.1",
-                "hoist-non-react-statics": "^2.3.1",
-                "react-lifecycles-compat": "^3.0.2",
-                "symbol-observable": "^1.0.4"
-              }
-            }
-          }
-        },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
-          }
-        },
-        "can-use-dom": {
-          "version": "0.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "change-emitter": {
-          "version": "0.1.6",
-          "bundled": true,
-          "dev": true
-        },
-        "core-js": {
-          "version": "2.5.7",
-          "bundled": true,
-          "dev": true
-        },
-        "encoding": {
-          "version": "0.1.12",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "iconv-lite": "~0.4.13"
-          }
-        },
-        "fbjs": {
-          "version": "0.8.17",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "core-js": "^1.0.0",
-            "isomorphic-fetch": "^2.1.1",
-            "loose-envify": "^1.0.0",
-            "object-assign": "^4.1.0",
-            "promise": "^7.1.1",
-            "setimmediate": "^1.0.5",
-            "ua-parser-js": "^0.7.18"
-          },
-          "dependencies": {
-            "core-js": {
-              "version": "1.2.7",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "google-maps-infobox": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "hoist-non-react-statics": {
-          "version": "2.5.5",
-          "bundled": true,
-          "dev": true
-        },
-        "iconv-lite": {
-          "version": "0.4.24",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safer-buffer": ">= 2.1.2 < 3"
-          }
-        },
-        "invariant": {
-          "version": "2.2.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.0.0"
-          }
-        },
-        "is-stream": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "isomorphic-fetch": {
-          "version": "2.2.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "node-fetch": "^1.0.1",
-            "whatwg-fetch": ">=0.10.0"
-          }
-        },
-        "js-tokens": {
-          "version": "4.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "lodash": {
-          "version": "4.17.10",
-          "bundled": true,
-          "dev": true
-        },
-        "loose-envify": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "js-tokens": "^3.0.0 || ^4.0.0"
-          }
-        },
-        "marker-clusterer-plus": {
-          "version": "2.1.4",
-          "bundled": true,
-          "dev": true
-        },
-        "markerwithlabel": {
-          "version": "2.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "node-fetch": {
-          "version": "1.7.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "encoding": "^0.1.11",
-            "is-stream": "^1.0.1"
-          }
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "promise": {
-          "version": "7.3.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "asap": "~2.0.3"
-          }
-        },
-        "prop-types": {
-          "version": "15.6.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.3.1",
-            "object-assign": "^4.1.1"
-          }
-        },
-        "react-google-maps": {
-          "version": "9.4.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "babel-runtime": "^6.11.6",
-            "can-use-dom": "^0.1.0",
-            "google-maps-infobox": "^2.0.0",
-            "invariant": "^2.2.1",
-            "lodash": "^4.16.2",
-            "marker-clusterer-plus": "^2.1.4",
-            "markerwithlabel": "^2.0.1",
-            "prop-types": "^15.5.8",
-            "recompose": "^0.26.0",
-            "scriptjs": "^2.5.8",
-            "warning": "^3.0.0"
-          }
-        },
-        "react-transition-group": {
-          "version": "2.9.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "dom-helpers": "^3.4.0",
-            "loose-envify": "^1.4.0",
-            "prop-types": "^15.6.2",
-            "react-lifecycles-compat": "^3.0.4"
-          }
-        },
-        "recompose": {
-          "version": "0.26.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "change-emitter": "^0.1.2",
-            "fbjs": "^0.8.1",
-            "hoist-non-react-statics": "^2.3.1",
-            "symbol-observable": "^1.0.4"
-          }
-        },
-        "regenerator-runtime": {
-          "version": "0.11.1",
-          "bundled": true,
-          "dev": true
-        },
-        "safer-buffer": {
-          "version": "2.1.2",
-          "bundled": true,
-          "dev": true
-        },
-        "scriptjs": {
-          "version": "2.5.8",
-          "bundled": true,
-          "dev": true
-        },
-        "setimmediate": {
-          "version": "1.0.5",
-          "bundled": true,
-          "dev": true
-        },
-        "symbol-observable": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true
-        },
-        "ua-parser-js": {
-          "version": "0.7.18",
-          "bundled": true,
-          "dev": true
-        },
-        "warning": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.0.0"
-          }
-        },
-        "whatwg-fetch": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true
-        }
       }
     },
     "bpk-component-mobile-scroll-container": {
       "version": "file:backpack/packages/bpk-component-mobile-scroll-container",
       "dev": true,
       "requires": {
-        "bpk-mixins": "^17.24.5",
+        "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
         "lodash.debounce": "^4.0.8",
         "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        },
-        "react-transition-group": {
-          "version": "2.9.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "dom-helpers": "^3.4.0",
-            "loose-envify": "^1.4.0",
-            "prop-types": "^15.6.2",
-            "react-lifecycles-compat": "^3.0.4"
-          }
-        },
-        "recompose": {
-          "version": "0.30.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "^7.0.0",
-            "change-emitter": "^0.1.2",
-            "fbjs": "^0.8.1",
-            "hoist-non-react-statics": "^2.3.1",
-            "react-lifecycles-compat": "^3.0.2",
-            "symbol-observable": "^1.0.4"
-          }
-        }
       }
     },
     "bpk-component-modal": {
       "version": "file:backpack/packages/bpk-component-modal",
       "dev": true,
       "requires": {
-        "bpk-component-close-button": "^1.0.142",
-        "bpk-component-icon": "^3.31.5",
-        "bpk-component-link": "^1.2.76",
-        "bpk-mixins": "^17.24.5",
+        "bpk-component-close-button": "^1.0.141",
+        "bpk-component-icon": "^3.31.4",
+        "bpk-component-link": "^1.2.75",
+        "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
-        "bpk-scrim-utils": "^3.2.76",
+        "bpk-scrim-utils": "^3.2.75",
         "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-component-close-button": {
-          "version": "1.0.142",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-component-icon": "^3.31.5",
-            "bpk-mixins": "^17.24.5",
-            "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-component-icon": {
-          "version": "3.31.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.5",
-            "bpk-react-utils": "^2.7.9",
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-component-link": {
-          "version": "1.2.76",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.5",
-            "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        },
-        "bpk-scrim-utils": {
-          "version": "3.2.76",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "a11y-focus-scope": "^1.1.3",
-            "a11y-focus-store": "^1.0.0",
-            "bpk-mixins": "^17.24.5",
-            "bpk-react-utils": "^2.7.9"
-          }
-        },
-        "react-transition-group": {
-          "version": "2.9.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "dom-helpers": "^3.4.0",
-            "loose-envify": "^1.4.0",
-            "prop-types": "^15.6.2",
-            "react-lifecycles-compat": "^3.0.4"
-          }
-        },
-        "recompose": {
-          "version": "0.30.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "^7.0.0",
-            "change-emitter": "^0.1.2",
-            "fbjs": "^0.8.1",
-            "hoist-non-react-statics": "^2.3.1",
-            "react-lifecycles-compat": "^3.0.2",
-            "symbol-observable": "^1.0.4"
-          }
-        }
       }
     },
     "bpk-component-navigation-bar": {
       "version": "file:backpack/packages/bpk-component-navigation-bar",
       "dev": true,
       "requires": {
-        "bpk-component-close-button": "^1.0.142",
-        "bpk-component-link": "^1.2.76",
-        "bpk-component-text": "^1.1.7",
-        "bpk-mixins": "^17.24.5",
+        "bpk-component-close-button": "^1.0.141",
+        "bpk-component-link": "^1.2.75",
+        "bpk-component-text": "^1.1.6",
+        "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-component-close-button": {
-          "version": "1.0.142",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-component-icon": "^3.31.5",
-            "bpk-mixins": "^17.24.5",
-            "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-component-icon": {
-          "version": "3.31.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.5",
-            "bpk-react-utils": "^2.7.9",
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-component-link": {
-          "version": "1.2.76",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.5",
-            "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-component-text": {
-          "version": "1.1.7",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.5",
-            "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
-          }
-        },
-        "js-tokens": {
-          "version": "4.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "loose-envify": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "js-tokens": "^3.0.0 || ^4.0.0"
-          }
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "prop-types": {
-          "version": "15.6.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.3.1",
-            "object-assign": "^4.1.1"
-          }
-        },
-        "react-transition-group": {
-          "version": "2.9.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "dom-helpers": "^3.4.0",
-            "loose-envify": "^1.4.0",
-            "prop-types": "^15.6.2",
-            "react-lifecycles-compat": "^3.0.4"
-          }
-        },
-        "recompose": {
-          "version": "0.30.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "^7.0.0",
-            "change-emitter": "^0.1.2",
-            "fbjs": "^0.8.1",
-            "hoist-non-react-statics": "^2.3.1",
-            "react-lifecycles-compat": "^3.0.2",
-            "symbol-observable": "^1.0.4"
-          }
-        }
       }
     },
     "bpk-component-navigation-stack": {
       "version": "file:backpack/packages/bpk-component-navigation-stack",
       "dev": true,
       "requires": {
-        "bpk-mixins": "^17.24.5",
+        "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
-        "bpk-tokens": "^27.6.5",
+        "bpk-tokens": "^27.6.4",
         "prop-types": "^15.6.2",
         "react-transition-group": "^2.5.3"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.5.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "regenerator-runtime": "^0.13.2"
-          }
-        },
-        "bpk-component-button": {
-          "version": "2.4.2",
-          "bundled": true
-        },
-        "bpk-component-icon": {
-          "version": "3.31.5",
-          "bundled": true
-        },
-        "bpk-component-navigation-bar": {
-          "version": "1.2.83",
-          "bundled": true,
-          "requires": {
-            "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
-          },
-          "dependencies": {
-            "bpk-component-close-button": {
-              "version": "1.0.141",
-              "bundled": true,
-              "requires": {
-                "bpk-component-icon": "^3.31.4",
-                "bpk-mixins": "^17.24.4",
-                "bpk-react-utils": "^2.7.9",
-                "prop-types": "^15.6.2"
-              }
-            },
-            "bpk-component-icon": {
-              "version": "3.31.5",
-              "bundled": true,
-              "requires": {
-                "bpk-react-utils": "^2.7.9",
-                "bpk-svgs": "^6.9.3",
-                "bpk-tokens": "^27.6.5",
-                "prop-types": "^15.6.2"
-              }
-            },
-            "bpk-component-link": {
-              "version": "1.2.75",
-              "bundled": true,
-              "requires": {
-                "bpk-mixins": "^17.24.4",
-                "bpk-react-utils": "^2.7.9",
-                "prop-types": "^15.6.2"
-              },
-              "dependencies": {
-                "bpk-react-utils": {
-                  "version": "2.7.9",
-                  "bundled": true,
-                  "requires": {
-                    "object-assign": "^4.1.1",
-                    "prop-types": "^15.6.2"
-                  }
-                }
-              }
-            },
-            "bpk-component-text": {
-              "version": "1.1.6",
-              "bundled": true,
-              "requires": {
-                "bpk-mixins": "^17.24.4",
-                "bpk-react-utils": "^2.7.9",
-                "prop-types": "^15.6.2"
-              }
-            },
-            "bpk-mixins": {
-              "version": "17.24.4",
-              "bundled": true,
-              "requires": {
-                "bpk-svgs": "^6.9.2",
-                "bpk-tokens": "^27.6.4"
-              }
-            },
-            "bpk-react-utils": {
-              "version": "2.7.9",
-              "bundled": true,
-              "requires": {
-                "object-assign": "^4.1.1",
-                "prop-types": "^15.6.2"
-              }
-            },
-            "bpk-svgs": {
-              "version": "6.9.3",
-              "bundled": true
-            },
-            "bpk-tokens": {
-              "version": "27.6.5",
-              "bundled": true
-            },
-            "js-tokens": {
-              "version": "4.0.0",
-              "bundled": true
-            },
-            "loose-envify": {
-              "version": "1.4.0",
-              "bundled": true,
-              "requires": {
-                "js-tokens": "^3.0.0 || ^4.0.0"
-              }
-            },
-            "object-assign": {
-              "version": "4.1.1",
-              "bundled": true
-            },
-            "prop-types": {
-              "version": "15.6.2",
-              "bundled": true,
-              "requires": {
-                "loose-envify": "^1.3.1",
-                "object-assign": "^4.1.1"
-              }
-            }
-          }
-        },
-        "bpk-component-rtl-toggle": {
-          "version": "1.1.95",
-          "bundled": true,
-          "requires": {
-            "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
-          },
-          "dependencies": {
-            "bpk-component-link": {
-              "version": "1.2.75",
-              "bundled": true,
-              "requires": {
-                "bpk-mixins": "^17.24.4",
-                "bpk-react-utils": "^2.7.9",
-                "prop-types": "^15.6.2"
-              }
-            },
-            "bpk-mixins": {
-              "version": "17.24.5",
-              "bundled": true,
-              "requires": {
-                "bpk-svgs": "^6.9.3",
-                "bpk-tokens": "^27.6.5"
-              }
-            },
-            "bpk-react-utils": {
-              "version": "2.7.9",
-              "bundled": true,
-              "requires": {
-                "object-assign": "^4.1.1",
-                "prop-types": "^15.6.2"
-              }
-            },
-            "bpk-svgs": {
-              "version": "6.9.3",
-              "bundled": true
-            },
-            "bpk-tokens": {
-              "version": "27.6.5",
-              "bundled": true
-            },
-            "js-tokens": {
-              "version": "4.0.0",
-              "bundled": true
-            },
-            "loose-envify": {
-              "version": "1.4.0",
-              "bundled": true,
-              "requires": {
-                "js-tokens": "^3.0.0 || ^4.0.0"
-              }
-            },
-            "object-assign": {
-              "version": "4.1.1",
-              "bundled": true
-            },
-            "prop-types": {
-              "version": "15.6.2",
-              "bundled": true,
-              "requires": {
-                "loose-envify": "^1.3.1",
-                "object-assign": "^4.1.1"
-              }
-            }
-          }
-        },
-        "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
-          }
-        },
-        "dom-helpers": {
-          "version": "3.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "^7.1.2"
-          }
-        },
-        "js-tokens": {
-          "version": "4.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "loose-envify": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "js-tokens": "^3.0.0 || ^4.0.0"
-          }
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "prop-types": {
-          "version": "15.6.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.3.1",
-            "object-assign": "^4.1.1"
-          }
-        },
-        "react-lifecycles-compat": {
-          "version": "3.0.4",
-          "bundled": true,
-          "dev": true
-        },
-        "react-transition-group": {
-          "version": "2.9.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "dom-helpers": "^3.4.0",
-            "loose-envify": "^1.4.0",
-            "prop-types": "^15.6.2",
-            "react-lifecycles-compat": "^3.0.4"
-          }
-        },
-        "recompose": {
-          "version": "0.30.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "^7.0.0",
-            "change-emitter": "^0.1.2",
-            "fbjs": "^0.8.1",
-            "hoist-non-react-statics": "^2.3.1",
-            "react-lifecycles-compat": "^3.0.2",
-            "symbol-observable": "^1.0.4"
-          }
-        },
-        "regenerator-runtime": {
-          "version": "0.13.3",
-          "bundled": true,
-          "dev": true
-        }
       }
     },
     "bpk-component-nudger": {
       "version": "file:backpack/packages/bpk-component-nudger",
       "dev": true,
       "requires": {
-        "bpk-component-button": "^2.4.2",
-        "bpk-component-icon": "^3.31.5",
-        "bpk-mixins": "^17.24.5",
+        "bpk-component-button": "^2.4.1",
+        "bpk-component-icon": "^3.31.4",
+        "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
-        "bpk-tokens": "^27.6.5",
+        "bpk-tokens": "^27.6.4",
         "lodash.clamp": "^4.0.3",
         "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-component-button": {
-          "version": "2.4.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.5",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-component-icon": {
-          "version": "3.31.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.5",
-            "bpk-react-utils": "^2.7.9",
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-component-label": {
-          "version": "3.2.145",
-          "bundled": true
-        },
-        "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
-          }
-        },
-        "js-tokens": {
-          "version": "4.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "lodash.clamp": {
-          "version": "4.0.3",
-          "bundled": true,
-          "dev": true
-        },
-        "loose-envify": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "js-tokens": "^3.0.0 || ^4.0.0"
-          }
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "prop-types": {
-          "version": "15.6.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.3.1",
-            "object-assign": "^4.1.1"
-          }
-        },
-        "react-transition-group": {
-          "version": "2.9.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "dom-helpers": "^3.4.0",
-            "loose-envify": "^1.4.0",
-            "prop-types": "^15.6.2",
-            "react-lifecycles-compat": "^3.0.4"
-          }
-        },
-        "recompose": {
-          "version": "0.30.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "^7.0.0",
-            "change-emitter": "^0.1.2",
-            "fbjs": "^0.8.1",
-            "hoist-non-react-statics": "^2.3.1",
-            "react-lifecycles-compat": "^3.0.2",
-            "symbol-observable": "^1.0.4"
-          }
-        }
       }
     },
     "bpk-component-pagination": {
       "version": "file:backpack/packages/bpk-component-pagination",
       "dev": true,
       "requires": {
-        "bpk-component-button": "^2.4.2",
-        "bpk-mixins": "^17.24.5",
+        "bpk-component-button": "^2.4.1",
+        "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-component-button": {
-          "version": "2.4.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.5",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-component-icon": {
-          "version": "3.31.5",
-          "bundled": true
-        },
-        "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
-          }
-        },
-        "js-tokens": {
-          "version": "4.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "loose-envify": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "js-tokens": "^3.0.0 || ^4.0.0"
-          }
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "prop-types": {
-          "version": "15.6.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.3.1",
-            "object-assign": "^4.1.1"
-          }
-        },
-        "react-transition-group": {
-          "version": "2.9.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "dom-helpers": "^3.4.0",
-            "loose-envify": "^1.4.0",
-            "prop-types": "^15.6.2",
-            "react-lifecycles-compat": "^3.0.4"
-          }
-        },
-        "recompose": {
-          "version": "0.30.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "^7.0.0",
-            "change-emitter": "^0.1.2",
-            "fbjs": "^0.8.1",
-            "hoist-non-react-statics": "^2.3.1",
-            "react-lifecycles-compat": "^3.0.2",
-            "symbol-observable": "^1.0.4"
-          }
-        }
       }
     },
     "bpk-component-panel": {
       "version": "file:backpack/packages/bpk-component-panel",
       "dev": true,
       "requires": {
-        "bpk-mixins": "^17.24.5",
+        "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
-          }
-        },
-        "js-tokens": {
-          "version": "4.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "loose-envify": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "js-tokens": "^3.0.0 || ^4.0.0"
-          }
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "prop-types": {
-          "version": "15.6.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.3.1",
-            "object-assign": "^4.1.1"
-          }
-        },
-        "react-transition-group": {
-          "version": "2.9.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "dom-helpers": "^3.4.0",
-            "loose-envify": "^1.4.0",
-            "prop-types": "^15.6.2",
-            "react-lifecycles-compat": "^3.0.4"
-          }
-        },
-        "recompose": {
-          "version": "0.30.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "^7.0.0",
-            "change-emitter": "^0.1.2",
-            "fbjs": "^0.8.1",
-            "hoist-non-react-statics": "^2.3.1",
-            "react-lifecycles-compat": "^3.0.2",
-            "symbol-observable": "^1.0.4"
-          }
-        }
       }
     },
     "bpk-component-phone-input": {
       "version": "file:backpack/packages/bpk-component-phone-input",
       "dev": true,
       "requires": {
-        "bpk-component-input": "^4.1.27",
-        "bpk-component-label": "^3.2.145",
-        "bpk-component-select": "^2.3.8",
-        "bpk-component-text": "^1.1.7",
-        "bpk-mixins": "^17.24.5",
+        "bpk-component-input": "^4.1.26",
+        "bpk-component-label": "^3.2.144",
+        "bpk-component-select": "^2.3.7",
+        "bpk-component-text": "^1.1.6",
+        "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
-        "bpk-tokens": "^27.6.5",
+        "bpk-tokens": "^27.6.4",
         "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-component-fieldset": {
-          "version": "1.1.113",
-          "bundled": true,
-          "requires": {
-            "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
-          },
-          "dependencies": {
-            "bpk-animate-height": {
-              "version": "1.1.113",
-              "bundled": true,
-              "requires": {
-                "prop-types": "^15.6.2"
-              }
-            },
-            "bpk-component-checkbox": {
-              "version": "1.4.110",
-              "bundled": true,
-              "requires": {
-                "bpk-react-utils": "^2.7.9",
-                "prop-types": "^15.6.2"
-              },
-              "dependencies": {
-                "bpk-component-icon": {
-                  "version": "3.31.4",
-                  "bundled": true,
-                  "requires": {
-                    "bpk-mixins": "^17.24.4",
-                    "bpk-react-utils": "^2.7.9",
-                    "bpk-svgs": "^6.9.2",
-                    "bpk-tokens": "^27.6.4",
-                    "prop-types": "^15.6.2"
-                  }
-                },
-                "bpk-mixins": {
-                  "version": "17.24.4",
-                  "bundled": true,
-                  "requires": {
-                    "bpk-svgs": "^6.9.2",
-                    "bpk-tokens": "^27.6.4"
-                  }
-                },
-                "bpk-react-utils": {
-                  "version": "2.7.9",
-                  "bundled": true,
-                  "requires": {
-                    "object-assign": "^4.1.1",
-                    "prop-types": "^15.6.2"
-                  }
-                },
-                "bpk-svgs": {
-                  "version": "6.9.3",
-                  "bundled": true
-                },
-                "bpk-tokens": {
-                  "version": "27.6.5",
-                  "bundled": true
-                },
-                "js-tokens": {
-                  "version": "4.0.0",
-                  "bundled": true
-                },
-                "loose-envify": {
-                  "version": "1.4.0",
-                  "bundled": true,
-                  "requires": {
-                    "js-tokens": "^3.0.0 || ^4.0.0"
-                  }
-                },
-                "object-assign": {
-                  "version": "4.1.1",
-                  "bundled": true
-                },
-                "prop-types": {
-                  "version": "15.6.2",
-                  "bundled": true,
-                  "requires": {
-                    "loose-envify": "^1.3.1",
-                    "object-assign": "^4.1.1"
-                  }
-                }
-              }
-            },
-            "bpk-component-form-validation": {
-              "version": "2.0.26",
-              "bundled": true,
-              "requires": {
-                "bpk-animate-height": "^1.1.112",
-                "bpk-mixins": "^17.24.4",
-                "bpk-react-utils": "^2.7.9",
-                "prop-types": "^15.6.2"
-              },
-              "dependencies": {
-                "bpk-animate-height": {
-                  "version": "1.1.112",
-                  "bundled": true,
-                  "requires": {
-                    "prop-types": "^15.6.2"
-                  }
-                },
-                "bpk-component-button": {
-                  "version": "",
-                  "bundled": true
-                },
-                "bpk-component-icon": {
-                  "version": "",
-                  "bundled": true
-                },
-                "bpk-mixins": {
-                  "version": "17.24.4",
-                  "bundled": true,
-                  "requires": {
-                    "bpk-svgs": "^6.9.2",
-                    "bpk-tokens": "^27.6.4"
-                  }
-                },
-                "bpk-react-utils": {
-                  "version": "2.7.9",
-                  "bundled": true
-                },
-                "bpk-svgs": {
-                  "version": "6.9.3",
-                  "bundled": true
-                },
-                "bpk-tokens": {
-                  "version": "27.6.5",
-                  "bundled": true
-                },
-                "js-tokens": {
-                  "version": "4.0.0",
-                  "bundled": true
-                },
-                "loose-envify": {
-                  "version": "1.4.0",
-                  "bundled": true,
-                  "requires": {
-                    "js-tokens": "^3.0.0 || ^4.0.0"
-                  }
-                },
-                "object-assign": {
-                  "version": "4.1.1",
-                  "bundled": true
-                },
-                "prop-types": {
-                  "version": "15.6.2",
-                  "bundled": true,
-                  "requires": {
-                    "loose-envify": "^1.3.1",
-                    "object-assign": "^4.1.1"
-                  }
-                }
-              }
-            },
-            "bpk-component-input": {
-              "version": "4.1.27",
-              "bundled": true
-            },
-            "bpk-component-label": {
-              "version": "3.2.144",
-              "bundled": true,
-              "requires": {
-                "bpk-mixins": "^17.24.4",
-                "bpk-react-utils": "^2.7.9",
-                "prop-types": "^15.6.2"
-              },
-              "dependencies": {
-                "bpk-mixins": {
-                  "version": "17.24.4",
-                  "bundled": true,
-                  "requires": {
-                    "bpk-svgs": "^6.9.2",
-                    "bpk-tokens": "^27.6.4"
-                  }
-                },
-                "bpk-react-utils": {
-                  "version": "2.7.9",
-                  "bundled": true
-                },
-                "bpk-svgs": {
-                  "version": "6.9.3",
-                  "bundled": true
-                },
-                "bpk-tokens": {
-                  "version": "27.6.5",
-                  "bundled": true
-                },
-                "js-tokens": {
-                  "version": "4.0.0",
-                  "bundled": true
-                },
-                "loose-envify": {
-                  "version": "1.4.0",
-                  "bundled": true,
-                  "requires": {
-                    "js-tokens": "^3.0.0 || ^4.0.0"
-                  }
-                },
-                "object-assign": {
-                  "version": "4.1.1",
-                  "bundled": true
-                },
-                "prop-types": {
-                  "version": "15.6.2",
-                  "bundled": true,
-                  "requires": {
-                    "loose-envify": "^1.3.1",
-                    "object-assign": "^4.1.1"
-                  }
-                }
-              }
-            },
-            "bpk-component-select": {
-              "version": "2.3.8",
-              "bundled": true
-            },
-            "bpk-mixins": {
-              "version": "17.24.4",
-              "bundled": true,
-              "requires": {
-                "bpk-svgs": "^6.9.2",
-                "bpk-tokens": "^27.6.4"
-              }
-            },
-            "bpk-react-utils": {
-              "version": "2.7.9",
-              "bundled": true,
-              "requires": {
-                "object-assign": "^4.1.1",
-                "prop-types": "^15.6.2"
-              }
-            },
-            "bpk-svgs": {
-              "version": "6.9.3",
-              "bundled": true
-            },
-            "bpk-tokens": {
-              "version": "27.6.5",
-              "bundled": true
-            },
-            "js-tokens": {
-              "version": "4.0.0",
-              "bundled": true
-            },
-            "loose-envify": {
-              "version": "1.4.0",
-              "bundled": true,
-              "requires": {
-                "js-tokens": "^3.0.0 || ^4.0.0"
-              }
-            },
-            "object-assign": {
-              "version": "4.1.1",
-              "bundled": true
-            },
-            "prop-types": {
-              "version": "15.6.2",
-              "bundled": true,
-              "requires": {
-                "loose-envify": "^1.3.1",
-                "object-assign": "^4.1.1"
-              }
-            }
-          }
-        },
-        "bpk-component-icon": {
-          "version": "3.31.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.5",
-            "bpk-react-utils": "^2.7.9",
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5",
-            "prop-types": "^15.6.2"
-          },
-          "dependencies": {
-            "bpk-mixins": {
-              "version": "17.24.5",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "bpk-svgs": "^6.9.3",
-                "bpk-tokens": "^27.6.5"
-              }
-            },
-            "bpk-tokens": {
-              "version": "27.6.5",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "color": "^3.0.0"
-              }
-            }
-          }
-        },
-        "bpk-component-image": {
-          "version": "2.2.8",
-          "bundled": true,
-          "requires": {
-            "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3"
-          },
-          "dependencies": {
-            "@babel/runtime": {
-              "version": "7.5.5",
-              "bundled": true,
-              "requires": {
-                "regenerator-runtime": "^0.13.2"
-              }
-            },
-            "bpk-component-mobile-scroll-container": {
-              "version": "1.1.82",
-              "bundled": true,
-              "requires": {
-                "bpk-react-utils": "^2.7.9"
-              },
-              "dependencies": {
-                "bpk-react-utils": {
-                  "version": "2.7.9",
-                  "bundled": true
-                }
-              }
-            },
-            "bpk-component-spinner": {
-              "version": "2.2.106",
-              "bundled": true,
-              "requires": {
-                "bpk-mixins": "^17.24.4",
-                "bpk-react-utils": "^2.7.9",
-                "bpk-svgs": "^6.9.2",
-                "prop-types": "^15.6.2"
-              },
-              "dependencies": {
-                "bpk-mixins": {
-                  "version": "17.24.4",
-                  "bundled": true,
-                  "requires": {
-                    "bpk-svgs": "^6.9.2",
-                    "bpk-tokens": "^27.6.4"
-                  }
-                },
-                "bpk-react-utils": {
-                  "version": "2.7.9",
-                  "bundled": true
-                },
-                "bpk-svgs": {
-                  "version": "6.9.2",
-                  "bundled": true
-                },
-                "bpk-tokens": {
-                  "version": "27.6.5",
-                  "bundled": true
-                },
-                "js-tokens": {
-                  "version": "4.0.0",
-                  "bundled": true
-                },
-                "loose-envify": {
-                  "version": "1.4.0",
-                  "bundled": true,
-                  "requires": {
-                    "js-tokens": "^3.0.0 || ^4.0.0"
-                  }
-                },
-                "object-assign": {
-                  "version": "4.1.1",
-                  "bundled": true
-                },
-                "prop-types": {
-                  "version": "15.6.2",
-                  "bundled": true,
-                  "requires": {
-                    "loose-envify": "^1.3.1",
-                    "object-assign": "^4.1.1"
-                  }
-                }
-              }
-            },
-            "bpk-component-text": {
-              "version": "1.1.7",
-              "bundled": true,
-              "requires": {
-                "bpk-react-utils": "^2.7.9"
-              },
-              "dependencies": {
-                "bpk-react-utils": {
-                  "version": "2.7.9",
-                  "bundled": true
-                }
-              }
-            },
-            "bpk-mixins": {
-              "version": "17.24.4",
-              "bundled": true,
-              "requires": {
-                "bpk-svgs": "^6.9.2",
-                "bpk-tokens": "^27.6.4"
-              }
-            },
-            "bpk-react-utils": {
-              "version": "2.7.9",
-              "bundled": true,
-              "requires": {
-                "object-assign": "^4.1.1",
-                "prop-types": "^15.6.2",
-                "react-transition-group": "^2.5.3"
-              }
-            },
-            "bpk-svgs": {
-              "version": "6.9.3",
-              "bundled": true
-            },
-            "bpk-tokens": {
-              "version": "27.6.5",
-              "bundled": true
-            },
-            "dom-helpers": {
-              "version": "3.4.0",
-              "bundled": true,
-              "requires": {
-                "@babel/runtime": "^7.1.2"
-              }
-            },
-            "js-tokens": {
-              "version": "4.0.0",
-              "bundled": true
-            },
-            "loose-envify": {
-              "version": "1.4.0",
-              "bundled": true,
-              "requires": {
-                "js-tokens": "^3.0.0 || ^4.0.0"
-              }
-            },
-            "object-assign": {
-              "version": "4.1.1",
-              "bundled": true
-            },
-            "prop-types": {
-              "version": "15.6.2",
-              "bundled": true,
-              "requires": {
-                "loose-envify": "^1.3.1",
-                "object-assign": "^4.1.1"
-              }
-            },
-            "react-lifecycles-compat": {
-              "version": "3.0.4",
-              "bundled": true
-            },
-            "react-transition-group": {
-              "version": "2.9.0",
-              "bundled": true,
-              "requires": {
-                "dom-helpers": "^3.4.0",
-                "loose-envify": "^1.4.0",
-                "prop-types": "^15.6.2",
-                "react-lifecycles-compat": "^3.0.4"
-              }
-            },
-            "regenerator-runtime": {
-              "version": "0.13.3",
-              "bundled": true
-            }
-          }
-        },
-        "bpk-component-input": {
-          "version": "4.1.27",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-component-icon": "^3.31.5",
-            "bpk-mixins": "^17.24.5",
-            "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-component-label": {
-          "version": "3.2.145",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.5",
-            "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-component-select": {
-          "version": "2.3.8",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.5",
-            "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-component-text": {
-          "version": "1.1.7",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.5",
-            "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
-          }
-        },
-        "js-tokens": {
-          "version": "4.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "loose-envify": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "js-tokens": "^3.0.0 || ^4.0.0"
-          }
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "prop-types": {
-          "version": "15.6.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.3.1",
-            "object-assign": "^4.1.1"
-          }
-        },
-        "react-transition-group": {
-          "version": "2.9.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "dom-helpers": "^3.4.0",
-            "loose-envify": "^1.4.0",
-            "prop-types": "^15.6.2",
-            "react-lifecycles-compat": "^3.0.4"
-          }
-        },
-        "recompose": {
-          "version": "0.30.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "^7.0.0",
-            "change-emitter": "^0.1.2",
-            "fbjs": "^0.8.1",
-            "hoist-non-react-statics": "^2.3.1",
-            "react-lifecycles-compat": "^3.0.2",
-            "symbol-observable": "^1.0.4"
-          }
-        }
       }
     },
     "bpk-component-popover": {
@@ -8137,815 +2938,81 @@
         "@skyscanner/popper.js": "^1.12.9-beta.1",
         "a11y-focus-scope": "^1.1.3",
         "a11y-focus-store": "^1.0.0",
-        "bpk-component-close-button": "^1.0.142",
-        "bpk-component-link": "^1.2.76",
-        "bpk-component-text": "^1.1.7",
-        "bpk-mixins": "^17.24.5",
+        "bpk-component-close-button": "^1.0.141",
+        "bpk-component-link": "^1.2.75",
+        "bpk-component-text": "^1.1.6",
+        "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-component-close-button": {
-          "version": "1.0.142",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-component-icon": "^3.31.5",
-            "bpk-mixins": "^17.24.5",
-            "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-component-icon": {
-          "version": "3.31.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.5",
-            "bpk-react-utils": "^2.7.9",
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-component-link": {
-          "version": "1.2.76",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.5",
-            "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-component-text": {
-          "version": "1.1.7",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.5",
-            "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        },
-        "react-transition-group": {
-          "version": "2.9.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "dom-helpers": "^3.4.0",
-            "loose-envify": "^1.4.0",
-            "prop-types": "^15.6.2",
-            "react-lifecycles-compat": "^3.0.4"
-          }
-        },
-        "recompose": {
-          "version": "0.30.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "^7.0.0",
-            "change-emitter": "^0.1.2",
-            "fbjs": "^0.8.1",
-            "hoist-non-react-statics": "^2.3.1",
-            "react-lifecycles-compat": "^3.0.2",
-            "symbol-observable": "^1.0.4"
-          }
-        }
       }
     },
     "bpk-component-progress": {
       "version": "file:backpack/packages/bpk-component-progress",
       "dev": true,
       "requires": {
-        "bpk-mixins": "^17.24.5",
+        "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
-        "bpk-tokens": "^27.6.5",
+        "bpk-tokens": "^27.6.4",
         "lodash.clamp": "^4.0.3",
         "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-component-button": {
-          "version": "2.4.2",
-          "bundled": true
-        },
-        "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
-          }
-        },
-        "js-tokens": {
-          "version": "4.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "lodash.clamp": {
-          "version": "4.0.3",
-          "bundled": true,
-          "dev": true
-        },
-        "loose-envify": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "js-tokens": "^3.0.0 || ^4.0.0"
-          }
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "prop-types": {
-          "version": "15.6.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.3.1",
-            "object-assign": "^4.1.1"
-          }
-        },
-        "react-transition-group": {
-          "version": "2.9.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "dom-helpers": "^3.4.0",
-            "loose-envify": "^1.4.0",
-            "prop-types": "^15.6.2",
-            "react-lifecycles-compat": "^3.0.4"
-          }
-        },
-        "recompose": {
-          "version": "0.30.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "^7.0.0",
-            "change-emitter": "^0.1.2",
-            "fbjs": "^0.8.1",
-            "hoist-non-react-statics": "^2.3.1",
-            "react-lifecycles-compat": "^3.0.2",
-            "symbol-observable": "^1.0.4"
-          }
-        }
       }
     },
     "bpk-component-radio": {
       "version": "file:backpack/packages/bpk-component-radio",
       "dev": true,
       "requires": {
-        "bpk-mixins": "^17.24.5",
+        "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
-          }
-        },
-        "js-tokens": {
-          "version": "4.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "loose-envify": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "js-tokens": "^3.0.0 || ^4.0.0"
-          }
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "prop-types": {
-          "version": "15.6.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.3.1",
-            "object-assign": "^4.1.1"
-          }
-        },
-        "react-transition-group": {
-          "version": "2.9.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "dom-helpers": "^3.4.0",
-            "loose-envify": "^1.4.0",
-            "prop-types": "^15.6.2",
-            "react-lifecycles-compat": "^3.0.4"
-          }
-        },
-        "recompose": {
-          "version": "0.30.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "^7.0.0",
-            "change-emitter": "^0.1.2",
-            "fbjs": "^0.8.1",
-            "hoist-non-react-statics": "^2.3.1",
-            "react-lifecycles-compat": "^3.0.2",
-            "symbol-observable": "^1.0.4"
-          }
-        }
       }
     },
     "bpk-component-router-link": {
       "version": "file:backpack/packages/bpk-component-router-link",
       "dev": true,
       "requires": {
-        "bpk-mixins": "^17.24.5",
+        "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
-          }
-        },
-        "js-tokens": {
-          "version": "4.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "loose-envify": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "js-tokens": "^3.0.0 || ^4.0.0"
-          }
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "prop-types": {
-          "version": "15.6.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.3.1",
-            "object-assign": "^4.1.1"
-          }
-        },
-        "react-transition-group": {
-          "version": "2.9.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "dom-helpers": "^3.4.0",
-            "loose-envify": "^1.4.0",
-            "prop-types": "^15.6.2",
-            "react-lifecycles-compat": "^3.0.4"
-          }
-        },
-        "recompose": {
-          "version": "0.30.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "^7.0.0",
-            "change-emitter": "^0.1.2",
-            "fbjs": "^0.8.1",
-            "hoist-non-react-statics": "^2.3.1",
-            "react-lifecycles-compat": "^3.0.2",
-            "symbol-observable": "^1.0.4"
-          }
-        }
       }
     },
     "bpk-component-rtl-toggle": {
       "version": "file:backpack/packages/bpk-component-rtl-toggle",
       "dev": true,
       "requires": {
-        "bpk-component-link": "^1.2.76",
+        "bpk-component-link": "^1.2.75",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-component-link": {
-          "version": "1.2.76",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.5",
-            "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
-          }
-        },
-        "js-tokens": {
-          "version": "4.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "loose-envify": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "js-tokens": "^3.0.0 || ^4.0.0"
-          }
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "prop-types": {
-          "version": "15.6.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.3.1",
-            "object-assign": "^4.1.1"
-          }
-        },
-        "react-transition-group": {
-          "version": "2.9.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "dom-helpers": "^3.4.0",
-            "loose-envify": "^1.4.0",
-            "prop-types": "^15.6.2",
-            "react-lifecycles-compat": "^3.0.4"
-          }
-        },
-        "recompose": {
-          "version": "0.30.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "^7.0.0",
-            "change-emitter": "^0.1.2",
-            "fbjs": "^0.8.1",
-            "hoist-non-react-statics": "^2.3.1",
-            "react-lifecycles-compat": "^3.0.2",
-            "symbol-observable": "^1.0.4"
-          }
-        }
       }
     },
     "bpk-component-scrollable-calendar": {
       "version": "file:backpack/packages/bpk-component-scrollable-calendar",
       "dev": true,
       "requires": {
-        "bpk-component-calendar": "^5.0.27",
-        "bpk-component-text": "^1.1.7",
-        "bpk-mixins": "^17.24.5",
+        "bpk-component-calendar": "^5.0.26",
+        "bpk-component-text": "^1.1.6",
+        "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.5.8",
         "react-window": "^1.5.0"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.2.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "regenerator-runtime": "^0.12.0"
-          },
-          "dependencies": {
-            "regenerator-runtime": {
-              "version": "0.12.1",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "bpk-component-calendar": {
-          "version": "5.0.27",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-component-icon": "^3.31.5",
-            "bpk-component-select": "^2.3.8",
-            "bpk-mixins": "^17.24.5",
-            "bpk-react-utils": "^2.7.9",
-            "bpk-tokens": "^27.6.5",
-            "date-fns": "^1.29.0",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-component-icon": {
-          "version": "3.31.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.5",
-            "bpk-react-utils": "^2.7.9",
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5",
-            "prop-types": "^15.6.2"
-          },
-          "dependencies": {
-            "bpk-mixins": {
-              "version": "17.24.5",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "bpk-svgs": "^6.9.3",
-                "bpk-tokens": "^27.6.5"
-              }
-            }
-          }
-        },
-        "bpk-component-select": {
-          "version": "2.3.8",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.5",
-            "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
-          },
-          "dependencies": {
-            "bpk-mixins": {
-              "version": "17.24.5",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "bpk-svgs": "^6.9.3",
-                "bpk-tokens": "^27.6.5"
-              }
-            }
-          }
-        },
-        "bpk-component-text": {
-          "version": "1.1.7",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.5",
-            "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
-          }
-        },
-        "js-tokens": {
-          "version": "4.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "loose-envify": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "js-tokens": "^3.0.0 || ^4.0.0"
-          }
-        },
-        "memoize-one": {
-          "version": "3.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "prop-types": {
-          "version": "15.6.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.3.1",
-            "object-assign": "^4.1.1"
-          }
-        },
-        "react-transition-group": {
-          "version": "2.9.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "dom-helpers": "^3.4.0",
-            "loose-envify": "^1.4.0",
-            "prop-types": "^15.6.2",
-            "react-lifecycles-compat": "^3.0.4"
-          }
-        },
-        "react-window": {
-          "version": "1.5.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "^7.0.0",
-            "memoize-one": "^3.1.1"
-          }
-        },
-        "recompose": {
-          "version": "0.30.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "^7.0.0",
-            "change-emitter": "^0.1.2",
-            "fbjs": "^0.8.1",
-            "hoist-non-react-statics": "^2.3.1",
-            "react-lifecycles-compat": "^3.0.2",
-            "symbol-observable": "^1.0.4"
-          }
-        }
       }
     },
     "bpk-component-section-list": {
       "version": "file:backpack/packages/bpk-component-section-list",
       "dev": true,
       "requires": {
-        "bpk-component-icon": "^3.31.5",
-        "bpk-component-text": "^1.1.7",
-        "bpk-mixins": "^17.24.5",
+        "bpk-component-icon": "^3.31.4",
+        "bpk-component-text": "^1.1.6",
+        "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
-        "bpk-tokens": "^27.6.5",
+        "bpk-tokens": "^27.6.4",
         "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-component-icon": {
-          "version": "3.31.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.5",
-            "bpk-react-utils": "^2.7.9",
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-component-text": {
-          "version": "1.1.7",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.5",
-            "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
-          }
-        },
-        "js-tokens": {
-          "version": "4.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "loose-envify": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "js-tokens": "^3.0.0 || ^4.0.0"
-          }
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "prop-types": {
-          "version": "15.6.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.3.1",
-            "object-assign": "^4.1.1"
-          }
-        },
-        "react-transition-group": {
-          "version": "2.9.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "dom-helpers": "^3.4.0",
-            "loose-envify": "^1.4.0",
-            "prop-types": "^15.6.2",
-            "react-lifecycles-compat": "^3.0.4"
-          }
-        },
-        "recompose": {
-          "version": "0.30.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "^7.0.0",
-            "change-emitter": "^0.1.2",
-            "fbjs": "^0.8.1",
-            "hoist-non-react-statics": "^2.3.1",
-            "react-lifecycles-compat": "^3.0.2",
-            "symbol-observable": "^1.0.4"
-          }
-        }
       }
     },
     "bpk-component-select": {
       "version": "file:backpack/packages/bpk-component-select",
       "dev": true,
       "requires": {
-        "bpk-mixins": "^17.24.5",
+        "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
       }
@@ -8954,921 +3021,79 @@
       "version": "file:backpack/packages/bpk-component-slider",
       "dev": true,
       "requires": {
-        "bpk-mixins": "^17.24.5",
+        "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
-        "bpk-tokens": "^27.6.5",
+        "bpk-tokens": "^27.6.4",
         "prop-types": "^15.6.2",
         "react-slider": "^0.11.2"
-      },
-      "dependencies": {
-        "asap": {
-          "version": "2.0.6",
-          "bundled": true
-        },
-        "bpk-component-rtl-toggle": {
-          "version": "1.1.95",
-          "bundled": true,
-          "requires": {
-            "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
-          },
-          "dependencies": {
-            "bpk-component-link": {
-              "version": "1.2.75",
-              "bundled": true,
-              "requires": {
-                "bpk-mixins": "^17.24.4",
-                "bpk-react-utils": "^2.7.9",
-                "prop-types": "^15.6.2"
-              }
-            },
-            "bpk-mixins": {
-              "version": "17.24.5",
-              "bundled": true,
-              "requires": {
-                "bpk-svgs": "^6.9.3",
-                "bpk-tokens": "^27.6.5"
-              }
-            },
-            "bpk-react-utils": {
-              "version": "2.7.9",
-              "bundled": true,
-              "requires": {
-                "object-assign": "^4.1.1",
-                "prop-types": "^15.6.2"
-              }
-            },
-            "bpk-svgs": {
-              "version": "6.9.3",
-              "bundled": true
-            },
-            "bpk-tokens": {
-              "version": "27.6.5",
-              "bundled": true
-            },
-            "js-tokens": {
-              "version": "4.0.0",
-              "bundled": true
-            },
-            "loose-envify": {
-              "version": "1.4.0",
-              "bundled": true,
-              "requires": {
-                "js-tokens": "^3.0.0 || ^4.0.0"
-              }
-            },
-            "object-assign": {
-              "version": "4.1.1",
-              "bundled": true
-            },
-            "prop-types": {
-              "version": "15.6.2",
-              "bundled": true,
-              "requires": {
-                "loose-envify": "^1.3.1",
-                "object-assign": "^4.1.1"
-              }
-            }
-          }
-        },
-        "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
-          }
-        },
-        "core-js": {
-          "version": "1.2.7",
-          "bundled": true
-        },
-        "create-react-class": {
-          "version": "15.6.3",
-          "bundled": true,
-          "requires": {
-            "fbjs": "^0.8.9",
-            "loose-envify": "^1.3.1",
-            "object-assign": "^4.1.1"
-          }
-        },
-        "encoding": {
-          "version": "0.1.12",
-          "bundled": true,
-          "requires": {
-            "iconv-lite": "~0.4.13"
-          }
-        },
-        "fbjs": {
-          "version": "0.8.17",
-          "bundled": true,
-          "requires": {
-            "core-js": "^1.0.0",
-            "isomorphic-fetch": "^2.1.1",
-            "loose-envify": "^1.0.0",
-            "object-assign": "^4.1.0",
-            "promise": "^7.1.1",
-            "setimmediate": "^1.0.5",
-            "ua-parser-js": "^0.7.18"
-          }
-        },
-        "iconv-lite": {
-          "version": "0.4.24",
-          "bundled": true,
-          "requires": {
-            "safer-buffer": ">= 2.1.2 < 3"
-          }
-        },
-        "is-stream": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "isomorphic-fetch": {
-          "version": "2.2.1",
-          "bundled": true,
-          "requires": {
-            "node-fetch": "^1.0.1",
-            "whatwg-fetch": ">=0.10.0"
-          }
-        },
-        "js-tokens": {
-          "version": "4.0.0",
-          "bundled": true
-        },
-        "loose-envify": {
-          "version": "1.4.0",
-          "bundled": true,
-          "requires": {
-            "js-tokens": "^3.0.0 || ^4.0.0"
-          }
-        },
-        "node-fetch": {
-          "version": "1.7.3",
-          "bundled": true,
-          "requires": {
-            "encoding": "^0.1.11",
-            "is-stream": "^1.0.1"
-          }
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true
-        },
-        "promise": {
-          "version": "7.3.1",
-          "bundled": true,
-          "requires": {
-            "asap": "~2.0.3"
-          }
-        },
-        "prop-types": {
-          "version": "15.6.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.3.1",
-            "object-assign": "^4.1.1"
-          }
-        },
-        "react-slider": {
-          "version": "0.11.2",
-          "bundled": true,
-          "dev": true
-        },
-        "react-transition-group": {
-          "version": "2.9.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "dom-helpers": "^3.4.0",
-            "loose-envify": "^1.4.0",
-            "prop-types": "^15.6.2",
-            "react-lifecycles-compat": "^3.0.4"
-          }
-        },
-        "recompose": {
-          "version": "0.30.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "^7.0.0",
-            "change-emitter": "^0.1.2",
-            "fbjs": "^0.8.1",
-            "hoist-non-react-statics": "^2.3.1",
-            "react-lifecycles-compat": "^3.0.2",
-            "symbol-observable": "^1.0.4"
-          }
-        },
-        "safer-buffer": {
-          "version": "2.1.2",
-          "bundled": true
-        },
-        "setimmediate": {
-          "version": "1.0.5",
-          "bundled": true
-        },
-        "ua-parser-js": {
-          "version": "0.7.20",
-          "bundled": true
-        },
-        "whatwg-fetch": {
-          "version": "3.0.0",
-          "bundled": true
-        }
       }
     },
     "bpk-component-spinner": {
       "version": "file:backpack/packages/bpk-component-spinner",
       "dev": true,
       "requires": {
-        "bpk-mixins": "^17.24.5",
+        "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
-        "bpk-svgs": "^6.9.3",
+        "bpk-svgs": "^6.9.2",
         "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        },
-        "react-transition-group": {
-          "version": "2.9.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "dom-helpers": "^3.4.0",
-            "loose-envify": "^1.4.0",
-            "prop-types": "^15.6.2",
-            "react-lifecycles-compat": "^3.0.4"
-          }
-        },
-        "recompose": {
-          "version": "0.30.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "^7.0.0",
-            "change-emitter": "^0.1.2",
-            "fbjs": "^0.8.1",
-            "hoist-non-react-statics": "^2.3.1",
-            "react-lifecycles-compat": "^3.0.2",
-            "symbol-observable": "^1.0.4"
-          }
-        }
       }
     },
     "bpk-component-star-rating": {
       "version": "file:backpack/packages/bpk-component-star-rating",
       "dev": true,
       "requires": {
-        "bpk-component-icon": "^3.31.5",
-        "bpk-mixins": "^17.24.5",
+        "bpk-component-icon": "^3.31.4",
+        "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-component-icon": {
-          "version": "3.31.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.5",
-            "bpk-react-utils": "^2.7.9",
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-component-table": {
-          "version": "1.1.81",
-          "bundled": true,
-          "requires": {
-            "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
-          },
-          "dependencies": {
-            "bpk-mixins": {
-              "version": "17.24.4",
-              "bundled": true,
-              "requires": {
-                "bpk-svgs": "^6.9.2",
-                "bpk-tokens": "^27.6.4"
-              }
-            },
-            "bpk-react-utils": {
-              "version": "2.7.9",
-              "bundled": true,
-              "requires": {
-                "object-assign": "^4.1.1",
-                "prop-types": "^15.6.2"
-              }
-            },
-            "bpk-svgs": {
-              "version": "6.9.3",
-              "bundled": true
-            },
-            "bpk-tokens": {
-              "version": "27.6.5",
-              "bundled": true
-            },
-            "js-tokens": {
-              "version": "4.0.0",
-              "bundled": true
-            },
-            "loose-envify": {
-              "version": "1.4.0",
-              "bundled": true,
-              "requires": {
-                "js-tokens": "^3.0.0 || ^4.0.0"
-              }
-            },
-            "object-assign": {
-              "version": "4.1.1",
-              "bundled": true
-            },
-            "prop-types": {
-              "version": "15.6.2",
-              "bundled": true,
-              "requires": {
-                "loose-envify": "^1.3.1",
-                "object-assign": "^4.1.1"
-              }
-            }
-          }
-        },
-        "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
-          }
-        },
-        "js-tokens": {
-          "version": "4.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "loose-envify": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "js-tokens": "^3.0.0 || ^4.0.0"
-          }
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "prop-types": {
-          "version": "15.6.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.3.1",
-            "object-assign": "^4.1.1"
-          }
-        },
-        "react-transition-group": {
-          "version": "2.9.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "dom-helpers": "^3.4.0",
-            "loose-envify": "^1.4.0",
-            "prop-types": "^15.6.2",
-            "react-lifecycles-compat": "^3.0.4"
-          }
-        },
-        "recompose": {
-          "version": "0.30.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "^7.0.0",
-            "change-emitter": "^0.1.2",
-            "fbjs": "^0.8.1",
-            "hoist-non-react-statics": "^2.3.1",
-            "react-lifecycles-compat": "^3.0.2",
-            "symbol-observable": "^1.0.4"
-          }
-        }
       }
     },
     "bpk-component-table": {
       "version": "file:backpack/packages/bpk-component-table",
       "dev": true,
       "requires": {
-        "bpk-mixins": "^17.24.5",
+        "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
-          }
-        },
-        "js-tokens": {
-          "version": "4.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "loose-envify": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "js-tokens": "^3.0.0 || ^4.0.0"
-          }
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "prop-types": {
-          "version": "15.6.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.3.1",
-            "object-assign": "^4.1.1"
-          }
-        },
-        "react-transition-group": {
-          "version": "2.9.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "dom-helpers": "^3.4.0",
-            "loose-envify": "^1.4.0",
-            "prop-types": "^15.6.2",
-            "react-lifecycles-compat": "^3.0.4"
-          }
-        },
-        "recompose": {
-          "version": "0.30.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "^7.0.0",
-            "change-emitter": "^0.1.2",
-            "fbjs": "^0.8.1",
-            "hoist-non-react-statics": "^2.3.1",
-            "react-lifecycles-compat": "^3.0.2",
-            "symbol-observable": "^1.0.4"
-          }
-        }
       }
     },
     "bpk-component-text": {
       "version": "file:backpack/packages/bpk-component-text",
       "dev": true,
       "requires": {
-        "bpk-mixins": "^17.24.5",
+        "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        },
-        "react-transition-group": {
-          "version": "2.9.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "dom-helpers": "^3.4.0",
-            "loose-envify": "^1.4.0",
-            "prop-types": "^15.6.2",
-            "react-lifecycles-compat": "^3.0.4"
-          }
-        },
-        "recompose": {
-          "version": "0.30.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "^7.0.0",
-            "change-emitter": "^0.1.2",
-            "fbjs": "^0.8.1",
-            "hoist-non-react-statics": "^2.3.1",
-            "react-lifecycles-compat": "^3.0.2",
-            "symbol-observable": "^1.0.4"
-          }
-        }
       }
     },
     "bpk-component-textarea": {
       "version": "file:backpack/packages/bpk-component-textarea",
       "dev": true,
       "requires": {
-        "bpk-mixins": "^17.24.5",
+        "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
-          }
-        },
-        "js-tokens": {
-          "version": "4.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "loose-envify": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "js-tokens": "^3.0.0 || ^4.0.0"
-          }
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "prop-types": {
-          "version": "15.6.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.3.1",
-            "object-assign": "^4.1.1"
-          }
-        },
-        "react-transition-group": {
-          "version": "2.9.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "dom-helpers": "^3.4.0",
-            "loose-envify": "^1.4.0",
-            "prop-types": "^15.6.2",
-            "react-lifecycles-compat": "^3.0.4"
-          }
-        },
-        "recompose": {
-          "version": "0.30.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "^7.0.0",
-            "change-emitter": "^0.1.2",
-            "fbjs": "^0.8.1",
-            "hoist-non-react-statics": "^2.3.1",
-            "react-lifecycles-compat": "^3.0.2",
-            "symbol-observable": "^1.0.4"
-          }
-        }
       }
     },
     "bpk-component-theme-toggle": {
       "version": "file:backpack/packages/bpk-component-theme-toggle",
       "dev": true,
       "requires": {
-        "bpk-component-label": "^3.2.145",
-        "bpk-component-select": "^2.3.8",
-        "bpk-mixins": "^17.24.5",
+        "bpk-component-label": "^3.2.144",
+        "bpk-component-select": "^2.3.7",
+        "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
-        "bpk-tokens": "^27.6.5",
+        "bpk-tokens": "^27.6.4",
         "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-component-label": {
-          "version": "3.2.145",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.5",
-            "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-component-select": {
-          "version": "2.3.8",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.5",
-            "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
-          }
-        },
-        "js-tokens": {
-          "version": "4.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "loose-envify": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "js-tokens": "^3.0.0 || ^4.0.0"
-          }
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "prop-types": {
-          "version": "15.6.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.3.1",
-            "object-assign": "^4.1.1"
-          }
-        },
-        "react-transition-group": {
-          "version": "2.9.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "dom-helpers": "^3.4.0",
-            "loose-envify": "^1.4.0",
-            "prop-types": "^15.6.2",
-            "react-lifecycles-compat": "^3.0.4"
-          }
-        },
-        "recompose": {
-          "version": "0.30.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "^7.0.0",
-            "change-emitter": "^0.1.2",
-            "fbjs": "^0.8.1",
-            "hoist-non-react-statics": "^2.3.1",
-            "react-lifecycles-compat": "^3.0.2",
-            "symbol-observable": "^1.0.4"
-          }
-        }
       }
     },
     "bpk-component-ticket": {
       "version": "file:backpack/packages/bpk-component-ticket",
       "dev": true,
       "requires": {
-        "bpk-mixins": "^17.24.5",
+        "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-component-button": {
-          "version": "2.4.2",
-          "bundled": true
-        },
-        "bpk-component-icon": {
-          "version": "3.31.5",
-          "bundled": true
-        },
-        "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
-          }
-        },
-        "js-tokens": {
-          "version": "4.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "loose-envify": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "js-tokens": "^3.0.0 || ^4.0.0"
-          }
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "prop-types": {
-          "version": "15.6.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.3.1",
-            "object-assign": "^4.1.1"
-          }
-        },
-        "react-transition-group": {
-          "version": "2.9.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "dom-helpers": "^3.4.0",
-            "loose-envify": "^1.4.0",
-            "prop-types": "^15.6.2",
-            "react-lifecycles-compat": "^3.0.4"
-          }
-        },
-        "recompose": {
-          "version": "0.30.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "^7.0.0",
-            "change-emitter": "^0.1.2",
-            "fbjs": "^0.8.1",
-            "hoist-non-react-statics": "^2.3.1",
-            "react-lifecycles-compat": "^3.0.2",
-            "symbol-observable": "^1.0.4"
-          }
-        }
       }
     },
     "bpk-component-tooltip": {
@@ -9876,121 +3101,17 @@
       "dev": true,
       "requires": {
         "@skyscanner/popper.js": "^1.12.9-beta.1",
-        "bpk-mixins": "^17.24.5",
+        "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "@skyscanner/popper.js": {
-          "version": "1.12.9-beta.1",
-          "bundled": true,
-          "dev": true
-        },
-        "bpk-component-text": {
-          "version": "1.1.7",
-          "bundled": true,
-          "requires": {
-            "bpk-react-utils": "^2.7.9"
-          },
-          "dependencies": {
-            "bpk-react-utils": {
-              "version": "2.7.9",
-              "bundled": true
-            }
-          }
-        },
-        "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
-          }
-        },
-        "js-tokens": {
-          "version": "4.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "loose-envify": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "js-tokens": "^3.0.0 || ^4.0.0"
-          }
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "prop-types": {
-          "version": "15.6.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.3.1",
-            "object-assign": "^4.1.1"
-          }
-        },
-        "react-transition-group": {
-          "version": "2.9.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "dom-helpers": "^3.4.0",
-            "loose-envify": "^1.4.0",
-            "prop-types": "^15.6.2",
-            "react-lifecycles-compat": "^3.0.4"
-          }
-        },
-        "recompose": {
-          "version": "0.30.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "^7.0.0",
-            "change-emitter": "^0.1.2",
-            "fbjs": "^0.8.1",
-            "hoist-non-react-statics": "^2.3.1",
-            "react-lifecycles-compat": "^3.0.2",
-            "symbol-observable": "^1.0.4"
-          }
-        }
       }
     },
     "bpk-mixins": {
       "version": "file:backpack/packages/bpk-mixins",
       "dev": true,
       "requires": {
-        "bpk-svgs": "^6.9.3",
-        "bpk-tokens": "^27.6.5"
+        "bpk-svgs": "^6.9.2",
+        "bpk-tokens": "^27.6.4"
       }
     },
     "bpk-react-utils": {
@@ -10001,32 +3122,6 @@
         "prop-types": "^15.6.2",
         "react-transition-group": "^2.5.3",
         "recompose": "^0.30.0"
-      },
-      "dependencies": {
-        "react-transition-group": {
-          "version": "2.9.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "dom-helpers": "^3.4.0",
-            "loose-envify": "^1.4.0",
-            "prop-types": "^15.6.2",
-            "react-lifecycles-compat": "^3.0.4"
-          }
-        },
-        "recompose": {
-          "version": "0.30.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "^7.0.0",
-            "change-emitter": "^0.1.2",
-            "fbjs": "^0.8.1",
-            "hoist-non-react-statics": "^2.3.1",
-            "react-lifecycles-compat": "^3.0.2",
-            "symbol-observable": "^1.0.4"
-          }
-        }
       }
     },
     "bpk-scrim-utils": {
@@ -10039,20 +3134,12 @@
         "a11y-focus-store": "^1.0.0",
         "bpk-mixins": "^17.24.5",
         "bpk-react-utils": "^2.7.9"
-      }
-    },
-    "bpk-stylesheets": {
-      "version": "file:backpack/packages/bpk-stylesheets",
-      "dev": true,
-      "requires": {
-        "bpk-mixins": "^17.24.5",
-        "bpk-tokens": "^27.6.5",
-        "normalize.css": "4.2.0"
       },
       "dependencies": {
         "bpk-mixins": {
           "version": "17.24.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.5.tgz",
+          "integrity": "sha512-qxpqlGH3V1+s1mOG5J6/wA5Qg9b4UHYfmDXBYKyf/A2cJZSZZgzI+JiTaEAuyluz9xF2s2hYWskrjttyc8Leeg==",
           "dev": true,
           "requires": {
             "bpk-svgs": "^6.9.3",
@@ -10061,22 +3148,28 @@
         },
         "bpk-svgs": {
           "version": "6.9.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/bpk-svgs/-/bpk-svgs-6.9.3.tgz",
+          "integrity": "sha512-OV/VTXqq2NmnJqqToY74RoLAapa+LPEHS/lI0gYnJYb/CUx1vBAp19qerRQfWb8ca6bNbpIol6YHIktSR83frg==",
           "dev": true
         },
         "bpk-tokens": {
           "version": "27.6.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/bpk-tokens/-/bpk-tokens-27.6.5.tgz",
+          "integrity": "sha512-wALtOBOSwSkN7t6GI3J3zamynysYD8eD8rwzN4xc7oTqVzKarVxLWi/CPHo5Xa2eByyIwhyGREcAkgKpY5Fr0w==",
           "dev": true,
           "requires": {
             "color": "^3.0.0"
           }
-        },
-        "normalize.css": {
-          "version": "4.2.0",
-          "bundled": true,
-          "dev": true
         }
+      }
+    },
+    "bpk-stylesheets": {
+      "version": "file:backpack/packages/bpk-stylesheets",
+      "dev": true,
+      "requires": {
+        "bpk-mixins": "^17.24.4",
+        "bpk-tokens": "^27.6.4",
+        "normalize.css": "4.2.0"
       }
     },
     "bpk-svgs": {
@@ -10087,45 +3180,8 @@
       "version": "file:backpack/packages/bpk-theming",
       "dev": true,
       "requires": {
-        "bpk-tokens": "^27.6.5",
+        "bpk-tokens": "^27.6.4",
         "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
-          }
-        },
-        "js-tokens": {
-          "version": "4.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "loose-envify": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "js-tokens": "^3.0.0 || ^4.0.0"
-          }
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "prop-types": {
-          "version": "15.6.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.3.1",
-            "object-assign": "^4.1.1"
-          }
-        }
       }
     },
     "bpk-tokens": {
@@ -10478,6 +3534,12 @@
         }
       }
     },
+    "can-use-dom": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/can-use-dom/-/can-use-dom-0.1.0.tgz",
+      "integrity": "sha1-IsxKNKCrxDlQ9CxkEQJKP2NmtFo=",
+      "dev": true
+    },
     "caniuse-db": {
       "version": "1.0.30000985",
       "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000985.tgz",
@@ -10544,7 +3606,8 @@
     "change-emitter": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/change-emitter/-/change-emitter-0.1.6.tgz",
-      "integrity": "sha1-6LL+PX8at9aaMhma/5HqaTFAlRU="
+      "integrity": "sha1-6LL+PX8at9aaMhma/5HqaTFAlRU=",
+      "dev": true
     },
     "character-entities": {
       "version": "1.2.3",
@@ -10950,6 +4013,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/color/-/color-3.1.2.tgz",
       "integrity": "sha512-vXTJhHebByxZn3lDvDJYw4lR5+uB3vuoHsuYA5AKuxRVn5wzzIfQKGLBmgdVRHKTJYeK5rvJcHnrd0Li49CFpg==",
+      "dev": true,
       "requires": {
         "color-convert": "^1.9.1",
         "color-string": "^1.5.2"
@@ -10959,6 +4023,7 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -10972,12 +4037,14 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
     },
     "color-string": {
       "version": "1.5.3",
       "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.3.tgz",
       "integrity": "sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==",
+      "dev": true,
       "requires": {
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
@@ -11782,6 +4849,74 @@
         "type": "^1.0.1"
       }
     },
+    "d3-array": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
+      "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw==",
+      "dev": true
+    },
+    "d3-collection": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/d3-collection/-/d3-collection-1.0.7.tgz",
+      "integrity": "sha512-ii0/r5f4sjKNTfh84Di+DpztYwqKhEyUlKoPrzUFfeSkWxjW49xU2QzO9qrPrNkpdI0XJkfzvmTu8V2Zylln6A==",
+      "dev": true
+    },
+    "d3-color": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.2.8.tgz",
+      "integrity": "sha512-yeANXzP37PHk0DbSTMNPhnJD+Nn4G//O5E825bR6fAfHH43hobSBpgB9G9oWVl9+XgUaQ4yCnsX1H+l8DoaL9A==",
+      "dev": true
+    },
+    "d3-format": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.3.2.tgz",
+      "integrity": "sha512-Z18Dprj96ExragQ0DeGi+SYPQ7pPfRMtUXtsg/ChVIKNBCzjO8XYJvRTC1usblx52lqge56V5ect+frYTQc8WQ==",
+      "dev": true
+    },
+    "d3-interpolate": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.3.2.tgz",
+      "integrity": "sha512-NlNKGopqaz9qM1PXh9gBF1KSCVh+jSFErrSlD/4hybwoNX/gt1d8CDbDW+3i+5UOHhjC6s6nMvRxcuoMVNgL2w==",
+      "dev": true,
+      "requires": {
+        "d3-color": "1"
+      }
+    },
+    "d3-path": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.7.tgz",
+      "integrity": "sha512-q0cW1RpvA5c5ma2rch62mX8AYaiLX0+bdaSM2wxSU9tXjU4DNvkx9qiUvjkuWCj3p22UO/hlPivujqMiR9PDzA==",
+      "dev": true
+    },
+    "d3-scale": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-2.2.2.tgz",
+      "integrity": "sha512-LbeEvGgIb8UMcAa0EATLNX0lelKWGYDQiPdHj+gLblGVhGLyNbaCn3EvrJf0A3Y/uOOU5aD6MTh5ZFCdEwGiCw==",
+      "dev": true,
+      "requires": {
+        "d3-array": "^1.2.0",
+        "d3-collection": "1",
+        "d3-format": "1",
+        "d3-interpolate": "1",
+        "d3-time": "1",
+        "d3-time-format": "2"
+      }
+    },
+    "d3-time": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.0.11.tgz",
+      "integrity": "sha512-Z3wpvhPLW4vEScGeIMUckDW7+3hWKOQfAWg/U7PlWBnQmeKQ00gCUsTtWSYulrKNA7ta8hJ+xXc6MHrMuITwEw==",
+      "dev": true
+    },
+    "d3-time-format": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.1.3.tgz",
+      "integrity": "sha512-6k0a2rZryzGm5Ihx+aFMuO1GgelgIz+7HhB4PH4OEndD5q2zGn1mDfRdNrulspOfR6JXkb2sThhDK41CSK85QA==",
+      "dev": true,
+      "requires": {
+        "d3-time": "1"
+      }
+    },
     "damerau-levenshtein": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.5.tgz",
@@ -12421,6 +5556,7 @@
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.4.0.tgz",
       "integrity": "sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==",
+      "dev": true,
       "requires": {
         "@babel/runtime": "^7.1.2"
       }
@@ -12582,6 +5718,7 @@
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
       "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "dev": true,
       "requires": {
         "iconv-lite": "~0.4.13"
       }
@@ -13669,6 +6806,7 @@
       "version": "0.8.17",
       "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
       "integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
+      "dev": true,
       "requires": {
         "core-js": "^1.0.0",
         "isomorphic-fetch": "^2.1.1",
@@ -13682,7 +6820,8 @@
         "core-js": {
           "version": "1.2.7",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
+          "dev": true
         }
       }
     },
@@ -14011,7 +7150,8 @@
     "focusin": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/focusin/-/focusin-2.0.0.tgz",
-      "integrity": "sha1-WMARgN+xlJ8D493u4GNzn8M7b/w="
+      "integrity": "sha1-WMARgN+xlJ8D493u4GNzn8M7b/w=",
+      "dev": true
     },
     "follow-redirects": {
       "version": "1.7.0",
@@ -14977,6 +8117,12 @@
         }
       }
     },
+    "google-maps-infobox": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/google-maps-infobox/-/google-maps-infobox-2.0.0.tgz",
+      "integrity": "sha512-hTuWmWZZSOxf5D/z7l3/hTF1grgRvLG53BEKMdjiKOG+FcK/kH7vqseUeyIU9Zj2ZIqKTOaro0nknxpAuRq4Vw==",
+      "dev": true
+    },
     "got": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/got/-/got-8.3.2.tgz",
@@ -15221,7 +8367,8 @@
     "hoist-non-react-statics": {
       "version": "2.5.5",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
-      "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
+      "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==",
+      "dev": true
     },
     "home-or-tmp": {
       "version": "2.0.0",
@@ -15922,6 +9069,7 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
@@ -16121,6 +9269,12 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
       "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==",
+      "dev": true
+    },
+    "intersection-observer": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/intersection-observer/-/intersection-observer-0.7.0.tgz",
+      "integrity": "sha512-Id0Fij0HsB/vKWGeBe9PxeY45ttRiBmhFyyt/geBdDHBYNctMRTE3dC1U3ujzz3lap+hVXlEcVaB56kZP/eEUg==",
       "dev": true
     },
     "into-stream": {
@@ -16476,7 +9630,8 @@
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
     },
     "is-string": {
       "version": "1.0.4",
@@ -16566,6 +9721,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
       "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+      "dev": true,
       "requires": {
         "node-fetch": "^1.0.1",
         "whatwg-fetch": ">=0.10.0"
@@ -17369,7 +10525,8 @@
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+      "dev": true
     },
     "js-yaml": {
       "version": "3.13.1",
@@ -18114,6 +11271,12 @@
       "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
       "dev": true
     },
+    "lodash.clamp": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.clamp/-/lodash.clamp-4.0.3.tgz",
+      "integrity": "sha1-XCS+3u7vB1NWDcK0y0Zx+Qpt36o=",
+      "dev": true
+    },
     "lodash.clonedeep": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
@@ -18339,6 +11502,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
@@ -18617,6 +11781,18 @@
       "integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg==",
       "dev": true
     },
+    "marker-clusterer-plus": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/marker-clusterer-plus/-/marker-clusterer-plus-2.1.4.tgz",
+      "integrity": "sha1-+O/3TVmdqzt9Dj/tUmTqDnBPXWc=",
+      "dev": true
+    },
+    "markerwithlabel": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/markerwithlabel/-/markerwithlabel-2.0.2.tgz",
+      "integrity": "sha512-C/cbm1A0h/u54gwHk5ZJNdUU3V3+1BbCpRPMsMyFA7vF4yL+aB4rWpxACz29TpQ+cTg6/iQroExh0PMSRGtQFg==",
+      "dev": true
+    },
     "matchmediaquery": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/matchmediaquery/-/matchmediaquery-0.3.0.tgz",
@@ -18698,6 +11874,12 @@
       "requires": {
         "mimic-fn": "^1.0.0"
       }
+    },
+    "memoize-one": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.0.5.tgz",
+      "integrity": "sha512-ey6EpYv0tEaIbM/nTDOpHciXUvd+ackQrJgEzBwemhZZIWZjcyodqEcrmqDy2BKRTM3a65kKBV4WtLXJDt26SQ==",
+      "dev": true
     },
     "memory-fs": {
       "version": "0.4.1",
@@ -19135,6 +12317,7 @@
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
       "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+      "dev": true,
       "requires": {
         "encoding": "^0.1.11",
         "is-stream": "^1.0.1"
@@ -19386,6 +12569,12 @@
         "sort-keys": "^2.0.0"
       }
     },
+    "normalize.css": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/normalize.css/-/normalize.css-4.2.0.tgz",
+      "integrity": "sha1-IdZsxVcVTUN5/R4HnsfeWKN5sJk=",
+      "dev": true
+    },
     "npm-run-path": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
@@ -19443,7 +12632,8 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
     },
     "object-copy": {
       "version": "0.1.0",
@@ -20552,6 +13742,7 @@
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
       "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "dev": true,
       "requires": {
         "asap": "~2.0.3"
       }
@@ -20850,6 +14041,28 @@
         "prop-types": "^15.6.0"
       }
     },
+    "react-autosuggest": {
+      "version": "9.4.3",
+      "resolved": "https://registry.npmjs.org/react-autosuggest/-/react-autosuggest-9.4.3.tgz",
+      "integrity": "sha512-wFbp5QpgFQRfw9cwKvcgLR8theikOUkv8PFsuLYqI2PUgVlx186Cz8MYt5bLxculi+jxGGUUVt+h0esaBZZouw==",
+      "dev": true,
+      "requires": {
+        "prop-types": "^15.5.10",
+        "react-autowhatever": "^10.1.2",
+        "shallow-equal": "^1.0.0"
+      }
+    },
+    "react-autowhatever": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/react-autowhatever/-/react-autowhatever-10.2.0.tgz",
+      "integrity": "sha512-dqHH4uqiJldPMbL8hl/i2HV4E8FMTDEdVlOIbRqYnJi0kTpWseF9fJslk/KS9pGDnm80JkYzVI+nzFjnOG/u+g==",
+      "dev": true,
+      "requires": {
+        "prop-types": "^15.5.8",
+        "react-themeable": "^1.1.0",
+        "section-iterator": "^2.0.0"
+      }
+    },
     "react-dom": {
       "version": "16.4.2",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.4.2.tgz",
@@ -20867,6 +14080,39 @@
       "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
       "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==",
       "dev": true
+    },
+    "react-google-maps": {
+      "version": "9.4.5",
+      "resolved": "https://registry.npmjs.org/react-google-maps/-/react-google-maps-9.4.5.tgz",
+      "integrity": "sha512-8z5nX9DxIcBCXuEiurmRT1VXVwnzx0C6+3Es6lxB2/OyY2SLax2/LcDu6Aldxnl3HegefTL7NJzGeaKAJ61pOA==",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.11.6",
+        "can-use-dom": "^0.1.0",
+        "google-maps-infobox": "^2.0.0",
+        "invariant": "^2.2.1",
+        "lodash": "^4.16.2",
+        "marker-clusterer-plus": "^2.1.4",
+        "markerwithlabel": "^2.0.1",
+        "prop-types": "^15.5.8",
+        "recompose": "^0.26.0",
+        "scriptjs": "^2.5.8",
+        "warning": "^3.0.0"
+      },
+      "dependencies": {
+        "recompose": {
+          "version": "0.26.0",
+          "resolved": "https://registry.npmjs.org/recompose/-/recompose-0.26.0.tgz",
+          "integrity": "sha512-KwOu6ztO0mN5vy3+zDcc45lgnaUoaQse/a5yLVqtzTK13czSWnFGmXbQVmnoMgDkI5POd1EwIKSbjU1V7xdZog==",
+          "dev": true,
+          "requires": {
+            "change-emitter": "^0.1.2",
+            "fbjs": "^0.8.1",
+            "hoist-non-react-statics": "^2.3.1",
+            "symbol-observable": "^1.0.4"
+          }
+        }
+      }
     },
     "react-helmet": {
       "version": "5.2.1",
@@ -20889,7 +14135,8 @@
     "react-lifecycles-compat": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
+      "dev": true
     },
     "react-markdown": {
       "version": "4.1.0",
@@ -20930,6 +14177,17 @@
         "path-to-regexp": "^1.7.0",
         "prop-types": "^15.6.1",
         "warning": "^4.0.1"
+      },
+      "dependencies": {
+        "warning": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+          "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.0.0"
+          }
+        }
       }
     },
     "react-router-dom": {
@@ -20944,6 +14202,17 @@
         "prop-types": "^15.6.1",
         "react-router": "^4.3.1",
         "warning": "^4.0.1"
+      },
+      "dependencies": {
+        "warning": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+          "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.0.0"
+          }
+        }
       }
     },
     "react-side-effect": {
@@ -20955,6 +14224,12 @@
         "exenv": "^1.2.1",
         "shallowequal": "^1.0.1"
       }
+    },
+    "react-slider": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/react-slider/-/react-slider-0.11.2.tgz",
+      "integrity": "sha512-y49ZwJJ7OcPdihgt71xYI8GRdAzpFuSLQR8b+cKotutxqf8MAEPEtqvWKlg+3ZQRe5PMN6oWbIb7wEYDF8XhNQ==",
+      "dev": true
     },
     "react-svg-core": {
       "version": "3.0.3",
@@ -20991,6 +14266,45 @@
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.0",
         "react-is": "^16.4.2"
+      }
+    },
+    "react-themeable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/react-themeable/-/react-themeable-1.1.0.tgz",
+      "integrity": "sha1-fURm3ZsrX6dQWHJ4JenxUro3mg4=",
+      "dev": true,
+      "requires": {
+        "object-assign": "^3.0.0"
+      },
+      "dependencies": {
+        "object-assign": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+          "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=",
+          "dev": true
+        }
+      }
+    },
+    "react-transition-group": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.9.0.tgz",
+      "integrity": "sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==",
+      "dev": true,
+      "requires": {
+        "dom-helpers": "^3.4.0",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2",
+        "react-lifecycles-compat": "^3.0.4"
+      }
+    },
+    "react-window": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.5.tgz",
+      "integrity": "sha512-HeTwlNa37AFa8MDZFZOKcNEkuF2YflA0hpGPiTT9vR7OawEt+GZbfM6wqkBahD3D3pUjIabQYzsnY/BSJbgq6Q==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.0.0",
+        "memoize-one": ">=3.1.1 <6"
       }
     },
     "read": {
@@ -21399,6 +14713,20 @@
       "dev": true,
       "requires": {
         "resolve": "^1.1.6"
+      }
+    },
+    "recompose": {
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/recompose/-/recompose-0.30.0.tgz",
+      "integrity": "sha512-ZTrzzUDa9AqUIhRk4KmVFihH0rapdCSMFXjhHbNrjAWxBuUD/guYlyysMnuHjlZC/KRiOKRtB4jf96yYSkKE8w==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.0.0",
+        "change-emitter": "^0.1.2",
+        "fbjs": "^0.8.1",
+        "hoist-non-react-statics": "^2.3.1",
+        "react-lifecycles-compat": "^3.0.2",
+        "symbol-observable": "^1.0.4"
       }
     },
     "redent": {
@@ -21949,7 +15277,8 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
     },
     "sane": {
       "version": "2.5.2",
@@ -22452,6 +15781,12 @@
         }
       }
     },
+    "scriptjs": {
+      "version": "2.5.9",
+      "resolved": "https://registry.npmjs.org/scriptjs/-/scriptjs-2.5.9.tgz",
+      "integrity": "sha512-qGVDoreyYiP1pkQnbnFAUIS5AjenNwwQBdl7zeos9etl+hYKWahjRTfzAZZYBv5xNHx7vNKCmaLDQZ6Fr2AEXg==",
+      "dev": true
+    },
     "scss-tokenizer": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
@@ -22472,6 +15807,12 @@
           }
         }
       }
+    },
+    "section-iterator": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/section-iterator/-/section-iterator-2.0.0.tgz",
+      "integrity": "sha1-v0RNev7rlK1Dw5rS+yYVFifMuio=",
+      "dev": true
     },
     "select-hose": {
       "version": "2.0.0",
@@ -22609,7 +15950,8 @@
     "setimmediate": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
+      "dev": true
     },
     "setprototypeof": {
       "version": "1.1.1",
@@ -22645,6 +15987,12 @@
           "dev": true
         }
       }
+    },
+    "shallow-equal": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shallow-equal/-/shallow-equal-1.2.0.tgz",
+      "integrity": "sha512-Z21pVxR4cXsfwpMKMhCEIO1PCi5sp7KEp+CmOpBQ+E8GpHwKOw2sEzk7sgblM3d/j4z4gakoWEoPcjK0VJQogA==",
+      "dev": true
     },
     "shallowequal": {
       "version": "1.1.0",
@@ -22694,6 +16042,7 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
       "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
+      "dev": true,
       "requires": {
         "is-arrayish": "^0.3.1"
       },
@@ -22701,7 +16050,8 @@
         "is-arrayish": {
           "version": "0.3.2",
           "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-          "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
+          "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
+          "dev": true
         }
       }
     },
@@ -24833,7 +18183,8 @@
     "symbol-observable": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
+      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
+      "dev": true
     },
     "symbol-tree": {
       "version": "3.2.4",
@@ -24853,7 +18204,8 @@
     "tabbable": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-1.1.3.tgz",
-      "integrity": "sha512-nOWwx35/JuDI4ONuF0ZTo6lYvI0fY0tZCH1ErzY2EXfu4az50ZyiUX8X073FLiZtmWUVlkRnuXsehjJgCw9tYg=="
+      "integrity": "sha512-nOWwx35/JuDI4ONuF0ZTo6lYvI0fY0tZCH1ErzY2EXfu4az50ZyiUX8X073FLiZtmWUVlkRnuXsehjJgCw9tYg==",
+      "dev": true
     },
     "table": {
       "version": "5.4.4",
@@ -25230,7 +18582,8 @@
     "ua-parser-js": {
       "version": "0.7.20",
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.20.tgz",
-      "integrity": "sha512-8OaIKfzL5cpx8eCMAhhvTlft8GYF8b2eQr6JkCyVdrgjcytyOmPCXrqXFcUnhonRpLlh5yxEZVohm6mzaowUOw=="
+      "integrity": "sha512-8OaIKfzL5cpx8eCMAhhvTlft8GYF8b2eQr6JkCyVdrgjcytyOmPCXrqXFcUnhonRpLlh5yxEZVohm6mzaowUOw==",
+      "dev": true
     },
     "uglify-js": {
       "version": "3.6.0",
@@ -25790,9 +19143,9 @@
       }
     },
     "warning": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
-      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
+      "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
       "dev": true,
       "requires": {
         "loose-envify": "^1.0.0"
@@ -26281,7 +19634,8 @@
     "whatwg-fetch": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
-      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
+      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==",
+      "dev": true
     },
     "whatwg-url": {
       "version": "4.8.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2493,6 +2493,61 @@
         "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-animate-height": {
+          "version": "1.1.113",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-icon": {
+          "version": "3.31.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
       }
     },
     "bpk-component-autosuggest": {
@@ -2504,6 +2559,64 @@
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2",
         "react-autosuggest": "^9.4.2"
+      },
+      "dependencies": {
+        "bpk-component-icon": {
+          "version": "3.31.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-input": {
+          "version": "4.1.27",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-component-icon": "^3.31.5",
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
       }
     },
     "bpk-component-badge": {
@@ -2513,6 +2626,41 @@
         "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
       }
     },
     "bpk-component-banner-alert": {
@@ -2527,6 +2675,72 @@
         "bpk-tokens": "^27.6.4",
         "prop-types": "^15.6.2",
         "react-transition-group": "^2.5.3"
+      },
+      "dependencies": {
+        "bpk-animate-height": {
+          "version": "1.1.113",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-close-button": {
+          "version": "1.0.142",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-component-icon": "^3.31.5",
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-icon": {
+          "version": "3.31.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
       }
     },
     "bpk-component-barchart": {
@@ -2541,6 +2755,52 @@
         "d3-scale": "^2.1.0",
         "lodash.debounce": "^4.0.8",
         "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-component-mobile-scroll-container": {
+          "version": "1.1.82",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "lodash.debounce": "^4.0.8",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
       }
     },
     "bpk-component-blockquote": {
@@ -2550,6 +2810,41 @@
         "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
       }
     },
     "bpk-component-breadcrumb": {
@@ -2562,6 +2857,73 @@
         "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-component-icon": {
+          "version": "3.31.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-link": {
+          "version": "1.2.76",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-text": {
+          "version": "1.1.7",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
       }
     },
     "bpk-component-breakpoint": {
@@ -2571,6 +2933,30 @@
         "bpk-mixins": "^17.24.4",
         "prop-types": "^15.6.2",
         "react-responsive": "^5.0.0"
+      },
+      "dependencies": {
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
       }
     },
     "bpk-component-button": {
@@ -2579,6 +2965,30 @@
       "requires": {
         "bpk-mixins": "^17.24.4",
         "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
       }
     },
     "bpk-component-calendar": {
@@ -2592,6 +3002,63 @@
         "bpk-tokens": "^27.6.4",
         "date-fns": "^1.29.0",
         "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-component-icon": {
+          "version": "3.31.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-select": {
+          "version": "2.3.8",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
       }
     },
     "bpk-component-card": {
@@ -2601,6 +3068,41 @@
         "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
       }
     },
     "bpk-component-checkbox": {
@@ -2611,6 +3113,53 @@
         "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-component-icon": {
+          "version": "3.31.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
       }
     },
     "bpk-component-chip": {
@@ -2621,6 +3170,64 @@
         "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-component-close-button": {
+          "version": "1.0.142",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-component-icon": "^3.31.5",
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-icon": {
+          "version": "3.31.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
       }
     },
     "bpk-component-close-button": {
@@ -2631,6 +3238,53 @@
         "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-component-icon": {
+          "version": "3.31.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
       }
     },
     "bpk-component-code": {
@@ -2640,6 +3294,41 @@
         "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
       }
     },
     "bpk-component-content-container": {
@@ -2649,6 +3338,41 @@
         "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
       }
     },
     "bpk-component-datepicker": {
@@ -2663,6 +3387,159 @@
         "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-component-breakpoint": {
+          "version": "1.1.75",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "prop-types": "^15.6.2",
+            "react-responsive": "^5.0.0"
+          }
+        },
+        "bpk-component-calendar": {
+          "version": "5.0.27",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-component-icon": "^3.31.5",
+            "bpk-component-select": "^2.3.8",
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "bpk-tokens": "^27.6.5",
+            "date-fns": "^1.29.0",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-close-button": {
+          "version": "1.0.142",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-component-icon": "^3.31.5",
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-icon": {
+          "version": "3.31.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-input": {
+          "version": "4.1.27",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-component-icon": "^3.31.5",
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-link": {
+          "version": "1.2.76",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-modal": {
+          "version": "1.8.74",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-component-close-button": "^1.0.142",
+            "bpk-component-icon": "^3.31.5",
+            "bpk-component-link": "^1.2.76",
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "bpk-scrim-utils": "^3.2.76",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-popover": {
+          "version": "2.2.50",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@skyscanner/popper.js": "^1.12.9-beta.1",
+            "a11y-focus-scope": "^1.1.3",
+            "a11y-focus-store": "^1.0.0",
+            "bpk-component-close-button": "^1.0.142",
+            "bpk-component-link": "^1.2.76",
+            "bpk-component-text": "^1.1.7",
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-select": {
+          "version": "2.3.8",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-text": {
+          "version": "1.1.7",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
       }
     },
     "bpk-component-description-list": {
@@ -2672,6 +3549,41 @@
         "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
       }
     },
     "bpk-component-dialog": {
@@ -2680,6 +3592,88 @@
       "requires": {
         "bpk-component-modal": "^1.8.73",
         "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-component-close-button": {
+          "version": "1.0.142",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-component-icon": "^3.31.5",
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-icon": {
+          "version": "3.31.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-link": {
+          "version": "1.2.76",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-modal": {
+          "version": "1.8.74",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-component-close-button": "^1.0.142",
+            "bpk-component-icon": "^3.31.5",
+            "bpk-component-link": "^1.2.76",
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "bpk-scrim-utils": "^3.2.76",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
       }
     },
     "bpk-component-drawer": {
@@ -2695,6 +3689,74 @@
         "bpk-tokens": "^27.6.4",
         "prop-types": "^15.6.2",
         "react-transition-group": "^2.5.3"
+      },
+      "dependencies": {
+        "bpk-component-close-button": {
+          "version": "1.0.142",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-component-icon": "^3.31.5",
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-icon": {
+          "version": "3.31.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-link": {
+          "version": "1.2.76",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
       }
     },
     "bpk-component-fieldset": {
@@ -2706,6 +3768,70 @@
         "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-animate-height": {
+          "version": "1.1.113",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-form-validation": {
+          "version": "2.0.27",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-animate-height": "^1.1.113",
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-label": {
+          "version": "3.2.145",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
       }
     },
     "bpk-component-form-validation": {
@@ -2716,6 +3842,49 @@
         "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-animate-height": {
+          "version": "1.1.113",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
       }
     },
     "bpk-component-grid": {
@@ -2725,6 +3894,41 @@
         "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
       }
     },
     "bpk-component-grid-toggle": {
@@ -2735,6 +3939,51 @@
         "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-component-link": {
+          "version": "1.2.76",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
       }
     },
     "bpk-component-horizontal-nav": {
@@ -2745,6 +3994,52 @@
         "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-component-mobile-scroll-container": {
+          "version": "1.1.82",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "lodash.debounce": "^4.0.8",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
       }
     },
     "bpk-component-icon": {
@@ -2756,6 +4051,41 @@
         "bpk-svgs": "^6.9.2",
         "bpk-tokens": "^27.6.4",
         "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
       }
     },
     "bpk-component-image": {
@@ -2767,6 +4097,52 @@
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2",
         "react-transition-group": "^2.5.3"
+      },
+      "dependencies": {
+        "bpk-component-spinner": {
+          "version": "2.2.107",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "bpk-svgs": "^6.9.3",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
       }
     },
     "bpk-component-infinite-scroll": {
@@ -2777,6 +4153,41 @@
         "bpk-react-utils": "^2.7.9",
         "intersection-observer": "^0.7.0",
         "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
       }
     },
     "bpk-component-input": {
@@ -2787,6 +4198,53 @@
         "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-component-icon": {
+          "version": "3.31.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
       }
     },
     "bpk-component-label": {
@@ -2796,6 +4254,41 @@
         "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
       }
     },
     "bpk-component-link": {
@@ -2805,6 +4298,41 @@
         "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
       }
     },
     "bpk-component-list": {
@@ -2814,6 +4342,41 @@
         "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
       }
     },
     "bpk-component-loading-button": {
@@ -2826,6 +4389,73 @@
         "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-component-button": {
+          "version": "2.4.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-icon": {
+          "version": "3.31.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-spinner": {
+          "version": "2.2.107",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "bpk-svgs": "^6.9.3",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
       }
     },
     "bpk-component-map": {
@@ -2837,6 +4467,52 @@
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.5.8",
         "react-google-maps": "^9.4.5"
+      },
+      "dependencies": {
+        "bpk-component-spinner": {
+          "version": "2.2.107",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "bpk-svgs": "^6.9.3",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
       }
     },
     "bpk-component-mobile-scroll-container": {
@@ -2847,6 +4523,41 @@
         "bpk-react-utils": "^2.7.9",
         "lodash.debounce": "^4.0.8",
         "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
       }
     },
     "bpk-component-modal": {
@@ -2860,6 +4571,74 @@
         "bpk-react-utils": "^2.7.9",
         "bpk-scrim-utils": "^3.2.75",
         "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-component-close-button": {
+          "version": "1.0.142",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-component-icon": "^3.31.5",
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-icon": {
+          "version": "3.31.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-link": {
+          "version": "1.2.76",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
       }
     },
     "bpk-component-navigation-bar": {
@@ -2872,6 +4651,84 @@
         "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-component-close-button": {
+          "version": "1.0.142",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-component-icon": "^3.31.5",
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-icon": {
+          "version": "3.31.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-link": {
+          "version": "1.2.76",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-text": {
+          "version": "1.1.7",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
       }
     },
     "bpk-component-navigation-stack": {
@@ -2883,6 +4740,41 @@
         "bpk-tokens": "^27.6.4",
         "prop-types": "^15.6.2",
         "react-transition-group": "^2.5.3"
+      },
+      "dependencies": {
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
       }
     },
     "bpk-component-nudger": {
@@ -2896,6 +4788,62 @@
         "bpk-tokens": "^27.6.4",
         "lodash.clamp": "^4.0.3",
         "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-component-button": {
+          "version": "2.4.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-icon": {
+          "version": "3.31.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
       }
     },
     "bpk-component-pagination": {
@@ -2906,6 +4854,50 @@
         "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-component-button": {
+          "version": "2.4.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
       }
     },
     "bpk-component-panel": {
@@ -2915,6 +4907,41 @@
         "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
       }
     },
     "bpk-component-phone-input": {
@@ -2929,6 +4956,94 @@
         "bpk-react-utils": "^2.7.9",
         "bpk-tokens": "^27.6.4",
         "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-component-icon": {
+          "version": "3.31.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-input": {
+          "version": "4.1.27",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-component-icon": "^3.31.5",
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-label": {
+          "version": "3.2.145",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-select": {
+          "version": "2.3.8",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-text": {
+          "version": "1.1.7",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
       }
     },
     "bpk-component-popover": {
@@ -2944,6 +5059,84 @@
         "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-component-close-button": {
+          "version": "1.0.142",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-component-icon": "^3.31.5",
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-icon": {
+          "version": "3.31.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-link": {
+          "version": "1.2.76",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-text": {
+          "version": "1.1.7",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
       }
     },
     "bpk-component-progress": {
@@ -2955,6 +5148,41 @@
         "bpk-tokens": "^27.6.4",
         "lodash.clamp": "^4.0.3",
         "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
       }
     },
     "bpk-component-radio": {
@@ -2964,6 +5192,41 @@
         "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
       }
     },
     "bpk-component-router-link": {
@@ -2973,6 +5236,41 @@
         "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
       }
     },
     "bpk-component-rtl-toggle": {
@@ -2982,6 +5280,51 @@
         "bpk-component-link": "^1.2.75",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-component-link": {
+          "version": "1.2.76",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
       }
     },
     "bpk-component-scrollable-calendar": {
@@ -2994,6 +5337,87 @@
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.5.8",
         "react-window": "^1.5.0"
+      },
+      "dependencies": {
+        "bpk-component-calendar": {
+          "version": "5.0.27",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-component-icon": "^3.31.5",
+            "bpk-component-select": "^2.3.8",
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "bpk-tokens": "^27.6.5",
+            "date-fns": "^1.29.0",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-icon": {
+          "version": "3.31.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-select": {
+          "version": "2.3.8",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-text": {
+          "version": "1.1.7",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
       }
     },
     "bpk-component-section-list": {
@@ -3006,6 +5430,63 @@
         "bpk-react-utils": "^2.7.9",
         "bpk-tokens": "^27.6.4",
         "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-component-icon": {
+          "version": "3.31.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-text": {
+          "version": "1.1.7",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
       }
     },
     "bpk-component-select": {
@@ -3015,6 +5496,41 @@
         "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
       }
     },
     "bpk-component-slider": {
@@ -3026,6 +5542,41 @@
         "bpk-tokens": "^27.6.4",
         "prop-types": "^15.6.2",
         "react-slider": "^0.11.2"
+      },
+      "dependencies": {
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
       }
     },
     "bpk-component-spinner": {
@@ -3036,6 +5587,41 @@
         "bpk-react-utils": "^2.7.9",
         "bpk-svgs": "^6.9.2",
         "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
       }
     },
     "bpk-component-star-rating": {
@@ -3046,6 +5632,53 @@
         "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-component-icon": {
+          "version": "3.31.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
       }
     },
     "bpk-component-table": {
@@ -3055,6 +5688,41 @@
         "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
       }
     },
     "bpk-component-text": {
@@ -3064,6 +5732,41 @@
         "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
       }
     },
     "bpk-component-textarea": {
@@ -3073,6 +5776,41 @@
         "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
       }
     },
     "bpk-component-theme-toggle": {
@@ -3085,6 +5823,61 @@
         "bpk-react-utils": "^2.7.9",
         "bpk-tokens": "^27.6.4",
         "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-component-label": {
+          "version": "3.2.145",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-select": {
+          "version": "2.3.8",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
       }
     },
     "bpk-component-ticket": {
@@ -3094,6 +5887,41 @@
         "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
       }
     },
     "bpk-component-tooltip": {
@@ -3104,6 +5932,41 @@
         "bpk-mixins": "^17.24.4",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
       }
     },
     "bpk-mixins": {
@@ -3112,6 +5975,21 @@
       "requires": {
         "bpk-svgs": "^6.9.2",
         "bpk-tokens": "^27.6.4"
+      },
+      "dependencies": {
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
       }
     },
     "bpk-react-utils": {
@@ -3146,6 +6024,18 @@
             "bpk-tokens": "^27.6.5"
           }
         },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
+          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
         "bpk-svgs": {
           "version": "6.9.3",
           "resolved": "https://registry.npmjs.org/bpk-svgs/-/bpk-svgs-6.9.3.tgz",
@@ -3170,6 +6060,30 @@
         "bpk-mixins": "^17.24.4",
         "bpk-tokens": "^27.6.4",
         "normalize.css": "4.2.0"
+      },
+      "dependencies": {
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
       }
     },
     "bpk-svgs": {
@@ -3182,6 +6096,16 @@
       "requires": {
         "bpk-tokens": "^27.6.4",
         "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
       }
     },
     "bpk-tokens": {
@@ -6188,6 +9112,17 @@
         "bpk-tokens": "^27.4.7",
         "lodash": "^4.17.11",
         "tinycolor2": "^1.4.1"
+      },
+      "dependencies": {
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "resolved": "https://registry.npmjs.org/bpk-tokens/-/bpk-tokens-27.6.5.tgz",
+          "integrity": "sha512-wALtOBOSwSkN7t6GI3J3zamynysYD8eD8rwzN4xc7oTqVzKarVxLWi/CPHo5Xa2eByyIwhyGREcAkgKpY5Fr0w==",
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        }
       }
     },
     "eslint-plugin-flowtype": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,31 +5,31 @@
   "requires": true,
   "dependencies": {
     "@babel/code-frame": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
-      "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
+      "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
       "dev": true,
       "requires": {
         "@babel/highlight": "^7.0.0"
       }
     },
     "@babel/core": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.4.4.tgz",
-      "integrity": "sha512-lQgGX3FPRgbz2SKmhMtYgJvVzGZrmjaF4apZ2bLwofAKiSjxU0drPh4S/VasyYXwaTs+A1gvQ45BN8SQJzHsQQ==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.5.5.tgz",
+      "integrity": "sha512-i4qoSr2KTtce0DmkuuQBV4AuQgGPUcPXMr9L5MyYAtk06z068lQ10a4O009fe5OB/DfNV+h+qqT7ddNV8UnRjg==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/generator": "^7.4.4",
-        "@babel/helpers": "^7.4.4",
-        "@babel/parser": "^7.4.4",
+        "@babel/code-frame": "^7.5.5",
+        "@babel/generator": "^7.5.5",
+        "@babel/helpers": "^7.5.5",
+        "@babel/parser": "^7.5.5",
         "@babel/template": "^7.4.4",
-        "@babel/traverse": "^7.4.4",
-        "@babel/types": "^7.4.4",
+        "@babel/traverse": "^7.5.5",
+        "@babel/types": "^7.5.5",
         "convert-source-map": "^1.1.0",
         "debug": "^4.1.0",
         "json5": "^2.1.0",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.13",
         "resolve": "^1.3.2",
         "semver": "^5.4.1",
         "source-map": "^0.5.0"
@@ -60,9 +60,9 @@
           "dev": true
         },
         "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         },
         "semver": {
@@ -80,14 +80,14 @@
       }
     },
     "@babel/generator": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.4.tgz",
-      "integrity": "sha512-53UOLK6TVNqKxf7RUh8NE851EHRxOOeVXKbK2bivdb+iziMyk03Sr4eaE9OELCbyZAAafAKPDwF2TPUES5QbxQ==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.5.5.tgz",
+      "integrity": "sha512-ETI/4vyTSxTzGnU2c49XHv2zhExkv9JHLTwDAFz85kmcwuShvYG2H08FwgIguQf4JC75CBnXAUM5PqeF4fj0nQ==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.4.4",
+        "@babel/types": "^7.5.5",
         "jsesc": "^2.5.1",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.13",
         "source-map": "^0.5.0",
         "trim-right": "^1.0.1"
       },
@@ -152,31 +152,39 @@
       }
     },
     "@babel/helpers": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.4.4.tgz",
-      "integrity": "sha512-igczbR/0SeuPR8RFfC7tGrbdTbFL3QTvH6D+Z6zNxnTe//GyqmtHmDkzrqDmyZ3eSwPqB/LhyKoU5DXsp+Vp2A==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.5.5.tgz",
+      "integrity": "sha512-nRq2BUhxZFnfEn/ciJuhklHvFOqjJUD5wpx+1bxUF2axL9C+v4DE/dmp5sT2dKnpOs4orZWzpAZqlCy8QqE/7g==",
       "dev": true,
       "requires": {
         "@babel/template": "^7.4.4",
-        "@babel/traverse": "^7.4.4",
-        "@babel/types": "^7.4.4"
+        "@babel/traverse": "^7.5.5",
+        "@babel/types": "^7.5.5"
       }
     },
     "@babel/highlight": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
-      "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.5.0.tgz",
+      "integrity": "sha512-7dV4eu9gBxoM0dAnj/BCFDW9LFU0zvTrkq0ugM7pnHEgguOEeOz1so2ZghEdzviYzQEED0r4EAgpsBChKy1TRQ==",
       "dev": true,
       "requires": {
         "chalk": "^2.0.0",
         "esutils": "^2.0.2",
         "js-tokens": "^4.0.0"
+      },
+      "dependencies": {
+        "js-tokens": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+          "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+          "dev": true
+        }
       }
     },
     "@babel/parser": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.4.tgz",
-      "integrity": "sha512-5pCS4mOsL+ANsFZGdvNLybx4wtqAZJ0MJjMHxvzI3bvIsz6sQvzW8XX92EYIkiPtIvcfG3Aj+Ir5VNyjnZhP7w==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.5.5.tgz",
+      "integrity": "sha512-E5BN68cqR7dhKan1SfqgPGhQ178bkVKpXTPEXnFJBrEt8/DKRZlybmy+IgYLTeN7tp1R5Ccmbm2rBk17sHYU3g==",
       "dev": true
     },
     "@babel/plugin-syntax-jsx": {
@@ -219,13 +227,37 @@
       }
     },
     "@babel/plugin-transform-react-jsx-source": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.2.0.tgz",
-      "integrity": "sha512-A32OkKTp4i5U6aE88GwwcuV4HAprUgHcTq0sSafLxjr6AW0QahrCRCjxogkbbcdtpbXkuTOlgpjophCxb6sh5g==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.5.0.tgz",
+      "integrity": "sha512-58Q+Jsy4IDCZx7kqEZuSDdam/1oW8OdDX8f+Loo6xyxdfg1yF0GE2XNJQSTZCaMol93+FBzpWiPEwtbMloAcPg==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/plugin-syntax-jsx": "^7.2.0"
+      }
+    },
+    "@babel/polyfill": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.4.4.tgz",
+      "integrity": "sha512-WlthFLfhQQhh+A2Gn5NSFl0Huxz36x86Jn+E9OW7ibK8edKPq+KLy4apM1yDpQ8kJOVi1OVjpP4vSDLdrI04dg==",
+      "dev": true,
+      "requires": {
+        "core-js": "^2.6.5",
+        "regenerator-runtime": "^0.13.2"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
+          "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==",
+          "dev": true
+        },
+        "regenerator-runtime": {
+          "version": "0.13.3",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+          "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
+          "dev": true
+        }
       }
     },
     "@babel/preset-react": {
@@ -242,19 +274,17 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.4.tgz",
-      "integrity": "sha512-w0+uT71b6Yi7i5SE0co4NioIpSYS6lLiXvCzWzGSKvpK5vdQtCbICHMj+gbAKAOtxiV6HsVh/MBdaF9EQ6faSg==",
-      "dev": true,
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.5.tgz",
+      "integrity": "sha512-28QvEGyQyNkB0/m2B4FU7IEZGK2NUrcMtT6BZEFALTguLk+AUT6ofsHtPk5QyjAdUkpMJ+/Em+quwz4HOt30AQ==",
       "requires": {
         "regenerator-runtime": "^0.13.2"
       },
       "dependencies": {
         "regenerator-runtime": {
-          "version": "0.13.2",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
-          "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA==",
-          "dev": true
+          "version": "0.13.3",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+          "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
         }
       }
     },
@@ -270,20 +300,20 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.4.tgz",
-      "integrity": "sha512-Gw6qqkw/e6AGzlyj9KnkabJX7VcubqPtkUQVAwkc0wUMldr3A/hezNB3Rc5eIvId95iSGkGIOe5hh1kMKf951A==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.5.5.tgz",
+      "integrity": "sha512-MqB0782whsfffYfSjH4TM+LMjrJnhCNEDMDIjeTpl+ASaUvxcjoiVCo/sM1GhS1pHOXYfWVCYneLjMckuUxDaQ==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/generator": "^7.4.4",
+        "@babel/code-frame": "^7.5.5",
+        "@babel/generator": "^7.5.5",
         "@babel/helper-function-name": "^7.1.0",
         "@babel/helper-split-export-declaration": "^7.4.4",
-        "@babel/parser": "^7.4.4",
-        "@babel/types": "^7.4.4",
+        "@babel/parser": "^7.5.5",
+        "@babel/types": "^7.5.5",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
-        "lodash": "^4.17.11"
+        "lodash": "^4.17.13"
       },
       "dependencies": {
         "debug": {
@@ -302,21 +332,21 @@
           "dev": true
         },
         "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         }
       }
     },
     "@babel/types": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
-      "integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.5.5.tgz",
+      "integrity": "sha512-s63F9nJioLqOlW3UkyMd+BYhXt44YuaFm/VV0VwuteqjYwRrObkU7ra9pY4wAJR3oXi8hJrMcrcJdO/HH33vtw==",
       "dev": true,
       "requires": {
         "esutils": "^2.0.2",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.13",
         "to-fast-properties": "^2.0.0"
       },
       "dependencies": {
@@ -391,15 +421,15 @@
           }
         },
         "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         },
         "node-fetch": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.5.0.tgz",
-          "integrity": "sha512-YuZKluhWGJwCcUu4RlZstdAxr8bFfOVHakc1mplwHkk8J+tqM1Y5yraYvIUpeX8aY7+crCwiELJq7Vl0o0LWXw==",
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+          "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
           "dev": true
         }
       }
@@ -412,6 +442,12 @@
       "requires": {
         "any-observable": "^0.3.0"
       }
+    },
+    "@sindresorhus/is": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
+      "integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==",
+      "dev": true
     },
     "@skyscanner/popper.js": {
       "version": "1.12.9-beta.1",
@@ -443,9 +479,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.0.tgz",
-      "integrity": "sha512-Jrb/x3HT4PTJp6a4avhmJCDEVrPdqLfl3e8GGMbpkGGdwAV5UGlIs4vVEfsHHfylZVOKZWpOqmqFH8CbfOZ6kg==",
+      "version": "12.6.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.6.8.tgz",
+      "integrity": "sha512-aX+gFgA5GHcDi89KG5keey2zf0WfZk/HAQotEamsK2kbey+8yGKcson0hbK8E+v0NArlCJQCqMP161YhV6ZXLg==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -501,7 +537,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/a11y-focus-scope/-/a11y-focus-scope-1.1.3.tgz",
       "integrity": "sha1-95U4TU3UDM7BxKFg700TNx0BWug=",
-      "dev": true,
       "requires": {
         "focusin": "^2.0.0",
         "tabbable": "^1.0.0"
@@ -510,8 +545,7 @@
     "a11y-focus-store": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/a11y-focus-store/-/a11y-focus-store-1.0.0.tgz",
-      "integrity": "sha1-rlJWHLhq5sKQTBpKvy5YIL9TBbA=",
-      "dev": true
+      "integrity": "sha1-rlJWHLhq5sKQTBpKvy5YIL9TBbA="
     },
     "abab": {
       "version": "1.0.4",
@@ -536,9 +570,9 @@
       }
     },
     "acorn": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
-      "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.2.1.tgz",
+      "integrity": "sha512-JD0xT5FCRDNyjDda3Lrg/IxFscp9q4tiYtxE1/nOzlKCk7hIRuYjhq1kCNkbPjMRMZuFq20HNQn1I9k8Oj0E+Q==",
       "dev": true
     },
     "acorn-dynamic-import": {
@@ -582,9 +616,9 @@
       "dev": true
     },
     "agent-base": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
-      "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+      "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
       "dev": true,
       "requires": {
         "es6-promisify": "^5.0.0"
@@ -609,9 +643,9 @@
       }
     },
     "ajv": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
-      "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
+      "version": "6.10.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+      "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
       "dev": true,
       "requires": {
         "fast-deep-equal": "^2.0.1",
@@ -627,9 +661,9 @@
       "dev": true
     },
     "ajv-keywords": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.0.tgz",
-      "integrity": "sha512-aUjdRFISbuFOl0EIZc+9e4FfZp0bDZgAdOOf30bJmw8VM9v84SHyVyxDfbWxpGYbdZD/9XoKxfHVNmxPkhwyGw==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.1.tgz",
+      "integrity": "sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ==",
       "dev": true
     },
     "align-text": {
@@ -692,13 +726,309 @@
         "normalize-path": "^2.1.1"
       },
       "dependencies": {
-        "normalize-path": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-          "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+        "arr-diff": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+          "dev": true
+        },
+        "array-unique": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+          "dev": true
+        },
+        "braces": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "dev": true,
           "requires": {
-            "remove-trailing-separator": "^1.0.1"
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "expand-brackets": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+          "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+          "dev": true,
+          "requires": {
+            "debug": "^2.3.3",
+            "define-property": "^0.2.5",
+            "extend-shallow": "^2.0.1",
+            "posix-character-classes": "^0.1.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+              "dev": true,
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "0.1.6",
+              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+              "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+              "dev": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "dev": true,
+                  "requires": {
+                    "is-buffer": "^1.1.5"
+                  }
+                }
+              }
+            },
+            "is-data-descriptor": {
+              "version": "0.1.4",
+              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+              "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+              "dev": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "dev": true,
+                  "requires": {
+                    "is-buffer": "^1.1.5"
+                  }
+                }
+              }
+            },
+            "is-descriptor": {
+              "version": "0.1.6",
+              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+              "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+              "dev": true,
+              "requires": {
+                "is-accessor-descriptor": "^0.1.6",
+                "is-data-descriptor": "^0.1.4",
+                "kind-of": "^5.0.0"
+              }
+            },
+            "kind-of": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+              "dev": true
+            }
+          }
+        },
+        "extend-shallow": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+          "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+          "dev": true,
+          "requires": {
+            "assign-symbols": "^1.0.0",
+            "is-extendable": "^1.0.1"
+          },
+          "dependencies": {
+            "is-extendable": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+              "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+              "dev": true,
+              "requires": {
+                "is-plain-object": "^2.0.4"
+              }
+            }
+          }
+        },
+        "extglob": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+          "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+          "dev": true,
+          "requires": {
+            "array-unique": "^0.3.2",
+            "define-property": "^1.0.0",
+            "expand-brackets": "^2.1.4",
+            "extend-shallow": "^2.0.1",
+            "fragment-cache": "^0.2.1",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+              "dev": true,
+              "requires": {
+                "is-descriptor": "^1.0.0"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "dev": true,
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
+        },
+        "micromatch": {
+          "version": "3.1.10",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+          "dev": true,
+          "requires": {
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.3.1",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "extglob": "^2.0.4",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^6.0.2",
+            "nanomatch": "^1.2.9",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.2"
+          }
+        },
+        "to-regex-range": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+          "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+          "dev": true,
+          "requires": {
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1"
           }
         }
       }
@@ -748,10 +1078,13 @@
       }
     },
     "arr-diff": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-      "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
-      "dev": true
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+      "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+      "dev": true,
+      "requires": {
+        "arr-flatten": "^1.0.1"
+      }
     },
     "arr-flatten": {
       "version": "1.1.0",
@@ -777,6 +1110,12 @@
       "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
       "dev": true
     },
+    "array-filter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-1.0.0.tgz",
+      "integrity": "sha1-uveeYubvTCpMC4MSMtr/7CUfnYM=",
+      "dev": true
+    },
     "array-find-index": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
@@ -784,9 +1123,9 @@
       "dev": true
     },
     "array-flatten": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.2.tgz",
+      "integrity": "sha512-hNfzcOV8W4NdualtqBFPyVO+54DSJuZGY9qT4pRroB6S9e3iiido2ISIC5h9R2sPJ8H3FHCIiEnsv1lPXO3KtQ==",
       "dev": true
     },
     "array-includes": {
@@ -815,19 +1154,19 @@
       "dev": true
     },
     "array-unique": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-      "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+      "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
       "dev": true
     },
     "array.prototype.find": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.0.4.tgz",
-      "integrity": "sha1-VWpcU2LAhkgyPdrrnenRS8GGTJA=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.1.0.tgz",
+      "integrity": "sha512-Wn41+K1yuO5p7wRZDl7890c3xvv5UBrfVXTVIe28rSQb6LS0fZMDrQB6PAcxQFRFy6vJTLDc3A2+3CjQdzVKRg==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.7.0"
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.13.0"
       }
     },
     "array.prototype.flat": {
@@ -850,8 +1189,7 @@
     "asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
-      "dev": true
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
     },
     "asn1": {
       "version": "0.2.4",
@@ -874,11 +1212,12 @@
       }
     },
     "assert": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
-      "integrity": "sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/assert/-/assert-1.5.0.tgz",
+      "integrity": "sha512-EDsgawzwoun2CZkCgtxJbv392v4nbk9XDD06zI+kQYoBM/3RBWLlEyJARDOmhAAosBjWACEkKL6S+lIZtcAubA==",
       "dev": true,
       "requires": {
+        "object-assign": "^4.1.1",
         "util": "0.10.3"
       },
       "dependencies": {
@@ -924,12 +1263,12 @@
       "dev": true
     },
     "async": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
-      "integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.11"
+        "lodash": "^4.17.14"
       }
     },
     "async-each": {
@@ -957,50 +1296,18 @@
       "dev": true
     },
     "autoprefixer": {
-      "version": "9.5.1",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.5.1.tgz",
-      "integrity": "sha512-KJSzkStUl3wP0D5sdMlP82Q52JLy5+atf2MHAre48+ckWkXgixmfHyWmA77wFDy6jTHU6mIgXv6hAQ2mf1PjJQ==",
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.6.1.tgz",
+      "integrity": "sha512-aVo5WxR3VyvyJxcJC3h4FKfwCQvQWb1tSI5VHNibddCVWrcD1NvlxEweg3TSgiPztMnWfjpy2FURKA2kvDE+Tw==",
       "dev": true,
       "requires": {
-        "browserslist": "^4.5.4",
-        "caniuse-lite": "^1.0.30000957",
+        "browserslist": "^4.6.3",
+        "caniuse-lite": "^1.0.30000980",
+        "chalk": "^2.4.2",
         "normalize-range": "^0.1.2",
         "num2fraction": "^1.2.2",
-        "postcss": "^7.0.14",
-        "postcss-value-parser": "^3.3.1"
-      },
-      "dependencies": {
-        "browserslist": {
-          "version": "4.5.6",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.5.6.tgz",
-          "integrity": "sha512-o/hPOtbU9oX507lIqon+UvPYqpx3mHc8cV3QemSBTXwkG8gSQSK6UKvXcE/DcleU3+A59XTUHyCvZ5qGy8xVAg==",
-          "dev": true,
-          "requires": {
-            "caniuse-lite": "^1.0.30000963",
-            "electron-to-chromium": "^1.3.127",
-            "node-releases": "^1.1.17"
-          }
-        },
-        "postcss": {
-          "version": "7.0.16",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
-          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
-          }
-        },
-        "supports-color": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
+        "postcss": "^7.0.17",
+        "postcss-value-parser": "^4.0.0"
       }
     },
     "aws-sign2": {
@@ -1054,12 +1361,6 @@
             "supports-color": "^2.0.0"
           }
         },
-        "js-tokens": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-          "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
-          "dev": true
-        },
         "supports-color": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
@@ -1104,9 +1405,9 @@
       }
     },
     "babel-eslint": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.0.1.tgz",
-      "integrity": "sha512-z7OT1iNV+TjOwHNLLyJk+HN+YVWX+CLE6fPD2SymJZOZQBs+QIexFjhm4keGTm8MW9xr4EC9Q0PbaLB24V5GoQ==",
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.0.2.tgz",
+      "integrity": "sha512-UdsurWPtgiPgpJ06ryUnuaSXC2s0WoSZnQmEpbAH65XZSdwowgN5MvyP7e88nW07FYXv72erVtpBkxyDVKhH1Q==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -1145,12 +1446,6 @@
         "trim-right": "^1.0.1"
       },
       "dependencies": {
-        "jsesc": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-          "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
-          "dev": true
-        },
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -1667,19 +1962,6 @@
         "babel-helper-regex": "^6.24.1",
         "babel-runtime": "^6.22.0",
         "regexpu-core": "^2.0.0"
-      },
-      "dependencies": {
-        "regexpu-core": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
-          "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
-          "dev": true,
-          "requires": {
-            "regenerate": "^1.2.1",
-            "regjsgen": "^0.2.0",
-            "regjsparser": "^0.1.4"
-          }
-        }
       }
     },
     "babel-plugin-transform-exponentiation-operator": {
@@ -1784,9 +2066,9 @@
       },
       "dependencies": {
         "core-js": {
-          "version": "2.6.5",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
-          "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==",
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
+          "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==",
           "dev": true
         },
         "regenerator-runtime": {
@@ -1902,9 +2184,9 @@
       },
       "dependencies": {
         "core-js": {
-          "version": "2.6.5",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
-          "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==",
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
+          "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==",
           "dev": true
         }
       }
@@ -1920,9 +2202,9 @@
       },
       "dependencies": {
         "core-js": {
-          "version": "2.6.5",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
-          "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==",
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
+          "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==",
           "dev": true
         }
       }
@@ -1976,15 +2258,15 @@
       "dev": true
     },
     "bail": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.3.tgz",
-      "integrity": "sha512-1X8CnjFVQ+a+KW36uBNMTU5s8+v5FzeqrP7hTG5aTb4aPreSbZJlhwPon9VKMuEVgV++JM+SQrALY3kr7eswdg==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.4.tgz",
+      "integrity": "sha512-S8vuDB4w6YpRhICUDET3guPlQpaJl7od94tpZ0Fvnyp+MKW/HyDTcRDck+29C9g+d/qQHnddRH3+94kZdrW0Ww==",
       "dev": true
     },
     "balanced-match": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-      "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
     "base": {
@@ -2040,6 +2322,12 @@
             "kind-of": "^6.0.2"
           }
         },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        },
         "kind-of": {
           "version": "6.0.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
@@ -2076,9 +2364,9 @@
       "dev": true
     },
     "big-integer": {
-      "version": "1.6.43",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.43.tgz",
-      "integrity": "sha512-9dULc9jsKmXl0Aeunug8wbF+58n+hQoFjqClN7WeZwGLh0XJUWyJJ9Ee+Ep+Ql/J9fRsTVaeThp8MhiCCrY0Jg==",
+      "version": "1.6.44",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.44.tgz",
+      "integrity": "sha512-7MzElZPTyJ2fNvBkPxtFQ2fWIkVmuzw41+BZHSzpEq3ymB2MfeKp1+yXl/tS75xCx+WnyV+yb0kp+K1C3UNwmQ==",
       "dev": true
     },
     "big.js": {
@@ -2113,9 +2401,9 @@
       }
     },
     "bluebird": {
-      "version": "3.5.4",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.4.tgz",
-      "integrity": "sha512-FG+nFEZChJrbQ9tIccIfZJBz3J7mLrAhxakAbnrJWn8d7aKOC+LWifa0G+p4ZqKp4y13T7juYvdhq9NzKdsrjw==",
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
+      "integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==",
       "dev": true
     },
     "bn.js": {
@@ -2125,36 +2413,33 @@
       "dev": true
     },
     "body-parser": {
-      "version": "1.18.3",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.3.tgz",
-      "integrity": "sha1-WykhmP/dVTs6DyDe0FkrlWlVyLQ=",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
+      "integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==",
       "dev": true,
       "requires": {
-        "bytes": "3.0.0",
+        "bytes": "3.1.0",
         "content-type": "~1.0.4",
         "debug": "2.6.9",
         "depd": "~1.1.2",
-        "http-errors": "~1.6.3",
-        "iconv-lite": "0.4.23",
+        "http-errors": "1.7.2",
+        "iconv-lite": "0.4.24",
         "on-finished": "~2.3.0",
-        "qs": "6.5.2",
-        "raw-body": "2.3.3",
-        "type-is": "~1.6.16"
+        "qs": "6.7.0",
+        "raw-body": "2.4.0",
+        "type-is": "~1.6.17"
       },
       "dependencies": {
-        "iconv-lite": {
-          "version": "0.4.23",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
-          "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
-          "dev": true,
-          "requires": {
-            "safer-buffer": ">= 2.1.2 < 3"
-          }
+        "bytes": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
+          "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
+          "dev": true
         },
         "qs": {
-          "version": "6.5.2",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+          "version": "6.7.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+          "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
           "dev": true
         }
       }
@@ -2173,10 +2458,10 @@
         "multicast-dns-service-types": "^1.1.0"
       },
       "dependencies": {
-        "array-flatten": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.2.tgz",
-          "integrity": "sha512-hNfzcOV8W4NdualtqBFPyVO+54DSJuZGY9qT4pRroB6S9e3iiido2ISIC5h9R2sPJ8H3FHCIiEnsv1lPXO3KtQ==",
+        "deep-equal": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+          "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
           "dev": true
         }
       }
@@ -2198,55 +2483,359 @@
       "version": "file:backpack/packages/bpk-component-accordion",
       "dev": true,
       "requires": {
-        "bpk-animate-height": "^1.1.112",
-        "bpk-component-icon": "^3.31.4",
-        "bpk-mixins": "^17.24.4",
+        "bpk-animate-height": "^1.1.113",
+        "bpk-component-icon": "^3.31.5",
+        "bpk-mixins": "^17.24.5",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
       },
       "dependencies": {
         "bpk-animate-height": {
-          "version": "1.1.112",
-          "resolved": "https://registry.npmjs.org/bpk-animate-height/-/bpk-animate-height-1.1.112.tgz",
-          "integrity": "sha512-xX5wT7YKYgFbwRlOZVQXhqNKm7d1tlnp8Pk5sCf1CKVzgZO+be9W7GgZ9HF6wTUoWuMIAt/31f3fP80mDwlvFg==",
+          "version": "1.1.113",
+          "bundled": true,
           "dev": true,
           "requires": {
             "prop-types": "^15.6.2"
           }
         },
+        "bpk-component-checkbox": {
+          "version": "1.4.110",
+          "bundled": true,
+          "requires": {
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          },
+          "dependencies": {
+            "bpk-component-icon": {
+              "version": "3.31.4",
+              "bundled": true,
+              "requires": {
+                "bpk-mixins": "^17.24.4",
+                "bpk-react-utils": "^2.7.9",
+                "bpk-svgs": "^6.9.2",
+                "bpk-tokens": "^27.6.4",
+                "prop-types": "^15.6.2"
+              }
+            },
+            "bpk-mixins": {
+              "version": "17.24.4",
+              "bundled": true,
+              "requires": {
+                "bpk-svgs": "^6.9.2",
+                "bpk-tokens": "^27.6.4"
+              }
+            },
+            "bpk-react-utils": {
+              "version": "2.7.9",
+              "bundled": true,
+              "requires": {
+                "object-assign": "^4.1.1",
+                "prop-types": "^15.6.2"
+              }
+            },
+            "bpk-svgs": {
+              "version": "6.9.3",
+              "bundled": true
+            },
+            "bpk-tokens": {
+              "version": "27.6.5",
+              "bundled": true
+            },
+            "js-tokens": {
+              "version": "4.0.0",
+              "bundled": true
+            },
+            "loose-envify": {
+              "version": "1.4.0",
+              "bundled": true,
+              "requires": {
+                "js-tokens": "^3.0.0 || ^4.0.0"
+              }
+            },
+            "object-assign": {
+              "version": "4.1.1",
+              "bundled": true
+            },
+            "prop-types": {
+              "version": "15.6.2",
+              "bundled": true,
+              "requires": {
+                "loose-envify": "^1.3.1",
+                "object-assign": "^4.1.1"
+              }
+            }
+          }
+        },
         "bpk-component-icon": {
-          "version": "3.31.4",
-          "resolved": "https://registry.npmjs.org/bpk-component-icon/-/bpk-component-icon-3.31.4.tgz",
-          "integrity": "sha512-DAiwhBYyyFmy2jonUFxEtxLpj2RlN17EDgd1zwZGpjfIhryyA+vL4XlSr8EkfPjZ6z+I6NWwbfmEUqDZgrn7Ag==",
+          "version": "3.31.5",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "bpk-mixins": "^17.24.4",
+            "bpk-mixins": "^17.24.5",
             "bpk-react-utils": "^2.7.9",
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4",
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5",
             "prop-types": "^15.6.2"
           }
         },
         "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
+          "version": "17.24.5",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
             "prop-types": "^15.6.2",
             "react-transition-group": "^2.5.3",
             "recompose": "^0.30.0"
+          },
+          "dependencies": {
+            "@babel/runtime": {
+              "version": "7.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "regenerator-runtime": "^0.12.0"
+              }
+            },
+            "asap": {
+              "version": "2.0.6",
+              "bundled": true,
+              "dev": true
+            },
+            "change-emitter": {
+              "version": "0.1.6",
+              "bundled": true,
+              "dev": true
+            },
+            "core-js": {
+              "version": "1.2.7",
+              "bundled": true,
+              "dev": true
+            },
+            "dom-helpers": {
+              "version": "3.4.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "@babel/runtime": "^7.1.2"
+              },
+              "dependencies": {
+                "@babel/runtime": {
+                  "version": "7.5.5",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "regenerator-runtime": "^0.13.2"
+                  }
+                },
+                "regenerator-runtime": {
+                  "version": "0.13.3",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            },
+            "encoding": {
+              "version": "0.1.12",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "iconv-lite": "~0.4.13"
+              }
+            },
+            "fbjs": {
+              "version": "0.8.17",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "core-js": "^1.0.0",
+                "isomorphic-fetch": "^2.1.1",
+                "loose-envify": "^1.0.0",
+                "object-assign": "^4.1.0",
+                "promise": "^7.1.1",
+                "setimmediate": "^1.0.5",
+                "ua-parser-js": "^0.7.18"
+              }
+            },
+            "hoist-non-react-statics": {
+              "version": "2.5.5",
+              "bundled": true,
+              "dev": true
+            },
+            "iconv-lite": {
+              "version": "0.4.24",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "safer-buffer": ">= 2.1.2 < 3"
+              }
+            },
+            "is-stream": {
+              "version": "1.1.0",
+              "bundled": true,
+              "dev": true
+            },
+            "isomorphic-fetch": {
+              "version": "2.2.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "node-fetch": "^1.0.1",
+                "whatwg-fetch": ">=0.10.0"
+              }
+            },
+            "js-tokens": {
+              "version": "4.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "loose-envify": {
+              "version": "1.4.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "js-tokens": "^3.0.0 || ^4.0.0"
+              }
+            },
+            "node-fetch": {
+              "version": "1.7.3",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "encoding": "^0.1.11",
+                "is-stream": "^1.0.1"
+              }
+            },
+            "object-assign": {
+              "version": "4.1.1",
+              "bundled": true,
+              "dev": true
+            },
+            "promise": {
+              "version": "7.3.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "asap": "~2.0.3"
+              }
+            },
+            "prop-types": {
+              "version": "15.6.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "loose-envify": "^1.3.1",
+                "object-assign": "^4.1.1"
+              }
+            },
+            "react-lifecycles-compat": {
+              "version": "3.0.4",
+              "bundled": true,
+              "dev": true
+            },
+            "react-transition-group": {
+              "version": "2.9.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "dom-helpers": "^3.4.0",
+                "loose-envify": "^1.4.0",
+                "prop-types": "^15.6.2",
+                "react-lifecycles-compat": "^3.0.4"
+              }
+            },
+            "recompose": {
+              "version": "0.30.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "@babel/runtime": "^7.0.0",
+                "change-emitter": "^0.1.2",
+                "fbjs": "^0.8.1",
+                "hoist-non-react-statics": "^2.3.1",
+                "react-lifecycles-compat": "^3.0.2",
+                "symbol-observable": "^1.0.4"
+              }
+            },
+            "regenerator-runtime": {
+              "version": "0.12.1",
+              "bundled": true,
+              "dev": true
+            },
+            "safer-buffer": {
+              "version": "2.1.2",
+              "bundled": true,
+              "dev": true
+            },
+            "setimmediate": {
+              "version": "1.0.5",
+              "bundled": true,
+              "dev": true
+            },
+            "symbol-observable": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true
+            },
+            "ua-parser-js": {
+              "version": "0.7.18",
+              "bundled": true,
+              "dev": true
+            },
+            "whatwg-fetch": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        },
+        "js-tokens": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "loose-envify": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "js-tokens": "^3.0.0 || ^4.0.0"
+          }
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "prop-types": {
+          "version": "15.6.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.3.1",
+            "object-assign": "^4.1.1"
           }
         }
       }
@@ -2255,1260 +2844,48 @@
       "version": "file:backpack/packages/bpk-component-autosuggest",
       "dev": true,
       "requires": {
-        "bpk-component-input": "^4.1.26",
-        "bpk-mixins": "^17.24.4",
+        "bpk-component-input": "^4.1.27",
+        "bpk-mixins": "^17.24.5",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2",
         "react-autosuggest": "^9.4.2"
       },
       "dependencies": {
-        "bpk-component-input": {
-          "version": "4.1.26",
-          "resolved": "https://registry.npmjs.org/bpk-component-input/-/bpk-component-input-4.1.26.tgz",
-          "integrity": "sha512-+5P8u4+tmf+pABR9fhqDvMcVDaThFZgiEk9yPOcv0m9rgPZMzWXxOcEpN7Wzr2fdW6P/kCAtFA0jwUKtuzEyWQ==",
-          "dev": true,
-          "requires": {
-            "bpk-component-icon": "^3.31.4",
-            "bpk-mixins": "^17.24.4",
-            "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        }
-      }
-    },
-    "bpk-component-badge": {
-      "version": "file:backpack/packages/bpk-component-badge",
-      "dev": true,
-      "requires": {
-        "bpk-mixins": "^17.24.4",
-        "bpk-react-utils": "^2.7.9",
-        "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        }
-      }
-    },
-    "bpk-component-banner-alert": {
-      "version": "file:backpack/packages/bpk-component-banner-alert",
-      "dev": true,
-      "requires": {
-        "bpk-animate-height": "^1.1.112",
-        "bpk-component-close-button": "^1.0.141",
-        "bpk-component-icon": "^3.31.4",
-        "bpk-mixins": "^17.24.4",
-        "bpk-react-utils": "^2.7.9",
-        "bpk-tokens": "^27.6.4",
-        "prop-types": "^15.6.2",
-        "react-transition-group": "^2.5.3"
-      },
-      "dependencies": {
-        "bpk-animate-height": {
-          "version": "1.1.112",
-          "resolved": "https://registry.npmjs.org/bpk-animate-height/-/bpk-animate-height-1.1.112.tgz",
-          "integrity": "sha512-xX5wT7YKYgFbwRlOZVQXhqNKm7d1tlnp8Pk5sCf1CKVzgZO+be9W7GgZ9HF6wTUoWuMIAt/31f3fP80mDwlvFg==",
-          "dev": true,
-          "requires": {
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-component-close-button": {
-          "version": "1.0.141",
-          "resolved": "https://registry.npmjs.org/bpk-component-close-button/-/bpk-component-close-button-1.0.141.tgz",
-          "integrity": "sha512-Yd2kQnwuEQ3Myoqk2z/NDVIxB3YebCZrtgFJlQ/C6otp3sH3lbWLg4INREQqAyK1ZU5GK96qhvneubMA1tPLqQ==",
-          "dev": true,
-          "requires": {
-            "bpk-component-icon": "^3.31.4",
-            "bpk-mixins": "^17.24.4",
-            "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
-          }
-        },
         "bpk-component-icon": {
-          "version": "3.31.4",
-          "resolved": "https://registry.npmjs.org/bpk-component-icon/-/bpk-component-icon-3.31.4.tgz",
-          "integrity": "sha512-DAiwhBYyyFmy2jonUFxEtxLpj2RlN17EDgd1zwZGpjfIhryyA+vL4XlSr8EkfPjZ6z+I6NWwbfmEUqDZgrn7Ag==",
+          "version": "3.31.5",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "bpk-mixins": "^17.24.4",
+            "bpk-mixins": "^17.24.5",
             "bpk-react-utils": "^2.7.9",
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        },
-        "bpk-tokens": {
-          "version": "27.6.4",
-          "resolved": "https://registry.npmjs.org/bpk-tokens/-/bpk-tokens-27.6.4.tgz",
-          "integrity": "sha512-/7BXdfw5Ft2UxkpLlme4x2TXoTEtITeJX1IzxqdgKZF0+fb+WT4SywoO0g9iM/nfQ1893ZEdNkG25u49v43dsQ==",
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
-          },
-          "dependencies": {
-            "color": {
-              "version": "3.1.2",
-              "resolved": "https://registry.npmjs.org/color/-/color-3.1.2.tgz",
-              "integrity": "sha512-vXTJhHebByxZn3lDvDJYw4lR5+uB3vuoHsuYA5AKuxRVn5wzzIfQKGLBmgdVRHKTJYeK5rvJcHnrd0Li49CFpg==",
-              "dev": true,
-              "requires": {
-                "color-convert": "^1.9.1",
-                "color-string": "^1.5.2"
-              }
-            }
-          }
-        }
-      }
-    },
-    "bpk-component-barchart": {
-      "version": "file:backpack/packages/bpk-component-barchart",
-      "dev": true,
-      "requires": {
-        "bpk-component-mobile-scroll-container": "^1.1.81",
-        "bpk-mixins": "^17.24.4",
-        "bpk-react-utils": "^2.7.9",
-        "bpk-tokens": "^27.6.4",
-        "d3-path": "^1.0.5",
-        "d3-scale": "^2.1.0",
-        "lodash.debounce": "^4.0.8",
-        "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-component-mobile-scroll-container": {
-          "version": "1.1.81",
-          "resolved": "https://registry.npmjs.org/bpk-component-mobile-scroll-container/-/bpk-component-mobile-scroll-container-1.1.81.tgz",
-          "integrity": "sha512-j+UYBa/vMZjqcCaz2cwoQWdcg3Tvt33iNdLNzrI/MWb92wqxW+BQ6PDazAX9L4VklzzEIAkOGS/76/DyIu57mg==",
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.4",
-            "bpk-react-utils": "^2.7.9",
-            "lodash.debounce": "^4.0.8",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        },
-        "bpk-tokens": {
-          "version": "27.6.4",
-          "resolved": "https://registry.npmjs.org/bpk-tokens/-/bpk-tokens-27.6.4.tgz",
-          "integrity": "sha512-/7BXdfw5Ft2UxkpLlme4x2TXoTEtITeJX1IzxqdgKZF0+fb+WT4SywoO0g9iM/nfQ1893ZEdNkG25u49v43dsQ==",
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
-          },
-          "dependencies": {
-            "color": {
-              "version": "3.1.2",
-              "resolved": "https://registry.npmjs.org/color/-/color-3.1.2.tgz",
-              "integrity": "sha512-vXTJhHebByxZn3lDvDJYw4lR5+uB3vuoHsuYA5AKuxRVn5wzzIfQKGLBmgdVRHKTJYeK5rvJcHnrd0Li49CFpg==",
-              "dev": true,
-              "requires": {
-                "color-convert": "^1.9.1",
-                "color-string": "^1.5.2"
-              }
-            }
-          }
-        }
-      }
-    },
-    "bpk-component-blockquote": {
-      "version": "file:backpack/packages/bpk-component-blockquote",
-      "dev": true,
-      "requires": {
-        "bpk-mixins": "^17.24.4",
-        "bpk-react-utils": "^2.7.9",
-        "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        }
-      }
-    },
-    "bpk-component-breadcrumb": {
-      "version": "file:backpack/packages/bpk-component-breadcrumb",
-      "dev": true,
-      "requires": {
-        "bpk-component-icon": "^3.31.4",
-        "bpk-component-link": "^1.2.75",
-        "bpk-component-text": "^1.1.6",
-        "bpk-mixins": "^17.24.4",
-        "bpk-react-utils": "^2.7.9",
-        "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-component-icon": {
-          "version": "3.31.4",
-          "resolved": "https://registry.npmjs.org/bpk-component-icon/-/bpk-component-icon-3.31.4.tgz",
-          "integrity": "sha512-DAiwhBYyyFmy2jonUFxEtxLpj2RlN17EDgd1zwZGpjfIhryyA+vL4XlSr8EkfPjZ6z+I6NWwbfmEUqDZgrn7Ag==",
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.4",
-            "bpk-react-utils": "^2.7.9",
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-component-link": {
-          "version": "1.2.75",
-          "resolved": "https://registry.npmjs.org/bpk-component-link/-/bpk-component-link-1.2.75.tgz",
-          "integrity": "sha512-qoosptvwz8ZjxRt2WvoERb2E71zrBhs5+USNjy6FtDl+cXndmMOsINB1JiAmMB9TO6PgUZJkj7FBN7Vm7rZ+bQ==",
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.4",
-            "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-component-text": {
-          "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/bpk-component-text/-/bpk-component-text-1.1.6.tgz",
-          "integrity": "sha512-U4wp5+Fz1Rd9LeJphQRKwKx2ekIbzGj0SFdvjDkVOkG120YVtVb4YQN/3xEl/zb7Csku5HLvkJIJK4C+wR22nQ==",
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.4",
-            "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        }
-      }
-    },
-    "bpk-component-breakpoint": {
-      "version": "file:backpack/packages/bpk-component-breakpoint",
-      "dev": true,
-      "requires": {
-        "bpk-mixins": "^17.24.4",
-        "prop-types": "^15.6.2",
-        "react-responsive": "^5.0.0"
-      },
-      "dependencies": {
-        "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
-          }
-        }
-      }
-    },
-    "bpk-component-button": {
-      "version": "file:backpack/packages/bpk-component-button",
-      "dev": true,
-      "requires": {
-        "bpk-mixins": "^17.24.4",
-        "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
-          }
-        }
-      }
-    },
-    "bpk-component-calendar": {
-      "version": "file:backpack/packages/bpk-component-calendar",
-      "dev": true,
-      "requires": {
-        "bpk-component-icon": "^3.31.4",
-        "bpk-component-select": "^2.3.7",
-        "bpk-mixins": "^17.24.4",
-        "bpk-react-utils": "^2.7.9",
-        "bpk-tokens": "^27.6.4",
-        "date-fns": "^1.29.0",
-        "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-component-icon": {
-          "version": "3.31.4",
-          "resolved": "https://registry.npmjs.org/bpk-component-icon/-/bpk-component-icon-3.31.4.tgz",
-          "integrity": "sha512-DAiwhBYyyFmy2jonUFxEtxLpj2RlN17EDgd1zwZGpjfIhryyA+vL4XlSr8EkfPjZ6z+I6NWwbfmEUqDZgrn7Ag==",
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.4",
-            "bpk-react-utils": "^2.7.9",
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-component-select": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/bpk-component-select/-/bpk-component-select-2.3.7.tgz",
-          "integrity": "sha512-5A3duQQ58GmdgHfI8GCvbMA8b8IzyUh+b+7mRQVR0NBCqY2HUL1rrjly95ejfZx1OhUWfEwwYU3fAOFgpj6o3A==",
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.4",
-            "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        },
-        "bpk-tokens": {
-          "version": "27.6.4",
-          "resolved": "https://registry.npmjs.org/bpk-tokens/-/bpk-tokens-27.6.4.tgz",
-          "integrity": "sha512-/7BXdfw5Ft2UxkpLlme4x2TXoTEtITeJX1IzxqdgKZF0+fb+WT4SywoO0g9iM/nfQ1893ZEdNkG25u49v43dsQ==",
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
-          },
-          "dependencies": {
-            "color": {
-              "version": "3.1.2",
-              "resolved": "https://registry.npmjs.org/color/-/color-3.1.2.tgz",
-              "integrity": "sha512-vXTJhHebByxZn3lDvDJYw4lR5+uB3vuoHsuYA5AKuxRVn5wzzIfQKGLBmgdVRHKTJYeK5rvJcHnrd0Li49CFpg==",
-              "dev": true,
-              "requires": {
-                "color-convert": "^1.9.1",
-                "color-string": "^1.5.2"
-              }
-            }
-          }
-        }
-      }
-    },
-    "bpk-component-card": {
-      "version": "file:backpack/packages/bpk-component-card",
-      "dev": true,
-      "requires": {
-        "bpk-mixins": "^17.24.4",
-        "bpk-react-utils": "^2.7.9",
-        "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        }
-      }
-    },
-    "bpk-component-checkbox": {
-      "version": "file:backpack/packages/bpk-component-checkbox",
-      "dev": true,
-      "requires": {
-        "bpk-component-icon": "^3.31.4",
-        "bpk-mixins": "^17.24.4",
-        "bpk-react-utils": "^2.7.9",
-        "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-component-icon": {
-          "version": "3.31.4",
-          "resolved": "https://registry.npmjs.org/bpk-component-icon/-/bpk-component-icon-3.31.4.tgz",
-          "integrity": "sha512-DAiwhBYyyFmy2jonUFxEtxLpj2RlN17EDgd1zwZGpjfIhryyA+vL4XlSr8EkfPjZ6z+I6NWwbfmEUqDZgrn7Ag==",
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.4",
-            "bpk-react-utils": "^2.7.9",
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        }
-      }
-    },
-    "bpk-component-chip": {
-      "version": "file:backpack/packages/bpk-component-chip",
-      "dev": true,
-      "requires": {
-        "bpk-component-close-button": "^1.0.141",
-        "bpk-mixins": "^17.24.4",
-        "bpk-react-utils": "^2.7.9",
-        "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-component-close-button": {
-          "version": "1.0.141",
-          "resolved": "https://registry.npmjs.org/bpk-component-close-button/-/bpk-component-close-button-1.0.141.tgz",
-          "integrity": "sha512-Yd2kQnwuEQ3Myoqk2z/NDVIxB3YebCZrtgFJlQ/C6otp3sH3lbWLg4INREQqAyK1ZU5GK96qhvneubMA1tPLqQ==",
-          "dev": true,
-          "requires": {
-            "bpk-component-icon": "^3.31.4",
-            "bpk-mixins": "^17.24.4",
-            "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        }
-      }
-    },
-    "bpk-component-close-button": {
-      "version": "file:backpack/packages/bpk-component-close-button",
-      "dev": true,
-      "requires": {
-        "bpk-component-icon": "^3.31.4",
-        "bpk-mixins": "^17.24.4",
-        "bpk-react-utils": "^2.7.9",
-        "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-component-icon": {
-          "version": "3.31.4",
-          "resolved": "https://registry.npmjs.org/bpk-component-icon/-/bpk-component-icon-3.31.4.tgz",
-          "integrity": "sha512-DAiwhBYyyFmy2jonUFxEtxLpj2RlN17EDgd1zwZGpjfIhryyA+vL4XlSr8EkfPjZ6z+I6NWwbfmEUqDZgrn7Ag==",
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.4",
-            "bpk-react-utils": "^2.7.9",
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        }
-      }
-    },
-    "bpk-component-code": {
-      "version": "file:backpack/packages/bpk-component-code",
-      "dev": true,
-      "requires": {
-        "bpk-mixins": "^17.24.4",
-        "bpk-react-utils": "^2.7.9",
-        "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        }
-      }
-    },
-    "bpk-component-content-container": {
-      "version": "file:backpack/packages/bpk-component-content-container",
-      "dev": true,
-      "requires": {
-        "bpk-mixins": "^17.24.4",
-        "bpk-react-utils": "^2.7.9",
-        "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        }
-      }
-    },
-    "bpk-component-datepicker": {
-      "version": "file:backpack/packages/bpk-component-datepicker",
-      "dev": true,
-      "requires": {
-        "bpk-component-breakpoint": "^1.1.74",
-        "bpk-component-calendar": "^5.0.26",
-        "bpk-component-input": "^4.1.26",
-        "bpk-component-modal": "^1.8.73",
-        "bpk-component-popover": "^2.2.49",
-        "bpk-mixins": "^17.24.4",
-        "bpk-react-utils": "^2.7.9",
-        "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-component-breakpoint": {
-          "version": "1.1.74",
-          "resolved": "https://registry.npmjs.org/bpk-component-breakpoint/-/bpk-component-breakpoint-1.1.74.tgz",
-          "integrity": "sha512-4C5vPMoBnKKXXC/C2KZg3Csz+c+nxmrJqGaTmEA5XlTG6GyomX4ltOmEtsG4x+mDK+qJYSg/HsxbZHIIxGHx/w==",
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.4",
-            "prop-types": "^15.6.2",
-            "react-responsive": "^5.0.0"
-          }
-        },
-        "bpk-component-calendar": {
-          "version": "5.0.26",
-          "resolved": "https://registry.npmjs.org/bpk-component-calendar/-/bpk-component-calendar-5.0.26.tgz",
-          "integrity": "sha512-eBo5tfZyTczqZn0EH5Xv1Weahf1S/hR92PpZlJV3GPs7yMrYsf0C+Bxn1edkvCKZu4lX83bl2Er6zfPAgfkUdg==",
-          "dev": true,
-          "requires": {
-            "bpk-component-icon": "^3.31.4",
-            "bpk-component-select": "^2.3.7",
-            "bpk-mixins": "^17.24.4",
-            "bpk-react-utils": "^2.7.9",
-            "bpk-tokens": "^27.6.4",
-            "date-fns": "^1.29.0",
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5",
             "prop-types": "^15.6.2"
           }
         },
         "bpk-component-input": {
-          "version": "4.1.26",
-          "resolved": "https://registry.npmjs.org/bpk-component-input/-/bpk-component-input-4.1.26.tgz",
-          "integrity": "sha512-+5P8u4+tmf+pABR9fhqDvMcVDaThFZgiEk9yPOcv0m9rgPZMzWXxOcEpN7Wzr2fdW6P/kCAtFA0jwUKtuzEyWQ==",
+          "version": "4.1.27",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "bpk-component-icon": "^3.31.4",
-            "bpk-mixins": "^17.24.4",
-            "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-component-modal": {
-          "version": "1.8.73",
-          "resolved": "https://registry.npmjs.org/bpk-component-modal/-/bpk-component-modal-1.8.73.tgz",
-          "integrity": "sha512-P3XSsRB8QzPnUnNNKXTj9mBSua976Kfsl7R2gSQbb+Jclm1GBboxx/ma4oqND2ywAHEPyv8cePWv2TwN/J7E/g==",
-          "dev": true,
-          "requires": {
-            "bpk-component-close-button": "^1.0.141",
-            "bpk-component-icon": "^3.31.4",
-            "bpk-component-link": "^1.2.75",
-            "bpk-mixins": "^17.24.4",
-            "bpk-react-utils": "^2.7.9",
-            "bpk-scrim-utils": "^3.2.75",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-component-popover": {
-          "version": "2.2.49",
-          "resolved": "https://registry.npmjs.org/bpk-component-popover/-/bpk-component-popover-2.2.49.tgz",
-          "integrity": "sha512-BSnRBLjK6V9he2MQescsfU+bONFKzo8IDE75c5cLRIvXTa+NWxtYh+yB0jh1lz3A8ycLHpNnFcDHYb5icOQ84A==",
-          "dev": true,
-          "requires": {
-            "@skyscanner/popper.js": "^1.12.9-beta.1",
-            "a11y-focus-scope": "^1.1.3",
-            "a11y-focus-store": "^1.0.0",
-            "bpk-component-close-button": "^1.0.141",
-            "bpk-component-link": "^1.2.75",
-            "bpk-component-text": "^1.1.6",
-            "bpk-mixins": "^17.24.4",
+            "bpk-component-icon": "^3.31.5",
+            "bpk-mixins": "^17.24.5",
             "bpk-react-utils": "^2.7.9",
             "prop-types": "^15.6.2"
           }
         },
         "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
+          "version": "17.24.5",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        },
-        "bpk-scrim-utils": {
-          "version": "3.2.75",
-          "resolved": "https://registry.npmjs.org/bpk-scrim-utils/-/bpk-scrim-utils-3.2.75.tgz",
-          "integrity": "sha512-8CSMp/znOPIza3/3jBCdHPNQF68AxpizJ87VLiXz/ILy1o9dNjsEW6AnzDuhuy1U38sAc2JGeIxOwCWIJPZfQw==",
-          "dev": true,
-          "requires": {
-            "a11y-focus-scope": "^1.1.3",
-            "a11y-focus-store": "^1.0.0",
-            "bpk-mixins": "^17.24.4",
-            "bpk-react-utils": "^2.7.9"
-          }
-        }
-      }
-    },
-    "bpk-component-description-list": {
-      "version": "file:backpack/packages/bpk-component-description-list",
-      "dev": true,
-      "requires": {
-        "bpk-mixins": "^17.24.4",
-        "bpk-react-utils": "^2.7.9",
-        "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        }
-      }
-    },
-    "bpk-component-dialog": {
-      "version": "file:backpack/packages/bpk-component-dialog",
-      "dev": true,
-      "requires": {
-        "bpk-component-modal": "^1.8.73",
-        "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-component-modal": {
-          "version": "1.8.73",
-          "resolved": "https://registry.npmjs.org/bpk-component-modal/-/bpk-component-modal-1.8.73.tgz",
-          "integrity": "sha512-P3XSsRB8QzPnUnNNKXTj9mBSua976Kfsl7R2gSQbb+Jclm1GBboxx/ma4oqND2ywAHEPyv8cePWv2TwN/J7E/g==",
-          "dev": true,
-          "requires": {
-            "bpk-component-close-button": "^1.0.141",
-            "bpk-component-icon": "^3.31.4",
-            "bpk-component-link": "^1.2.75",
-            "bpk-mixins": "^17.24.4",
-            "bpk-react-utils": "^2.7.9",
-            "bpk-scrim-utils": "^3.2.75",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-scrim-utils": {
-          "version": "3.2.75",
-          "resolved": "https://registry.npmjs.org/bpk-scrim-utils/-/bpk-scrim-utils-3.2.75.tgz",
-          "integrity": "sha512-8CSMp/znOPIza3/3jBCdHPNQF68AxpizJ87VLiXz/ILy1o9dNjsEW6AnzDuhuy1U38sAc2JGeIxOwCWIJPZfQw==",
-          "dev": true,
-          "requires": {
-            "a11y-focus-scope": "^1.1.3",
-            "a11y-focus-store": "^1.0.0",
-            "bpk-mixins": "^17.24.4",
-            "bpk-react-utils": "^2.7.9"
-          }
-        }
-      }
-    },
-    "bpk-component-drawer": {
-      "version": "file:backpack/packages/bpk-component-drawer",
-      "dev": true,
-      "requires": {
-        "bpk-component-close-button": "^1.0.141",
-        "bpk-component-icon": "^3.31.4",
-        "bpk-component-link": "^1.2.75",
-        "bpk-mixins": "^17.24.4",
-        "bpk-react-utils": "^2.7.9",
-        "bpk-scrim-utils": "^3.2.75",
-        "bpk-tokens": "^27.6.4",
-        "prop-types": "^15.6.2",
-        "react-transition-group": "^2.5.3"
-      },
-      "dependencies": {
-        "bpk-component-close-button": {
-          "version": "1.0.141",
-          "resolved": "https://registry.npmjs.org/bpk-component-close-button/-/bpk-component-close-button-1.0.141.tgz",
-          "integrity": "sha512-Yd2kQnwuEQ3Myoqk2z/NDVIxB3YebCZrtgFJlQ/C6otp3sH3lbWLg4INREQqAyK1ZU5GK96qhvneubMA1tPLqQ==",
-          "dev": true,
-          "requires": {
-            "bpk-component-icon": "^3.31.4",
-            "bpk-mixins": "^17.24.4",
-            "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-component-icon": {
-          "version": "3.31.4",
-          "resolved": "https://registry.npmjs.org/bpk-component-icon/-/bpk-component-icon-3.31.4.tgz",
-          "integrity": "sha512-DAiwhBYyyFmy2jonUFxEtxLpj2RlN17EDgd1zwZGpjfIhryyA+vL4XlSr8EkfPjZ6z+I6NWwbfmEUqDZgrn7Ag==",
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.4",
-            "bpk-react-utils": "^2.7.9",
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-component-link": {
-          "version": "1.2.75",
-          "resolved": "https://registry.npmjs.org/bpk-component-link/-/bpk-component-link-1.2.75.tgz",
-          "integrity": "sha512-qoosptvwz8ZjxRt2WvoERb2E71zrBhs5+USNjy6FtDl+cXndmMOsINB1JiAmMB9TO6PgUZJkj7FBN7Vm7rZ+bQ==",
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.4",
-            "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        },
-        "bpk-scrim-utils": {
-          "version": "3.2.75",
-          "resolved": "https://registry.npmjs.org/bpk-scrim-utils/-/bpk-scrim-utils-3.2.75.tgz",
-          "integrity": "sha512-8CSMp/znOPIza3/3jBCdHPNQF68AxpizJ87VLiXz/ILy1o9dNjsEW6AnzDuhuy1U38sAc2JGeIxOwCWIJPZfQw==",
-          "dev": true,
-          "requires": {
-            "a11y-focus-scope": "^1.1.3",
-            "a11y-focus-store": "^1.0.0",
-            "bpk-mixins": "^17.24.4",
-            "bpk-react-utils": "^2.7.9"
-          }
-        },
-        "bpk-tokens": {
-          "version": "27.6.4",
-          "resolved": "https://registry.npmjs.org/bpk-tokens/-/bpk-tokens-27.6.4.tgz",
-          "integrity": "sha512-/7BXdfw5Ft2UxkpLlme4x2TXoTEtITeJX1IzxqdgKZF0+fb+WT4SywoO0g9iM/nfQ1893ZEdNkG25u49v43dsQ==",
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
-          },
-          "dependencies": {
-            "color": {
-              "version": "3.1.2",
-              "resolved": "https://registry.npmjs.org/color/-/color-3.1.2.tgz",
-              "integrity": "sha512-vXTJhHebByxZn3lDvDJYw4lR5+uB3vuoHsuYA5AKuxRVn5wzzIfQKGLBmgdVRHKTJYeK5rvJcHnrd0Li49CFpg==",
-              "dev": true,
-              "requires": {
-                "color-convert": "^1.9.1",
-                "color-string": "^1.5.2"
-              }
-            }
-          }
-        }
-      }
-    },
-    "bpk-component-fieldset": {
-      "version": "file:backpack/packages/bpk-component-fieldset",
-      "dev": true,
-      "requires": {
-        "bpk-component-form-validation": "^2.0.26",
-        "bpk-component-label": "^3.2.144",
-        "bpk-mixins": "^17.24.4",
-        "bpk-react-utils": "^2.7.9",
-        "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-component-form-validation": {
-          "version": "2.0.26",
-          "resolved": "https://registry.npmjs.org/bpk-component-form-validation/-/bpk-component-form-validation-2.0.26.tgz",
-          "integrity": "sha512-APA045h/x0cWVmyUKkVfzJR7R6L2un8EngRcr4MrhN12EC3Ppoc58WilzfkWYf2gq7uOt1HDZyXVbyxiWn0Naw==",
-          "dev": true,
-          "requires": {
-            "bpk-animate-height": "^1.1.112",
-            "bpk-mixins": "^17.24.4",
-            "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-component-label": {
-          "version": "3.2.144",
-          "resolved": "https://registry.npmjs.org/bpk-component-label/-/bpk-component-label-3.2.144.tgz",
-          "integrity": "sha512-78mIbPwaeOwidu76SlPVo4fJG6d7kfSQ2JGlvZ4yU70it793xmj/ll0E2+PcAaAWoeNTVwreQmctg/RkwgNTRQ==",
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.4",
-            "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        }
-      }
-    },
-    "bpk-component-form-validation": {
-      "version": "file:backpack/packages/bpk-component-form-validation",
-      "dev": true,
-      "requires": {
-        "bpk-animate-height": "^1.1.112",
-        "bpk-mixins": "^17.24.4",
-        "bpk-react-utils": "^2.7.9",
-        "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-animate-height": {
-          "version": "1.1.112",
-          "resolved": "https://registry.npmjs.org/bpk-animate-height/-/bpk-animate-height-1.1.112.tgz",
-          "integrity": "sha512-xX5wT7YKYgFbwRlOZVQXhqNKm7d1tlnp8Pk5sCf1CKVzgZO+be9W7GgZ9HF6wTUoWuMIAt/31f3fP80mDwlvFg==",
-          "dev": true,
-          "requires": {
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        }
-      }
-    },
-    "bpk-component-grid": {
-      "version": "file:backpack/packages/bpk-component-grid",
-      "dev": true,
-      "requires": {
-        "bpk-mixins": "^17.24.4",
-        "bpk-react-utils": "^2.7.9",
-        "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        }
-      }
-    },
-    "bpk-component-grid-toggle": {
-      "version": "file:backpack/packages/bpk-component-grid-toggle",
-      "dev": true,
-      "requires": {
-        "bpk-component-link": "^1.2.75",
-        "bpk-mixins": "^17.24.4",
-        "bpk-react-utils": "^2.7.9",
-        "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-component-link": {
-          "version": "1.2.75",
-          "resolved": "https://registry.npmjs.org/bpk-component-link/-/bpk-component-link-1.2.75.tgz",
-          "integrity": "sha512-qoosptvwz8ZjxRt2WvoERb2E71zrBhs5+USNjy6FtDl+cXndmMOsINB1JiAmMB9TO6PgUZJkj7FBN7Vm7rZ+bQ==",
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.4",
-            "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        }
-      }
-    },
-    "bpk-component-horizontal-nav": {
-      "version": "file:backpack/packages/bpk-component-horizontal-nav",
-      "dev": true,
-      "requires": {
-        "bpk-component-mobile-scroll-container": "^1.1.81",
-        "bpk-mixins": "^17.24.4",
-        "bpk-react-utils": "^2.7.9",
-        "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-component-mobile-scroll-container": {
-          "version": "1.1.81",
-          "resolved": "https://registry.npmjs.org/bpk-component-mobile-scroll-container/-/bpk-component-mobile-scroll-container-1.1.81.tgz",
-          "integrity": "sha512-j+UYBa/vMZjqcCaz2cwoQWdcg3Tvt33iNdLNzrI/MWb92wqxW+BQ6PDazAX9L4VklzzEIAkOGS/76/DyIu57mg==",
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.4",
-            "bpk-react-utils": "^2.7.9",
-            "lodash.debounce": "^4.0.8",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        }
-      }
-    },
-    "bpk-component-icon": {
-      "version": "file:backpack/packages/bpk-component-icon",
-      "dev": true,
-      "requires": {
-        "bpk-mixins": "^17.24.4",
-        "bpk-react-utils": "^2.7.9",
-        "bpk-svgs": "^6.9.2",
-        "bpk-tokens": "^27.6.4",
-        "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
@@ -3518,105 +2895,280 @@
           }
         },
         "bpk-svgs": {
-          "version": "6.9.2",
-          "resolved": "https://registry.npmjs.org/bpk-svgs/-/bpk-svgs-6.9.2.tgz",
-          "integrity": "sha512-gicoSPPzsQVc0eBUtpn0vGfs/azztQIsA5IDeJaW50G1MHst9C7KBUdegnf64oRwjuVRZbdXsTz5I7h1UqgXKA==",
+          "version": "6.9.3",
+          "bundled": true,
           "dev": true
         },
         "bpk-tokens": {
-          "version": "27.6.4",
-          "resolved": "https://registry.npmjs.org/bpk-tokens/-/bpk-tokens-27.6.4.tgz",
-          "integrity": "sha512-/7BXdfw5Ft2UxkpLlme4x2TXoTEtITeJX1IzxqdgKZF0+fb+WT4SywoO0g9iM/nfQ1893ZEdNkG25u49v43dsQ==",
+          "version": "27.6.5",
+          "bundled": true,
           "dev": true,
           "requires": {
             "color": "^3.0.0"
+          }
+        },
+        "js-tokens": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "loose-envify": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "js-tokens": "^3.0.0 || ^4.0.0"
+          }
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "prop-types": {
+          "version": "15.6.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.3.1",
+            "object-assign": "^4.1.1"
+          }
+        },
+        "react-autosuggest": {
+          "version": "9.4.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "prop-types": "^15.5.10",
+            "react-autowhatever": "^10.1.2",
+            "shallow-equal": "^1.0.0"
+          }
+        },
+        "react-autowhatever": {
+          "version": "10.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "prop-types": "^15.5.8",
+            "react-themeable": "^1.1.0",
+            "section-iterator": "^2.0.0"
+          }
+        },
+        "react-themeable": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^3.0.0"
           },
           "dependencies": {
-            "color": {
-              "version": "3.1.2",
-              "resolved": "https://registry.npmjs.org/color/-/color-3.1.2.tgz",
-              "integrity": "sha512-vXTJhHebByxZn3lDvDJYw4lR5+uB3vuoHsuYA5AKuxRVn5wzzIfQKGLBmgdVRHKTJYeK5rvJcHnrd0Li49CFpg==",
-              "dev": true,
-              "requires": {
-                "color-convert": "^1.9.1",
-                "color-string": "^1.5.2"
-              }
+            "object-assign": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true
             }
+          }
+        },
+        "react-transition-group": {
+          "version": "2.9.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "dom-helpers": "^3.4.0",
+            "loose-envify": "^1.4.0",
+            "prop-types": "^15.6.2",
+            "react-lifecycles-compat": "^3.0.4"
+          }
+        },
+        "recompose": {
+          "version": "0.30.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "change-emitter": "^0.1.2",
+            "fbjs": "^0.8.1",
+            "hoist-non-react-statics": "^2.3.1",
+            "react-lifecycles-compat": "^3.0.2",
+            "symbol-observable": "^1.0.4"
+          }
+        },
+        "section-iterator": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "shallow-equal": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        }
+      }
+    },
+    "bpk-component-badge": {
+      "version": "file:backpack/packages/bpk-component-badge",
+      "dev": true,
+      "requires": {
+        "bpk-mixins": "^17.24.5",
+        "bpk-react-utils": "^2.7.9",
+        "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-component-icon": {
+          "version": "3.31.5",
+          "bundled": true
+        },
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        },
+        "js-tokens": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "loose-envify": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "js-tokens": "^3.0.0 || ^4.0.0"
+          }
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "prop-types": {
+          "version": "15.6.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.3.1",
+            "object-assign": "^4.1.1"
+          }
+        },
+        "react-transition-group": {
+          "version": "2.9.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "dom-helpers": "^3.4.0",
+            "loose-envify": "^1.4.0",
+            "prop-types": "^15.6.2",
+            "react-lifecycles-compat": "^3.0.4"
+          }
+        },
+        "recompose": {
+          "version": "0.30.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "change-emitter": "^0.1.2",
+            "fbjs": "^0.8.1",
+            "hoist-non-react-statics": "^2.3.1",
+            "react-lifecycles-compat": "^3.0.2",
+            "symbol-observable": "^1.0.4"
           }
         }
       }
     },
-    "bpk-component-image": {
-      "version": "file:backpack/packages/bpk-component-image",
+    "bpk-component-banner-alert": {
+      "version": "file:backpack/packages/bpk-component-banner-alert",
       "dev": true,
       "requires": {
-        "bpk-component-spinner": "^2.2.106",
-        "bpk-mixins": "^17.24.4",
+        "bpk-animate-height": "^1.1.113",
+        "bpk-component-close-button": "^1.0.142",
+        "bpk-component-icon": "^3.31.5",
+        "bpk-mixins": "^17.24.5",
         "bpk-react-utils": "^2.7.9",
+        "bpk-tokens": "^27.6.5",
         "prop-types": "^15.6.2",
         "react-transition-group": "^2.5.3"
       },
       "dependencies": {
-        "bpk-component-spinner": {
-          "version": "2.2.106",
-          "resolved": "https://registry.npmjs.org/bpk-component-spinner/-/bpk-component-spinner-2.2.106.tgz",
-          "integrity": "sha512-iOd+i+VMT0lN35FPhr9bEvet205lD911cf7Nu75tAgrBOL/n8B23p4KWkJU8WOB6pccUZ1gC9EClQ2UDSMOXFQ==",
+        "@babel/runtime": {
+          "version": "7.5.5",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "bpk-mixins": "^17.24.4",
+            "regenerator-runtime": "^0.13.2"
+          }
+        },
+        "bpk-animate-height": {
+          "version": "1.1.113",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-close-button": {
+          "version": "1.0.142",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-component-icon": "^3.31.5",
+            "bpk-mixins": "^17.24.5",
             "bpk-react-utils": "^2.7.9",
-            "bpk-svgs": "^6.9.2",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-icon": {
+          "version": "3.31.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5",
             "prop-types": "^15.6.2"
           }
         },
         "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
+          "version": "17.24.5",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        }
-      }
-    },
-    "bpk-component-infinite-scroll": {
-      "version": "file:backpack/packages/bpk-component-infinite-scroll",
-      "dev": true,
-      "requires": {
-        "bpk-mixins": "^17.24.4",
-        "bpk-react-utils": "^2.7.9",
-        "intersection-observer": "^0.7.0",
-        "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
@@ -3625,302 +3177,267 @@
             "recompose": "^0.30.0"
           }
         },
-        "intersection-observer": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/intersection-observer/-/intersection-observer-0.7.0.tgz",
-          "integrity": "sha512-Id0Fij0HsB/vKWGeBe9PxeY45ttRiBmhFyyt/geBdDHBYNctMRTE3dC1U3ujzz3lap+hVXlEcVaB56kZP/eEUg==",
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        },
+        "dom-helpers": {
+          "version": "3.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.1.2"
+          }
+        },
+        "js-tokens": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "loose-envify": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "js-tokens": "^3.0.0 || ^4.0.0"
+          }
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "prop-types": {
+          "version": "15.6.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.3.1",
+            "object-assign": "^4.1.1"
+          }
+        },
+        "react-lifecycles-compat": {
+          "version": "3.0.4",
+          "bundled": true,
+          "dev": true
+        },
+        "react-transition-group": {
+          "version": "2.9.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "dom-helpers": "^3.4.0",
+            "loose-envify": "^1.4.0",
+            "prop-types": "^15.6.2",
+            "react-lifecycles-compat": "^3.0.4"
+          }
+        },
+        "recompose": {
+          "version": "0.30.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "change-emitter": "^0.1.2",
+            "fbjs": "^0.8.1",
+            "hoist-non-react-statics": "^2.3.1",
+            "react-lifecycles-compat": "^3.0.2",
+            "symbol-observable": "^1.0.4"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.3",
+          "bundled": true,
           "dev": true
         }
       }
     },
-    "bpk-component-input": {
-      "version": "file:backpack/packages/bpk-component-input",
+    "bpk-component-barchart": {
+      "version": "file:backpack/packages/bpk-component-barchart",
       "dev": true,
       "requires": {
-        "bpk-component-icon": "^3.31.4",
-        "bpk-mixins": "^17.24.4",
+        "bpk-component-mobile-scroll-container": "^1.1.82",
+        "bpk-mixins": "^17.24.5",
         "bpk-react-utils": "^2.7.9",
-        "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-component-icon": {
-          "version": "3.31.4",
-          "resolved": "https://registry.npmjs.org/bpk-component-icon/-/bpk-component-icon-3.31.4.tgz",
-          "integrity": "sha512-DAiwhBYyyFmy2jonUFxEtxLpj2RlN17EDgd1zwZGpjfIhryyA+vL4XlSr8EkfPjZ6z+I6NWwbfmEUqDZgrn7Ag==",
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.4",
-            "bpk-react-utils": "^2.7.9",
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        }
-      }
-    },
-    "bpk-component-label": {
-      "version": "file:backpack/packages/bpk-component-label",
-      "dev": true,
-      "requires": {
-        "bpk-mixins": "^17.24.4",
-        "bpk-react-utils": "^2.7.9",
-        "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        }
-      }
-    },
-    "bpk-component-link": {
-      "version": "file:backpack/packages/bpk-component-link",
-      "dev": true,
-      "requires": {
-        "bpk-mixins": "^17.24.4",
-        "bpk-react-utils": "^2.7.9",
-        "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        }
-      }
-    },
-    "bpk-component-list": {
-      "version": "file:backpack/packages/bpk-component-list",
-      "dev": true,
-      "requires": {
-        "bpk-mixins": "^17.24.4",
-        "bpk-react-utils": "^2.7.9",
-        "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        }
-      }
-    },
-    "bpk-component-loading-button": {
-      "version": "file:backpack/packages/bpk-component-loading-button",
-      "dev": true,
-      "requires": {
-        "bpk-component-button": "^2.4.1",
-        "bpk-component-icon": "^3.31.4",
-        "bpk-component-spinner": "^2.2.106",
-        "bpk-mixins": "^17.24.4",
-        "bpk-react-utils": "^2.7.9",
-        "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-component-button": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/bpk-component-button/-/bpk-component-button-2.4.1.tgz",
-          "integrity": "sha512-4jJ5wxgquUUVGHpblXf0yWlpVFNtmDo0DjLMkGL5U4HxFIgc0XZp911KjIzUVeCh+3eGASeAthQgLCruQghzOg==",
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.4",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-component-icon": {
-          "version": "3.31.4",
-          "resolved": "https://registry.npmjs.org/bpk-component-icon/-/bpk-component-icon-3.31.4.tgz",
-          "integrity": "sha512-DAiwhBYyyFmy2jonUFxEtxLpj2RlN17EDgd1zwZGpjfIhryyA+vL4XlSr8EkfPjZ6z+I6NWwbfmEUqDZgrn7Ag==",
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.4",
-            "bpk-react-utils": "^2.7.9",
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-component-spinner": {
-          "version": "2.2.106",
-          "resolved": "https://registry.npmjs.org/bpk-component-spinner/-/bpk-component-spinner-2.2.106.tgz",
-          "integrity": "sha512-iOd+i+VMT0lN35FPhr9bEvet205lD911cf7Nu75tAgrBOL/n8B23p4KWkJU8WOB6pccUZ1gC9EClQ2UDSMOXFQ==",
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.4",
-            "bpk-react-utils": "^2.7.9",
-            "bpk-svgs": "^6.9.2",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        }
-      }
-    },
-    "bpk-component-map": {
-      "version": "file:backpack/packages/bpk-component-map",
-      "dev": true,
-      "requires": {
-        "bpk-component-spinner": "^2.2.106",
-        "bpk-mixins": "^17.24.4",
-        "bpk-react-utils": "^2.7.9",
-        "prop-types": "^15.5.8",
-        "react-google-maps": "^9.4.5"
-      },
-      "dependencies": {
-        "bpk-component-spinner": {
-          "version": "2.2.106",
-          "resolved": "https://registry.npmjs.org/bpk-component-spinner/-/bpk-component-spinner-2.2.106.tgz",
-          "integrity": "sha512-iOd+i+VMT0lN35FPhr9bEvet205lD911cf7Nu75tAgrBOL/n8B23p4KWkJU8WOB6pccUZ1gC9EClQ2UDSMOXFQ==",
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.4",
-            "bpk-react-utils": "^2.7.9",
-            "bpk-svgs": "^6.9.2",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        }
-      }
-    },
-    "bpk-component-mobile-scroll-container": {
-      "version": "file:backpack/packages/bpk-component-mobile-scroll-container",
-      "dev": true,
-      "requires": {
-        "bpk-mixins": "^17.24.4",
-        "bpk-react-utils": "^2.7.9",
+        "bpk-tokens": "^27.6.5",
+        "d3-path": "^1.0.5",
+        "d3-scale": "^2.1.0",
         "lodash.debounce": "^4.0.8",
         "prop-types": "^15.6.2"
       },
       "dependencies": {
-        "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
+        "bpk-component-breakpoint": {
+          "version": "1.1.75",
+          "bundled": true
+        },
+        "bpk-component-content-container": {
+          "version": "1.3.81",
+          "bundled": true,
+          "requires": {
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          },
+          "dependencies": {
+            "bpk-mixins": {
+              "version": "17.24.4",
+              "bundled": true,
+              "requires": {
+                "bpk-svgs": "^6.9.2",
+                "bpk-tokens": "^27.6.4"
+              }
+            },
+            "bpk-react-utils": {
+              "version": "2.7.9",
+              "bundled": true,
+              "requires": {
+                "object-assign": "^4.1.1",
+                "prop-types": "^15.6.2"
+              }
+            },
+            "bpk-svgs": {
+              "version": "6.9.3",
+              "bundled": true
+            },
+            "bpk-tokens": {
+              "version": "27.6.5",
+              "bundled": true
+            },
+            "js-tokens": {
+              "version": "4.0.0",
+              "bundled": true
+            },
+            "loose-envify": {
+              "version": "1.4.0",
+              "bundled": true,
+              "requires": {
+                "js-tokens": "^3.0.0 || ^4.0.0"
+              }
+            },
+            "object-assign": {
+              "version": "4.1.1",
+              "bundled": true
+            },
+            "prop-types": {
+              "version": "15.6.2",
+              "bundled": true,
+              "requires": {
+                "loose-envify": "^1.3.1",
+                "object-assign": "^4.1.1"
+              }
+            }
+          }
+        },
+        "bpk-component-mobile-scroll-container": {
+          "version": "1.1.82",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "lodash.debounce": "^4.0.8",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-rtl-toggle": {
+          "version": "1.1.95",
+          "bundled": true,
+          "requires": {
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          },
+          "dependencies": {
+            "bpk-component-link": {
+              "version": "1.2.75",
+              "bundled": true,
+              "requires": {
+                "bpk-mixins": "^17.24.4",
+                "bpk-react-utils": "^2.7.9",
+                "prop-types": "^15.6.2"
+              }
+            },
+            "bpk-mixins": {
+              "version": "17.24.5",
+              "bundled": true,
+              "requires": {
+                "bpk-svgs": "^6.9.3",
+                "bpk-tokens": "^27.6.5"
+              }
+            },
+            "bpk-react-utils": {
+              "version": "2.7.9",
+              "bundled": true,
+              "requires": {
+                "object-assign": "^4.1.1",
+                "prop-types": "^15.6.2"
+              }
+            },
+            "bpk-svgs": {
+              "version": "6.9.3",
+              "bundled": true
+            },
+            "bpk-tokens": {
+              "version": "27.6.5",
+              "bundled": true
+            },
+            "js-tokens": {
+              "version": "4.0.0",
+              "bundled": true
+            },
+            "loose-envify": {
+              "version": "1.4.0",
+              "bundled": true,
+              "requires": {
+                "js-tokens": "^3.0.0 || ^4.0.0"
+              }
+            },
+            "object-assign": {
+              "version": "4.1.1",
+              "bundled": true
+            },
+            "prop-types": {
+              "version": "15.6.2",
+              "bundled": true,
+              "requires": {
+                "loose-envify": "^1.3.1",
+                "object-assign": "^4.1.1"
+              }
+            }
+          }
+        },
+        "bpk-component-text": {
+          "version": "1.1.7",
+          "bundled": true,
+          "requires": {
+            "bpk-react-utils": "^2.7.9"
+          },
+          "dependencies": {
+            "bpk-react-utils": {
+              "version": "2.7.9",
+              "bundled": true
+            }
+          }
+        },
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
@@ -3928,73 +3445,1137 @@
             "react-transition-group": "^2.5.3",
             "recompose": "^0.30.0"
           }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        },
+        "d3-array": {
+          "version": "1.2.4",
+          "bundled": true,
+          "dev": true
+        },
+        "d3-collection": {
+          "version": "1.0.7",
+          "bundled": true,
+          "dev": true
+        },
+        "d3-color": {
+          "version": "1.2.3",
+          "bundled": true,
+          "dev": true
+        },
+        "d3-format": {
+          "version": "1.3.2",
+          "bundled": true,
+          "dev": true
+        },
+        "d3-interpolate": {
+          "version": "1.3.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "d3-color": "1"
+          }
+        },
+        "d3-path": {
+          "version": "1.0.7",
+          "bundled": true,
+          "dev": true
+        },
+        "d3-scale": {
+          "version": "2.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "d3-array": "^1.2.0",
+            "d3-collection": "1",
+            "d3-format": "1",
+            "d3-interpolate": "1",
+            "d3-time": "1",
+            "d3-time-format": "2"
+          }
+        },
+        "d3-time": {
+          "version": "1.0.10",
+          "bundled": true,
+          "dev": true
+        },
+        "d3-time-format": {
+          "version": "2.1.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "d3-time": "1"
+          }
+        },
+        "js-tokens": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "lodash.debounce": {
+          "version": "4.0.8",
+          "bundled": true,
+          "dev": true
+        },
+        "loose-envify": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "js-tokens": "^3.0.0 || ^4.0.0"
+          }
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "prop-types": {
+          "version": "15.6.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.3.1",
+            "object-assign": "^4.1.1"
+          }
+        },
+        "react-transition-group": {
+          "version": "2.9.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "dom-helpers": "^3.4.0",
+            "loose-envify": "^1.4.0",
+            "prop-types": "^15.6.2",
+            "react-lifecycles-compat": "^3.0.4"
+          }
+        },
+        "recompose": {
+          "version": "0.30.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "change-emitter": "^0.1.2",
+            "fbjs": "^0.8.1",
+            "hoist-non-react-statics": "^2.3.1",
+            "react-lifecycles-compat": "^3.0.2",
+            "symbol-observable": "^1.0.4"
+          }
         }
       }
     },
-    "bpk-component-modal": {
-      "version": "file:backpack/packages/bpk-component-modal",
+    "bpk-component-blockquote": {
+      "version": "file:backpack/packages/bpk-component-blockquote",
       "dev": true,
       "requires": {
-        "bpk-component-close-button": "^1.0.141",
-        "bpk-component-icon": "^3.31.4",
-        "bpk-component-link": "^1.2.75",
-        "bpk-mixins": "^17.24.4",
+        "bpk-mixins": "^17.24.5",
         "bpk-react-utils": "^2.7.9",
-        "bpk-scrim-utils": "^3.2.75",
         "prop-types": "^15.6.2"
       },
       "dependencies": {
-        "bpk-component-close-button": {
-          "version": "1.0.141",
-          "resolved": "https://registry.npmjs.org/bpk-component-close-button/-/bpk-component-close-button-1.0.141.tgz",
-          "integrity": "sha512-Yd2kQnwuEQ3Myoqk2z/NDVIxB3YebCZrtgFJlQ/C6otp3sH3lbWLg4INREQqAyK1ZU5GK96qhvneubMA1tPLqQ==",
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "bpk-component-icon": "^3.31.4",
-            "bpk-mixins": "^17.24.4",
-            "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
           }
         },
-        "bpk-component-icon": {
-          "version": "3.31.4",
-          "resolved": "https://registry.npmjs.org/bpk-component-icon/-/bpk-component-icon-3.31.4.tgz",
-          "integrity": "sha512-DAiwhBYyyFmy2jonUFxEtxLpj2RlN17EDgd1zwZGpjfIhryyA+vL4XlSr8EkfPjZ6z+I6NWwbfmEUqDZgrn7Ag==",
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "bpk-mixins": "^17.24.4",
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        },
+        "js-tokens": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "loose-envify": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "js-tokens": "^3.0.0 || ^4.0.0"
+          }
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "prop-types": {
+          "version": "15.6.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.3.1",
+            "object-assign": "^4.1.1"
+          }
+        },
+        "react-transition-group": {
+          "version": "2.9.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "dom-helpers": "^3.4.0",
+            "loose-envify": "^1.4.0",
+            "prop-types": "^15.6.2",
+            "react-lifecycles-compat": "^3.0.4"
+          }
+        },
+        "recompose": {
+          "version": "0.30.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "change-emitter": "^0.1.2",
+            "fbjs": "^0.8.1",
+            "hoist-non-react-statics": "^2.3.1",
+            "react-lifecycles-compat": "^3.0.2",
+            "symbol-observable": "^1.0.4"
+          }
+        }
+      }
+    },
+    "bpk-component-breadcrumb": {
+      "version": "file:backpack/packages/bpk-component-breadcrumb",
+      "dev": true,
+      "requires": {
+        "bpk-component-icon": "^3.31.5",
+        "bpk-component-link": "^1.2.76",
+        "bpk-component-text": "^1.1.7",
+        "bpk-mixins": "^17.24.5",
+        "bpk-react-utils": "^2.7.9",
+        "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-component-icon": {
+          "version": "3.31.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
             "bpk-react-utils": "^2.7.9",
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4",
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5",
             "prop-types": "^15.6.2"
           }
         },
         "bpk-component-link": {
-          "version": "1.2.75",
-          "resolved": "https://registry.npmjs.org/bpk-component-link/-/bpk-component-link-1.2.75.tgz",
-          "integrity": "sha512-qoosptvwz8ZjxRt2WvoERb2E71zrBhs5+USNjy6FtDl+cXndmMOsINB1JiAmMB9TO6PgUZJkj7FBN7Vm7rZ+bQ==",
+          "version": "1.2.76",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "bpk-mixins": "^17.24.4",
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-text": {
+          "version": "1.1.7",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
             "bpk-react-utils": "^2.7.9",
             "prop-types": "^15.6.2"
           }
         },
         "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
+          "version": "17.24.5",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
+          "bundled": true,
           "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        },
+        "js-tokens": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "loose-envify": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "js-tokens": "^3.0.0 || ^4.0.0"
+          }
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "prop-types": {
+          "version": "15.6.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.3.1",
+            "object-assign": "^4.1.1"
+          }
+        },
+        "react-transition-group": {
+          "version": "2.9.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "dom-helpers": "^3.4.0",
+            "loose-envify": "^1.4.0",
+            "prop-types": "^15.6.2",
+            "react-lifecycles-compat": "^3.0.4"
+          }
+        },
+        "recompose": {
+          "version": "0.30.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "change-emitter": "^0.1.2",
+            "fbjs": "^0.8.1",
+            "hoist-non-react-statics": "^2.3.1",
+            "react-lifecycles-compat": "^3.0.2",
+            "symbol-observable": "^1.0.4"
+          }
+        }
+      }
+    },
+    "bpk-component-breakpoint": {
+      "version": "file:backpack/packages/bpk-component-breakpoint",
+      "dev": true,
+      "requires": {
+        "bpk-mixins": "^17.24.5",
+        "prop-types": "^15.6.2",
+        "react-responsive": "^5.0.0"
+      }
+    },
+    "bpk-component-button": {
+      "version": "file:backpack/packages/bpk-component-button",
+      "dev": true,
+      "requires": {
+        "bpk-mixins": "^17.24.5",
+        "prop-types": "^15.6.2"
+      }
+    },
+    "bpk-component-calendar": {
+      "version": "file:backpack/packages/bpk-component-calendar",
+      "dev": true,
+      "requires": {
+        "bpk-component-icon": "^3.31.5",
+        "bpk-component-select": "^2.3.8",
+        "bpk-mixins": "^17.24.5",
+        "bpk-react-utils": "^2.7.9",
+        "bpk-tokens": "^27.6.5",
+        "date-fns": "^1.29.0",
+        "prop-types": "^15.6.2"
+      }
+    },
+    "bpk-component-card": {
+      "version": "file:backpack/packages/bpk-component-card",
+      "dev": true,
+      "requires": {
+        "bpk-mixins": "^17.24.5",
+        "bpk-react-utils": "^2.7.9",
+        "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        },
+        "js-tokens": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "loose-envify": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "js-tokens": "^3.0.0 || ^4.0.0"
+          }
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "prop-types": {
+          "version": "15.6.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.3.1",
+            "object-assign": "^4.1.1"
+          }
+        },
+        "react-transition-group": {
+          "version": "2.9.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "dom-helpers": "^3.4.0",
+            "loose-envify": "^1.4.0",
+            "prop-types": "^15.6.2",
+            "react-lifecycles-compat": "^3.0.4"
+          }
+        },
+        "recompose": {
+          "version": "0.30.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "change-emitter": "^0.1.2",
+            "fbjs": "^0.8.1",
+            "hoist-non-react-statics": "^2.3.1",
+            "react-lifecycles-compat": "^3.0.2",
+            "symbol-observable": "^1.0.4"
+          }
+        }
+      }
+    },
+    "bpk-component-checkbox": {
+      "version": "file:backpack/packages/bpk-component-checkbox",
+      "dev": true,
+      "requires": {
+        "bpk-component-icon": "^3.31.5",
+        "bpk-mixins": "^17.24.5",
+        "bpk-react-utils": "^2.7.9",
+        "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-component-icon": {
+          "version": "3.31.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        },
+        "js-tokens": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "loose-envify": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "js-tokens": "^3.0.0 || ^4.0.0"
+          }
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "prop-types": {
+          "version": "15.6.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.3.1",
+            "object-assign": "^4.1.1"
+          }
+        },
+        "react-transition-group": {
+          "version": "2.9.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "dom-helpers": "^3.4.0",
+            "loose-envify": "^1.4.0",
+            "prop-types": "^15.6.2",
+            "react-lifecycles-compat": "^3.0.4"
+          }
+        },
+        "recompose": {
+          "version": "0.30.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "change-emitter": "^0.1.2",
+            "fbjs": "^0.8.1",
+            "hoist-non-react-statics": "^2.3.1",
+            "react-lifecycles-compat": "^3.0.2",
+            "symbol-observable": "^1.0.4"
+          }
+        }
+      }
+    },
+    "bpk-component-chip": {
+      "version": "file:backpack/packages/bpk-component-chip",
+      "dev": true,
+      "requires": {
+        "bpk-component-close-button": "^1.0.142",
+        "bpk-mixins": "^17.24.5",
+        "bpk-react-utils": "^2.7.9",
+        "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-component-close-button": {
+          "version": "1.0.142",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-component-icon": "^3.31.5",
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-icon": {
+          "version": "3.31.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5",
+            "prop-types": "^15.6.2"
+          },
+          "dependencies": {
+            "bpk-mixins": {
+              "version": "17.24.5",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "bpk-svgs": "^6.9.3",
+                "bpk-tokens": "^27.6.5"
+              }
+            }
+          }
+        },
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        },
+        "js-tokens": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "loose-envify": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "js-tokens": "^3.0.0 || ^4.0.0"
+          }
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "prop-types": {
+          "version": "15.6.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.3.1",
+            "object-assign": "^4.1.1"
+          }
+        },
+        "react-transition-group": {
+          "version": "2.9.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "dom-helpers": "^3.4.0",
+            "loose-envify": "^1.4.0",
+            "prop-types": "^15.6.2",
+            "react-lifecycles-compat": "^3.0.4"
+          }
+        },
+        "recompose": {
+          "version": "0.30.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "change-emitter": "^0.1.2",
+            "fbjs": "^0.8.1",
+            "hoist-non-react-statics": "^2.3.1",
+            "react-lifecycles-compat": "^3.0.2",
+            "symbol-observable": "^1.0.4"
+          }
+        }
+      }
+    },
+    "bpk-component-close-button": {
+      "version": "file:backpack/packages/bpk-component-close-button",
+      "dev": true,
+      "requires": {
+        "bpk-component-icon": "^3.31.5",
+        "bpk-mixins": "^17.24.5",
+        "bpk-react-utils": "^2.7.9",
+        "prop-types": "^15.6.2"
+      }
+    },
+    "bpk-component-code": {
+      "version": "file:backpack/packages/bpk-component-code",
+      "dev": true,
+      "requires": {
+        "bpk-mixins": "^17.24.5",
+        "bpk-react-utils": "^2.7.9",
+        "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        },
+        "js-tokens": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "loose-envify": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "js-tokens": "^3.0.0 || ^4.0.0"
+          }
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "prop-types": {
+          "version": "15.6.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.3.1",
+            "object-assign": "^4.1.1"
+          }
+        },
+        "react-transition-group": {
+          "version": "2.9.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "dom-helpers": "^3.4.0",
+            "loose-envify": "^1.4.0",
+            "prop-types": "^15.6.2",
+            "react-lifecycles-compat": "^3.0.4"
+          }
+        },
+        "recompose": {
+          "version": "0.30.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "change-emitter": "^0.1.2",
+            "fbjs": "^0.8.1",
+            "hoist-non-react-statics": "^2.3.1",
+            "react-lifecycles-compat": "^3.0.2",
+            "symbol-observable": "^1.0.4"
+          }
+        }
+      }
+    },
+    "bpk-component-content-container": {
+      "version": "file:backpack/packages/bpk-component-content-container",
+      "dev": true,
+      "requires": {
+        "bpk-mixins": "^17.24.5",
+        "bpk-react-utils": "^2.7.9",
+        "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        },
+        "js-tokens": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "loose-envify": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "js-tokens": "^3.0.0 || ^4.0.0"
+          }
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "prop-types": {
+          "version": "15.6.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.3.1",
+            "object-assign": "^4.1.1"
+          }
+        },
+        "react-transition-group": {
+          "version": "2.9.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "dom-helpers": "^3.4.0",
+            "loose-envify": "^1.4.0",
+            "prop-types": "^15.6.2",
+            "react-lifecycles-compat": "^3.0.4"
+          }
+        },
+        "recompose": {
+          "version": "0.30.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "change-emitter": "^0.1.2",
+            "fbjs": "^0.8.1",
+            "hoist-non-react-statics": "^2.3.1",
+            "react-lifecycles-compat": "^3.0.2",
+            "symbol-observable": "^1.0.4"
+          }
+        }
+      }
+    },
+    "bpk-component-datepicker": {
+      "version": "file:backpack/packages/bpk-component-datepicker",
+      "dev": true,
+      "requires": {
+        "bpk-component-breakpoint": "^1.1.75",
+        "bpk-component-calendar": "^5.0.27",
+        "bpk-component-input": "^4.1.27",
+        "bpk-component-modal": "^1.8.74",
+        "bpk-component-popover": "^2.2.50",
+        "bpk-mixins": "^17.24.5",
+        "bpk-react-utils": "^2.7.9",
+        "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-component-breakpoint": {
+          "version": "1.1.75",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "prop-types": "^15.6.2",
+            "react-responsive": "^5.0.0"
+          }
+        },
+        "bpk-component-calendar": {
+          "version": "5.0.27",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-component-icon": "^3.31.5",
+            "bpk-component-select": "^2.3.8",
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "bpk-tokens": "^27.6.5",
+            "date-fns": "^1.29.0",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-close-button": {
+          "version": "1.0.142",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-component-icon": "^3.31.5",
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          },
+          "dependencies": {
+            "bpk-mixins": {
+              "version": "17.24.5",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "bpk-svgs": "^6.9.3",
+                "bpk-tokens": "^27.6.5"
+              }
+            }
+          }
+        },
+        "bpk-component-icon": {
+          "version": "3.31.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5",
+            "prop-types": "^15.6.2"
+          },
+          "dependencies": {
+            "bpk-mixins": {
+              "version": "17.24.5",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "bpk-svgs": "^6.9.3",
+                "bpk-tokens": "^27.6.5"
+              }
+            }
+          }
+        },
+        "bpk-component-input": {
+          "version": "4.1.27",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-component-icon": "^3.31.5",
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-link": {
+          "version": "1.2.76",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          },
+          "dependencies": {
+            "bpk-mixins": {
+              "version": "17.24.5",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "bpk-svgs": "^6.9.3",
+                "bpk-tokens": "^27.6.5"
+              }
+            }
+          }
+        },
+        "bpk-component-modal": {
+          "version": "1.8.74",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-component-close-button": "^1.0.142",
+            "bpk-component-icon": "^3.31.5",
+            "bpk-component-link": "^1.2.76",
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "bpk-scrim-utils": "^3.2.76",
+            "prop-types": "^15.6.2"
+          },
+          "dependencies": {
+            "bpk-scrim-utils": {
+              "version": "3.2.76",
+              "resolved": "https://registry.npmjs.org/bpk-scrim-utils/-/bpk-scrim-utils-3.2.76.tgz",
+              "integrity": "sha512-aDl5SN+smHgLXYf2IzjOKnmgNlxQVZ8tNR/uxlpzld5Uigl55eBlzJ+IfMVZlMIHmN0esm8xX2qpnEhG0jTkyw==",
+              "dev": true,
+              "requires": {
+                "a11y-focus-scope": "^1.1.3",
+                "a11y-focus-store": "^1.0.0",
+                "bpk-mixins": "^17.24.5",
+                "bpk-react-utils": "^2.7.9"
+              }
+            }
+          }
+        },
+        "bpk-component-popover": {
+          "version": "2.2.50",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@skyscanner/popper.js": "^1.12.9-beta.1",
+            "a11y-focus-scope": "^1.1.3",
+            "a11y-focus-store": "^1.0.0",
+            "bpk-component-close-button": "^1.0.142",
+            "bpk-component-link": "^1.2.76",
+            "bpk-component-text": "^1.1.7",
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-select": {
+          "version": "2.3.8",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          },
+          "dependencies": {
+            "bpk-mixins": {
+              "version": "17.24.5",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "bpk-svgs": "^6.9.3",
+                "bpk-tokens": "^27.6.5"
+              }
+            }
+          }
+        },
+        "bpk-component-text": {
+          "version": "1.1.7",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          },
+          "dependencies": {
+            "bpk-mixins": {
+              "version": "17.24.5",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "bpk-svgs": "^6.9.3",
+                "bpk-tokens": "^27.6.5"
+              }
+            }
+          }
+        },
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
           "requires": {
             "object-assign": "^4.1.1",
             "prop-types": "^15.6.2",
@@ -4004,14 +4585,2163 @@
         },
         "bpk-scrim-utils": {
           "version": "3.2.75",
-          "resolved": "https://registry.npmjs.org/bpk-scrim-utils/-/bpk-scrim-utils-3.2.75.tgz",
-          "integrity": "sha512-8CSMp/znOPIza3/3jBCdHPNQF68AxpizJ87VLiXz/ILy1o9dNjsEW6AnzDuhuy1U38sAc2JGeIxOwCWIJPZfQw==",
-          "dev": true,
+          "bundled": true,
           "requires": {
             "a11y-focus-scope": "^1.1.3",
             "a11y-focus-store": "^1.0.0",
             "bpk-mixins": "^17.24.4",
             "bpk-react-utils": "^2.7.9"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        },
+        "js-tokens": {
+          "version": "4.0.0",
+          "bundled": true
+        },
+        "loose-envify": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "js-tokens": "^3.0.0 || ^4.0.0"
+          }
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true
+        },
+        "prop-types": {
+          "version": "15.6.2",
+          "bundled": true,
+          "requires": {
+            "loose-envify": "^1.3.1",
+            "object-assign": "^4.1.1"
+          }
+        },
+        "react-transition-group": {
+          "version": "2.9.0",
+          "bundled": true,
+          "requires": {
+            "dom-helpers": "^3.4.0",
+            "loose-envify": "^1.4.0",
+            "prop-types": "^15.6.2",
+            "react-lifecycles-compat": "^3.0.4"
+          }
+        },
+        "recompose": {
+          "version": "0.30.0",
+          "bundled": true,
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "change-emitter": "^0.1.2",
+            "fbjs": "^0.8.1",
+            "hoist-non-react-statics": "^2.3.1",
+            "react-lifecycles-compat": "^3.0.2",
+            "symbol-observable": "^1.0.4"
+          }
+        }
+      }
+    },
+    "bpk-component-description-list": {
+      "version": "file:backpack/packages/bpk-component-description-list",
+      "dev": true,
+      "requires": {
+        "bpk-mixins": "^17.24.5",
+        "bpk-react-utils": "^2.7.9",
+        "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        },
+        "js-tokens": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "loose-envify": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "js-tokens": "^3.0.0 || ^4.0.0"
+          }
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "prop-types": {
+          "version": "15.6.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.3.1",
+            "object-assign": "^4.1.1"
+          }
+        },
+        "react-transition-group": {
+          "version": "2.9.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "dom-helpers": "^3.4.0",
+            "loose-envify": "^1.4.0",
+            "prop-types": "^15.6.2",
+            "react-lifecycles-compat": "^3.0.4"
+          }
+        },
+        "recompose": {
+          "version": "0.30.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "change-emitter": "^0.1.2",
+            "fbjs": "^0.8.1",
+            "hoist-non-react-statics": "^2.3.1",
+            "react-lifecycles-compat": "^3.0.2",
+            "symbol-observable": "^1.0.4"
+          }
+        }
+      }
+    },
+    "bpk-component-dialog": {
+      "version": "file:backpack/packages/bpk-component-dialog",
+      "dev": true,
+      "requires": {
+        "bpk-component-modal": "^1.8.74",
+        "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-component-button": {
+          "version": "2.4.2",
+          "bundled": true
+        },
+        "bpk-component-close-button": {
+          "version": "1.0.142",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-component-icon": "^3.31.5",
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          },
+          "dependencies": {
+            "bpk-component-icon": {
+              "version": "3.31.5",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "bpk-mixins": "^17.24.5",
+                "bpk-react-utils": "^2.7.9",
+                "bpk-svgs": "^6.9.3",
+                "bpk-tokens": "^27.6.5",
+                "prop-types": "^15.6.2"
+              }
+            },
+            "bpk-react-utils": {
+              "version": "2.7.9",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "object-assign": "^4.1.1",
+                "prop-types": "^15.6.2",
+                "react-transition-group": "^2.5.3",
+                "recompose": "^0.30.0"
+              }
+            }
+          }
+        },
+        "bpk-component-icon": {
+          "version": "3.31.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-link": {
+          "version": "1.2.76",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-modal": {
+          "version": "1.8.74",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-component-close-button": "^1.0.142",
+            "bpk-component-icon": "^3.31.5",
+            "bpk-component-link": "^1.2.76",
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "bpk-scrim-utils": "^3.2.76",
+            "prop-types": "^15.6.2"
+          },
+          "dependencies": {
+            "bpk-scrim-utils": {
+              "version": "3.2.76",
+              "resolved": "https://registry.npmjs.org/bpk-scrim-utils/-/bpk-scrim-utils-3.2.76.tgz",
+              "integrity": "sha512-aDl5SN+smHgLXYf2IzjOKnmgNlxQVZ8tNR/uxlpzld5Uigl55eBlzJ+IfMVZlMIHmN0esm8xX2qpnEhG0jTkyw==",
+              "dev": true,
+              "requires": {
+                "a11y-focus-scope": "^1.1.3",
+                "a11y-focus-store": "^1.0.0",
+                "bpk-mixins": "^17.24.5",
+                "bpk-react-utils": "^2.7.9"
+              }
+            }
+          }
+        },
+        "bpk-component-text": {
+          "version": "1.1.7",
+          "bundled": true,
+          "requires": {
+            "bpk-react-utils": "^2.7.9"
+          },
+          "dependencies": {
+            "bpk-react-utils": {
+              "version": "2.7.9",
+              "bundled": true
+            }
+          }
+        },
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-scrim-utils": {
+          "version": "3.2.75",
+          "bundled": true,
+          "requires": {
+            "a11y-focus-scope": "^1.1.3",
+            "a11y-focus-store": "^1.0.0",
+            "bpk-mixins": "^17.24.4",
+            "bpk-react-utils": "^2.7.9"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        },
+        "js-tokens": {
+          "version": "4.0.0",
+          "bundled": true
+        },
+        "loose-envify": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "js-tokens": "^3.0.0 || ^4.0.0"
+          }
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true
+        },
+        "prop-types": {
+          "version": "15.6.2",
+          "bundled": true,
+          "requires": {
+            "loose-envify": "^1.3.1",
+            "object-assign": "^4.1.1"
+          }
+        },
+        "react-transition-group": {
+          "version": "2.9.0",
+          "bundled": true,
+          "requires": {
+            "dom-helpers": "^3.4.0",
+            "loose-envify": "^1.4.0",
+            "prop-types": "^15.6.2",
+            "react-lifecycles-compat": "^3.0.4"
+          }
+        },
+        "recompose": {
+          "version": "0.30.0",
+          "bundled": true,
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "change-emitter": "^0.1.2",
+            "fbjs": "^0.8.1",
+            "hoist-non-react-statics": "^2.3.1",
+            "react-lifecycles-compat": "^3.0.2",
+            "symbol-observable": "^1.0.4"
+          }
+        }
+      }
+    },
+    "bpk-component-drawer": {
+      "version": "file:backpack/packages/bpk-component-drawer",
+      "dev": true,
+      "requires": {
+        "bpk-component-close-button": "^1.0.142",
+        "bpk-component-icon": "^3.31.5",
+        "bpk-component-link": "^1.2.76",
+        "bpk-mixins": "^17.24.5",
+        "bpk-react-utils": "^2.7.9",
+        "bpk-scrim-utils": "^3.2.76",
+        "bpk-tokens": "^27.6.5",
+        "prop-types": "^15.6.2",
+        "react-transition-group": "^2.5.3"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.5.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        },
+        "bpk-component-button": {
+          "version": "2.4.2",
+          "bundled": true
+        },
+        "bpk-component-close-button": {
+          "version": "1.0.142",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-component-icon": "^3.31.5",
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-icon": {
+          "version": "3.31.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-link": {
+          "version": "1.2.76",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-text": {
+          "version": "1.1.7",
+          "bundled": true,
+          "requires": {
+            "bpk-react-utils": "^2.7.9"
+          },
+          "dependencies": {
+            "bpk-react-utils": {
+              "version": "2.7.9",
+              "bundled": true
+            }
+          }
+        },
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        },
+        "dom-helpers": {
+          "version": "3.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.1.2"
+          }
+        },
+        "js-tokens": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "loose-envify": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "js-tokens": "^3.0.0 || ^4.0.0"
+          }
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "prop-types": {
+          "version": "15.6.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.3.1",
+            "object-assign": "^4.1.1"
+          }
+        },
+        "react-lifecycles-compat": {
+          "version": "3.0.4",
+          "bundled": true,
+          "dev": true
+        },
+        "react-transition-group": {
+          "version": "2.9.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "dom-helpers": "^3.4.0",
+            "loose-envify": "^1.4.0",
+            "prop-types": "^15.6.2",
+            "react-lifecycles-compat": "^3.0.4"
+          }
+        },
+        "recompose": {
+          "version": "0.30.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "change-emitter": "^0.1.2",
+            "fbjs": "^0.8.1",
+            "hoist-non-react-statics": "^2.3.1",
+            "react-lifecycles-compat": "^3.0.2",
+            "symbol-observable": "^1.0.4"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.3",
+          "bundled": true,
+          "dev": true
+        }
+      }
+    },
+    "bpk-component-fieldset": {
+      "version": "file:backpack/packages/bpk-component-fieldset",
+      "dev": true,
+      "requires": {
+        "bpk-component-form-validation": "^2.0.27",
+        "bpk-component-label": "^3.2.145",
+        "bpk-mixins": "^17.24.5",
+        "bpk-react-utils": "^2.7.9",
+        "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-animate-height": {
+          "version": "1.1.113",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-checkbox": {
+          "version": "1.4.110",
+          "bundled": true,
+          "requires": {
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          },
+          "dependencies": {
+            "bpk-component-icon": {
+              "version": "3.31.4",
+              "bundled": true,
+              "requires": {
+                "bpk-mixins": "^17.24.4",
+                "bpk-react-utils": "^2.7.9",
+                "bpk-svgs": "^6.9.2",
+                "bpk-tokens": "^27.6.4",
+                "prop-types": "^15.6.2"
+              }
+            },
+            "bpk-mixins": {
+              "version": "17.24.4",
+              "bundled": true,
+              "requires": {
+                "bpk-svgs": "^6.9.2",
+                "bpk-tokens": "^27.6.4"
+              }
+            },
+            "bpk-react-utils": {
+              "version": "2.7.9",
+              "bundled": true,
+              "requires": {
+                "object-assign": "^4.1.1",
+                "prop-types": "^15.6.2"
+              }
+            },
+            "bpk-svgs": {
+              "version": "6.9.3",
+              "bundled": true
+            },
+            "bpk-tokens": {
+              "version": "27.6.5",
+              "bundled": true
+            },
+            "js-tokens": {
+              "version": "4.0.0",
+              "bundled": true
+            },
+            "loose-envify": {
+              "version": "1.4.0",
+              "bundled": true,
+              "requires": {
+                "js-tokens": "^3.0.0 || ^4.0.0"
+              }
+            },
+            "object-assign": {
+              "version": "4.1.1",
+              "bundled": true
+            },
+            "prop-types": {
+              "version": "15.6.2",
+              "bundled": true,
+              "requires": {
+                "loose-envify": "^1.3.1",
+                "object-assign": "^4.1.1"
+              }
+            }
+          }
+        },
+        "bpk-component-form-validation": {
+          "version": "2.0.27",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-animate-height": "^1.1.113",
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-input": {
+          "version": "4.1.27",
+          "bundled": true
+        },
+        "bpk-component-label": {
+          "version": "3.2.145",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-select": {
+          "version": "2.3.8",
+          "bundled": true
+        },
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        },
+        "js-tokens": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "loose-envify": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "js-tokens": "^3.0.0 || ^4.0.0"
+          }
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "prop-types": {
+          "version": "15.6.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.3.1",
+            "object-assign": "^4.1.1"
+          }
+        },
+        "react-transition-group": {
+          "version": "2.9.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "dom-helpers": "^3.4.0",
+            "loose-envify": "^1.4.0",
+            "prop-types": "^15.6.2",
+            "react-lifecycles-compat": "^3.0.4"
+          }
+        },
+        "recompose": {
+          "version": "0.30.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "change-emitter": "^0.1.2",
+            "fbjs": "^0.8.1",
+            "hoist-non-react-statics": "^2.3.1",
+            "react-lifecycles-compat": "^3.0.2",
+            "symbol-observable": "^1.0.4"
+          }
+        }
+      }
+    },
+    "bpk-component-form-validation": {
+      "version": "file:backpack/packages/bpk-component-form-validation",
+      "dev": true,
+      "requires": {
+        "bpk-animate-height": "^1.1.113",
+        "bpk-mixins": "^17.24.5",
+        "bpk-react-utils": "^2.7.9",
+        "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "react-transition-group": {
+          "version": "2.9.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "dom-helpers": "^3.4.0",
+            "loose-envify": "^1.4.0",
+            "prop-types": "^15.6.2",
+            "react-lifecycles-compat": "^3.0.4"
+          }
+        },
+        "recompose": {
+          "version": "0.30.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "change-emitter": "^0.1.2",
+            "fbjs": "^0.8.1",
+            "hoist-non-react-statics": "^2.3.1",
+            "react-lifecycles-compat": "^3.0.2",
+            "symbol-observable": "^1.0.4"
+          }
+        }
+      }
+    },
+    "bpk-component-grid": {
+      "version": "file:backpack/packages/bpk-component-grid",
+      "dev": true,
+      "requires": {
+        "bpk-mixins": "^17.24.5",
+        "bpk-react-utils": "^2.7.9",
+        "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        },
+        "js-tokens": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "loose-envify": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "js-tokens": "^3.0.0 || ^4.0.0"
+          }
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "prop-types": {
+          "version": "15.6.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.3.1",
+            "object-assign": "^4.1.1"
+          }
+        },
+        "react-transition-group": {
+          "version": "2.9.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "dom-helpers": "^3.4.0",
+            "loose-envify": "^1.4.0",
+            "prop-types": "^15.6.2",
+            "react-lifecycles-compat": "^3.0.4"
+          }
+        },
+        "recompose": {
+          "version": "0.30.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "change-emitter": "^0.1.2",
+            "fbjs": "^0.8.1",
+            "hoist-non-react-statics": "^2.3.1",
+            "react-lifecycles-compat": "^3.0.2",
+            "symbol-observable": "^1.0.4"
+          }
+        }
+      }
+    },
+    "bpk-component-grid-toggle": {
+      "version": "file:backpack/packages/bpk-component-grid-toggle",
+      "dev": true,
+      "requires": {
+        "bpk-component-link": "^1.2.76",
+        "bpk-mixins": "^17.24.5",
+        "bpk-react-utils": "^2.7.9",
+        "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-component-link": {
+          "version": "1.2.76",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        },
+        "js-tokens": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "loose-envify": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "js-tokens": "^3.0.0 || ^4.0.0"
+          }
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "prop-types": {
+          "version": "15.6.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.3.1",
+            "object-assign": "^4.1.1"
+          }
+        },
+        "react-transition-group": {
+          "version": "2.9.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "dom-helpers": "^3.4.0",
+            "loose-envify": "^1.4.0",
+            "prop-types": "^15.6.2",
+            "react-lifecycles-compat": "^3.0.4"
+          }
+        },
+        "recompose": {
+          "version": "0.30.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "change-emitter": "^0.1.2",
+            "fbjs": "^0.8.1",
+            "hoist-non-react-statics": "^2.3.1",
+            "react-lifecycles-compat": "^3.0.2",
+            "symbol-observable": "^1.0.4"
+          }
+        }
+      }
+    },
+    "bpk-component-horizontal-nav": {
+      "version": "file:backpack/packages/bpk-component-horizontal-nav",
+      "dev": true,
+      "requires": {
+        "bpk-component-mobile-scroll-container": "^1.1.82",
+        "bpk-mixins": "^17.24.5",
+        "bpk-react-utils": "^2.7.9",
+        "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-component-mobile-scroll-container": {
+          "version": "1.1.82",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "lodash.debounce": "^4.0.8",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        },
+        "js-tokens": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "loose-envify": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "js-tokens": "^3.0.0 || ^4.0.0"
+          }
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "prop-types": {
+          "version": "15.6.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.3.1",
+            "object-assign": "^4.1.1"
+          }
+        },
+        "react-transition-group": {
+          "version": "2.9.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "dom-helpers": "^3.4.0",
+            "loose-envify": "^1.4.0",
+            "prop-types": "^15.6.2",
+            "react-lifecycles-compat": "^3.0.4"
+          }
+        },
+        "recompose": {
+          "version": "0.30.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "change-emitter": "^0.1.2",
+            "fbjs": "^0.8.1",
+            "hoist-non-react-statics": "^2.3.1",
+            "react-lifecycles-compat": "^3.0.2",
+            "symbol-observable": "^1.0.4"
+          }
+        }
+      }
+    },
+    "bpk-component-icon": {
+      "version": "file:backpack/packages/bpk-component-icon",
+      "dev": true,
+      "requires": {
+        "bpk-mixins": "^17.24.5",
+        "bpk-react-utils": "^2.7.9",
+        "bpk-svgs": "^6.9.3",
+        "bpk-tokens": "^27.6.5",
+        "prop-types": "^15.6.2"
+      }
+    },
+    "bpk-component-image": {
+      "version": "file:backpack/packages/bpk-component-image",
+      "dev": true,
+      "requires": {
+        "bpk-component-spinner": "^2.2.107",
+        "bpk-mixins": "^17.24.5",
+        "bpk-react-utils": "^2.7.9",
+        "prop-types": "^15.6.2",
+        "react-transition-group": "^2.5.3"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.5.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        },
+        "bpk-component-mobile-scroll-container": {
+          "version": "1.1.82",
+          "bundled": true,
+          "requires": {
+            "bpk-react-utils": "^2.7.9"
+          },
+          "dependencies": {
+            "bpk-react-utils": {
+              "version": "2.7.9",
+              "bundled": true
+            }
+          }
+        },
+        "bpk-component-spinner": {
+          "version": "2.2.107",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "bpk-svgs": "^6.9.3",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-text": {
+          "version": "1.1.7",
+          "bundled": true,
+          "requires": {
+            "bpk-react-utils": "^2.7.9"
+          },
+          "dependencies": {
+            "bpk-react-utils": {
+              "version": "2.7.9",
+              "bundled": true
+            }
+          }
+        },
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        },
+        "dom-helpers": {
+          "version": "3.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.1.2"
+          }
+        },
+        "js-tokens": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "loose-envify": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "js-tokens": "^3.0.0 || ^4.0.0"
+          }
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "prop-types": {
+          "version": "15.6.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.3.1",
+            "object-assign": "^4.1.1"
+          }
+        },
+        "react-lifecycles-compat": {
+          "version": "3.0.4",
+          "bundled": true,
+          "dev": true
+        },
+        "react-transition-group": {
+          "version": "2.9.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "dom-helpers": "^3.4.0",
+            "loose-envify": "^1.4.0",
+            "prop-types": "^15.6.2",
+            "react-lifecycles-compat": "^3.0.4"
+          }
+        },
+        "recompose": {
+          "version": "0.30.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "change-emitter": "^0.1.2",
+            "fbjs": "^0.8.1",
+            "hoist-non-react-statics": "^2.3.1",
+            "react-lifecycles-compat": "^3.0.2",
+            "symbol-observable": "^1.0.4"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.3",
+          "bundled": true,
+          "dev": true
+        }
+      }
+    },
+    "bpk-component-infinite-scroll": {
+      "version": "file:backpack/packages/bpk-component-infinite-scroll",
+      "dev": true,
+      "requires": {
+        "bpk-mixins": "^17.24.5",
+        "bpk-react-utils": "^2.7.9",
+        "intersection-observer": "^0.7.0",
+        "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-component-button": {
+          "version": "2.4.2",
+          "bundled": true
+        },
+        "bpk-component-card": {
+          "version": "1.1.90",
+          "bundled": true,
+          "requires": {
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          },
+          "dependencies": {
+            "bpk-mixins": {
+              "version": "17.24.4",
+              "bundled": true,
+              "requires": {
+                "bpk-svgs": "^6.9.2",
+                "bpk-tokens": "^27.6.4"
+              }
+            },
+            "bpk-react-utils": {
+              "version": "2.7.9",
+              "bundled": true,
+              "requires": {
+                "object-assign": "^4.1.1",
+                "prop-types": "^15.6.2"
+              }
+            },
+            "bpk-svgs": {
+              "version": "6.9.3",
+              "bundled": true
+            },
+            "bpk-tokens": {
+              "version": "27.6.5",
+              "bundled": true
+            },
+            "js-tokens": {
+              "version": "4.0.0",
+              "bundled": true
+            },
+            "loose-envify": {
+              "version": "1.4.0",
+              "bundled": true,
+              "requires": {
+                "js-tokens": "^3.0.0 || ^4.0.0"
+              }
+            },
+            "object-assign": {
+              "version": "4.1.1",
+              "bundled": true
+            },
+            "prop-types": {
+              "version": "15.6.2",
+              "bundled": true,
+              "requires": {
+                "loose-envify": "^1.3.1",
+                "object-assign": "^4.1.1"
+              }
+            }
+          }
+        },
+        "bpk-component-spinner": {
+          "version": "2.2.107",
+          "bundled": true,
+          "requires": {
+            "bpk-react-utils": "^2.7.9"
+          },
+          "dependencies": {
+            "bpk-react-utils": {
+              "version": "2.7.9",
+              "bundled": true
+            }
+          }
+        },
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        },
+        "intersection-observer": {
+          "version": "0.7.0",
+          "bundled": true,
+          "dev": true
+        },
+        "js-tokens": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "loose-envify": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "js-tokens": "^3.0.0 || ^4.0.0"
+          }
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "prop-types": {
+          "version": "15.6.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.3.1",
+            "object-assign": "^4.1.1"
+          }
+        },
+        "react-transition-group": {
+          "version": "2.9.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "dom-helpers": "^3.4.0",
+            "loose-envify": "^1.4.0",
+            "prop-types": "^15.6.2",
+            "react-lifecycles-compat": "^3.0.4"
+          }
+        },
+        "recompose": {
+          "version": "0.30.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "change-emitter": "^0.1.2",
+            "fbjs": "^0.8.1",
+            "hoist-non-react-statics": "^2.3.1",
+            "react-lifecycles-compat": "^3.0.2",
+            "symbol-observable": "^1.0.4"
+          }
+        }
+      }
+    },
+    "bpk-component-input": {
+      "version": "file:backpack/packages/bpk-component-input",
+      "dev": true,
+      "requires": {
+        "bpk-component-icon": "^3.31.5",
+        "bpk-mixins": "^17.24.5",
+        "bpk-react-utils": "^2.7.9",
+        "prop-types": "^15.6.2"
+      }
+    },
+    "bpk-component-label": {
+      "version": "file:backpack/packages/bpk-component-label",
+      "dev": true,
+      "requires": {
+        "bpk-mixins": "^17.24.5",
+        "bpk-react-utils": "^2.7.9",
+        "prop-types": "^15.6.2"
+      }
+    },
+    "bpk-component-link": {
+      "version": "file:backpack/packages/bpk-component-link",
+      "dev": true,
+      "requires": {
+        "bpk-mixins": "^17.24.5",
+        "bpk-react-utils": "^2.7.9",
+        "prop-types": "^15.6.2"
+      }
+    },
+    "bpk-component-list": {
+      "version": "file:backpack/packages/bpk-component-list",
+      "dev": true,
+      "requires": {
+        "bpk-mixins": "^17.24.5",
+        "bpk-react-utils": "^2.7.9",
+        "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        },
+        "js-tokens": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "loose-envify": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "js-tokens": "^3.0.0 || ^4.0.0"
+          }
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "prop-types": {
+          "version": "15.6.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.3.1",
+            "object-assign": "^4.1.1"
+          }
+        },
+        "react-transition-group": {
+          "version": "2.9.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "dom-helpers": "^3.4.0",
+            "loose-envify": "^1.4.0",
+            "prop-types": "^15.6.2",
+            "react-lifecycles-compat": "^3.0.4"
+          }
+        },
+        "recompose": {
+          "version": "0.30.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "change-emitter": "^0.1.2",
+            "fbjs": "^0.8.1",
+            "hoist-non-react-statics": "^2.3.1",
+            "react-lifecycles-compat": "^3.0.2",
+            "symbol-observable": "^1.0.4"
+          }
+        }
+      }
+    },
+    "bpk-component-loading-button": {
+      "version": "file:backpack/packages/bpk-component-loading-button",
+      "dev": true,
+      "requires": {
+        "bpk-component-button": "^2.4.2",
+        "bpk-component-icon": "^3.31.5",
+        "bpk-component-spinner": "^2.2.107",
+        "bpk-mixins": "^17.24.5",
+        "bpk-react-utils": "^2.7.9",
+        "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-component-button": {
+          "version": "2.4.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-icon": {
+          "version": "3.31.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-spinner": {
+          "version": "2.2.107",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "bpk-svgs": "^6.9.3",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        },
+        "js-tokens": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "loose-envify": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "js-tokens": "^3.0.0 || ^4.0.0"
+          }
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "prop-types": {
+          "version": "15.6.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.3.1",
+            "object-assign": "^4.1.1"
+          }
+        },
+        "react-transition-group": {
+          "version": "2.9.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "dom-helpers": "^3.4.0",
+            "loose-envify": "^1.4.0",
+            "prop-types": "^15.6.2",
+            "react-lifecycles-compat": "^3.0.4"
+          }
+        },
+        "recompose": {
+          "version": "0.30.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "change-emitter": "^0.1.2",
+            "fbjs": "^0.8.1",
+            "hoist-non-react-statics": "^2.3.1",
+            "react-lifecycles-compat": "^3.0.2",
+            "symbol-observable": "^1.0.4"
+          }
+        }
+      }
+    },
+    "bpk-component-map": {
+      "version": "file:backpack/packages/bpk-component-map",
+      "dev": true,
+      "requires": {
+        "bpk-component-spinner": "^2.2.107",
+        "bpk-mixins": "^17.24.5",
+        "bpk-react-utils": "^2.7.9",
+        "prop-types": "^15.5.8",
+        "react-google-maps": "^9.4.5"
+      },
+      "dependencies": {
+        "asap": {
+          "version": "2.0.6",
+          "bundled": true,
+          "dev": true
+        },
+        "babel-runtime": {
+          "version": "6.26.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "core-js": "^2.4.0",
+            "regenerator-runtime": "^0.11.0"
+          }
+        },
+        "bpk-component-icon": {
+          "version": "3.31.5",
+          "bundled": true
+        },
+        "bpk-component-spinner": {
+          "version": "2.2.107",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "bpk-svgs": "^6.9.3",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-text": {
+          "version": "1.1.7",
+          "bundled": true,
+          "requires": {
+            "bpk-react-utils": "^2.7.9"
+          },
+          "dependencies": {
+            "bpk-react-utils": {
+              "version": "2.7.9",
+              "bundled": true
+            }
+          }
+        },
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          },
+          "dependencies": {
+            "recompose": {
+              "version": "0.30.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "@babel/runtime": "^7.0.0",
+                "change-emitter": "^0.1.2",
+                "fbjs": "^0.8.1",
+                "hoist-non-react-statics": "^2.3.1",
+                "react-lifecycles-compat": "^3.0.2",
+                "symbol-observable": "^1.0.4"
+              }
+            }
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        },
+        "can-use-dom": {
+          "version": "0.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "change-emitter": {
+          "version": "0.1.6",
+          "bundled": true,
+          "dev": true
+        },
+        "core-js": {
+          "version": "2.5.7",
+          "bundled": true,
+          "dev": true
+        },
+        "encoding": {
+          "version": "0.1.12",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "iconv-lite": "~0.4.13"
+          }
+        },
+        "fbjs": {
+          "version": "0.8.17",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "core-js": "^1.0.0",
+            "isomorphic-fetch": "^2.1.1",
+            "loose-envify": "^1.0.0",
+            "object-assign": "^4.1.0",
+            "promise": "^7.1.1",
+            "setimmediate": "^1.0.5",
+            "ua-parser-js": "^0.7.18"
+          },
+          "dependencies": {
+            "core-js": {
+              "version": "1.2.7",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "google-maps-infobox": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "hoist-non-react-statics": {
+          "version": "2.5.5",
+          "bundled": true,
+          "dev": true
+        },
+        "iconv-lite": {
+          "version": "0.4.24",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        },
+        "invariant": {
+          "version": "2.2.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.0.0"
+          }
+        },
+        "is-stream": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "isomorphic-fetch": {
+          "version": "2.2.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "node-fetch": "^1.0.1",
+            "whatwg-fetch": ">=0.10.0"
+          }
+        },
+        "js-tokens": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "lodash": {
+          "version": "4.17.10",
+          "bundled": true,
+          "dev": true
+        },
+        "loose-envify": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "js-tokens": "^3.0.0 || ^4.0.0"
+          }
+        },
+        "marker-clusterer-plus": {
+          "version": "2.1.4",
+          "bundled": true,
+          "dev": true
+        },
+        "markerwithlabel": {
+          "version": "2.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "node-fetch": {
+          "version": "1.7.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "encoding": "^0.1.11",
+            "is-stream": "^1.0.1"
+          }
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "promise": {
+          "version": "7.3.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "asap": "~2.0.3"
+          }
+        },
+        "prop-types": {
+          "version": "15.6.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.3.1",
+            "object-assign": "^4.1.1"
+          }
+        },
+        "react-google-maps": {
+          "version": "9.4.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-runtime": "^6.11.6",
+            "can-use-dom": "^0.1.0",
+            "google-maps-infobox": "^2.0.0",
+            "invariant": "^2.2.1",
+            "lodash": "^4.16.2",
+            "marker-clusterer-plus": "^2.1.4",
+            "markerwithlabel": "^2.0.1",
+            "prop-types": "^15.5.8",
+            "recompose": "^0.26.0",
+            "scriptjs": "^2.5.8",
+            "warning": "^3.0.0"
+          }
+        },
+        "react-transition-group": {
+          "version": "2.9.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "dom-helpers": "^3.4.0",
+            "loose-envify": "^1.4.0",
+            "prop-types": "^15.6.2",
+            "react-lifecycles-compat": "^3.0.4"
+          }
+        },
+        "recompose": {
+          "version": "0.26.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "change-emitter": "^0.1.2",
+            "fbjs": "^0.8.1",
+            "hoist-non-react-statics": "^2.3.1",
+            "symbol-observable": "^1.0.4"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.11.1",
+          "bundled": true,
+          "dev": true
+        },
+        "safer-buffer": {
+          "version": "2.1.2",
+          "bundled": true,
+          "dev": true
+        },
+        "scriptjs": {
+          "version": "2.5.8",
+          "bundled": true,
+          "dev": true
+        },
+        "setimmediate": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true
+        },
+        "symbol-observable": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "ua-parser-js": {
+          "version": "0.7.18",
+          "bundled": true,
+          "dev": true
+        },
+        "warning": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.0.0"
+          }
+        },
+        "whatwg-fetch": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true
+        }
+      }
+    },
+    "bpk-component-mobile-scroll-container": {
+      "version": "file:backpack/packages/bpk-component-mobile-scroll-container",
+      "dev": true,
+      "requires": {
+        "bpk-mixins": "^17.24.5",
+        "bpk-react-utils": "^2.7.9",
+        "lodash.debounce": "^4.0.8",
+        "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "react-transition-group": {
+          "version": "2.9.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "dom-helpers": "^3.4.0",
+            "loose-envify": "^1.4.0",
+            "prop-types": "^15.6.2",
+            "react-lifecycles-compat": "^3.0.4"
+          }
+        },
+        "recompose": {
+          "version": "0.30.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "change-emitter": "^0.1.2",
+            "fbjs": "^0.8.1",
+            "hoist-non-react-statics": "^2.3.1",
+            "react-lifecycles-compat": "^3.0.2",
+            "symbol-observable": "^1.0.4"
+          }
+        }
+      }
+    },
+    "bpk-component-modal": {
+      "version": "file:backpack/packages/bpk-component-modal",
+      "dev": true,
+      "requires": {
+        "bpk-component-close-button": "^1.0.142",
+        "bpk-component-icon": "^3.31.5",
+        "bpk-component-link": "^1.2.76",
+        "bpk-mixins": "^17.24.5",
+        "bpk-react-utils": "^2.7.9",
+        "bpk-scrim-utils": "^3.2.76",
+        "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-component-close-button": {
+          "version": "1.0.142",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-component-icon": "^3.31.5",
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-icon": {
+          "version": "3.31.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-link": {
+          "version": "1.2.76",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-scrim-utils": {
+          "version": "3.2.76",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "a11y-focus-scope": "^1.1.3",
+            "a11y-focus-store": "^1.0.0",
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9"
+          }
+        },
+        "react-transition-group": {
+          "version": "2.9.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "dom-helpers": "^3.4.0",
+            "loose-envify": "^1.4.0",
+            "prop-types": "^15.6.2",
+            "react-lifecycles-compat": "^3.0.4"
+          }
+        },
+        "recompose": {
+          "version": "0.30.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "change-emitter": "^0.1.2",
+            "fbjs": "^0.8.1",
+            "hoist-non-react-statics": "^2.3.1",
+            "react-lifecycles-compat": "^3.0.2",
+            "symbol-observable": "^1.0.4"
           }
         }
       }
@@ -4020,68 +6750,139 @@
       "version": "file:backpack/packages/bpk-component-navigation-bar",
       "dev": true,
       "requires": {
-        "bpk-component-close-button": "^1.0.141",
-        "bpk-component-link": "^1.2.75",
-        "bpk-component-text": "^1.1.6",
-        "bpk-mixins": "^17.24.4",
+        "bpk-component-close-button": "^1.0.142",
+        "bpk-component-link": "^1.2.76",
+        "bpk-component-text": "^1.1.7",
+        "bpk-mixins": "^17.24.5",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
       },
       "dependencies": {
         "bpk-component-close-button": {
-          "version": "1.0.141",
-          "resolved": "https://registry.npmjs.org/bpk-component-close-button/-/bpk-component-close-button-1.0.141.tgz",
-          "integrity": "sha512-Yd2kQnwuEQ3Myoqk2z/NDVIxB3YebCZrtgFJlQ/C6otp3sH3lbWLg4INREQqAyK1ZU5GK96qhvneubMA1tPLqQ==",
+          "version": "1.0.142",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "bpk-component-icon": "^3.31.4",
-            "bpk-mixins": "^17.24.4",
+            "bpk-component-icon": "^3.31.5",
+            "bpk-mixins": "^17.24.5",
             "bpk-react-utils": "^2.7.9",
             "prop-types": "^15.6.2"
           }
         },
-        "bpk-component-link": {
-          "version": "1.2.75",
-          "resolved": "https://registry.npmjs.org/bpk-component-link/-/bpk-component-link-1.2.75.tgz",
-          "integrity": "sha512-qoosptvwz8ZjxRt2WvoERb2E71zrBhs5+USNjy6FtDl+cXndmMOsINB1JiAmMB9TO6PgUZJkj7FBN7Vm7rZ+bQ==",
+        "bpk-component-icon": {
+          "version": "3.31.5",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "bpk-mixins": "^17.24.4",
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-link": {
+          "version": "1.2.76",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
             "bpk-react-utils": "^2.7.9",
             "prop-types": "^15.6.2"
           }
         },
         "bpk-component-text": {
-          "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/bpk-component-text/-/bpk-component-text-1.1.6.tgz",
-          "integrity": "sha512-U4wp5+Fz1Rd9LeJphQRKwKx2ekIbzGj0SFdvjDkVOkG120YVtVb4YQN/3xEl/zb7Csku5HLvkJIJK4C+wR22nQ==",
+          "version": "1.1.7",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "bpk-mixins": "^17.24.4",
+            "bpk-mixins": "^17.24.5",
             "bpk-react-utils": "^2.7.9",
             "prop-types": "^15.6.2"
           }
         },
         "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
+          "version": "17.24.5",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
             "prop-types": "^15.6.2",
             "react-transition-group": "^2.5.3",
             "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        },
+        "js-tokens": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "loose-envify": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "js-tokens": "^3.0.0 || ^4.0.0"
+          }
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "prop-types": {
+          "version": "15.6.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.3.1",
+            "object-assign": "^4.1.1"
+          }
+        },
+        "react-transition-group": {
+          "version": "2.9.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "dom-helpers": "^3.4.0",
+            "loose-envify": "^1.4.0",
+            "prop-types": "^15.6.2",
+            "react-lifecycles-compat": "^3.0.4"
+          }
+        },
+        "recompose": {
+          "version": "0.30.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "change-emitter": "^0.1.2",
+            "fbjs": "^0.8.1",
+            "hoist-non-react-statics": "^2.3.1",
+            "react-lifecycles-compat": "^3.0.2",
+            "symbol-observable": "^1.0.4"
           }
         }
       }
@@ -4090,27 +6891,212 @@
       "version": "file:backpack/packages/bpk-component-navigation-stack",
       "dev": true,
       "requires": {
-        "bpk-mixins": "^17.24.4",
+        "bpk-mixins": "^17.24.5",
         "bpk-react-utils": "^2.7.9",
-        "bpk-tokens": "^27.6.4",
+        "bpk-tokens": "^27.6.5",
         "prop-types": "^15.6.2",
         "react-transition-group": "^2.5.3"
       },
       "dependencies": {
-        "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
+        "@babel/runtime": {
+          "version": "7.5.5",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
+            "regenerator-runtime": "^0.13.2"
+          }
+        },
+        "bpk-component-button": {
+          "version": "2.4.2",
+          "bundled": true
+        },
+        "bpk-component-icon": {
+          "version": "3.31.5",
+          "bundled": true
+        },
+        "bpk-component-navigation-bar": {
+          "version": "1.2.83",
+          "bundled": true,
+          "requires": {
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          },
+          "dependencies": {
+            "bpk-component-close-button": {
+              "version": "1.0.141",
+              "bundled": true,
+              "requires": {
+                "bpk-component-icon": "^3.31.4",
+                "bpk-mixins": "^17.24.4",
+                "bpk-react-utils": "^2.7.9",
+                "prop-types": "^15.6.2"
+              }
+            },
+            "bpk-component-icon": {
+              "version": "3.31.5",
+              "bundled": true,
+              "requires": {
+                "bpk-react-utils": "^2.7.9",
+                "bpk-svgs": "^6.9.3",
+                "bpk-tokens": "^27.6.5",
+                "prop-types": "^15.6.2"
+              }
+            },
+            "bpk-component-link": {
+              "version": "1.2.75",
+              "bundled": true,
+              "requires": {
+                "bpk-mixins": "^17.24.4",
+                "bpk-react-utils": "^2.7.9",
+                "prop-types": "^15.6.2"
+              },
+              "dependencies": {
+                "bpk-react-utils": {
+                  "version": "2.7.9",
+                  "bundled": true,
+                  "requires": {
+                    "object-assign": "^4.1.1",
+                    "prop-types": "^15.6.2"
+                  }
+                }
+              }
+            },
+            "bpk-component-text": {
+              "version": "1.1.6",
+              "bundled": true,
+              "requires": {
+                "bpk-mixins": "^17.24.4",
+                "bpk-react-utils": "^2.7.9",
+                "prop-types": "^15.6.2"
+              }
+            },
+            "bpk-mixins": {
+              "version": "17.24.4",
+              "bundled": true,
+              "requires": {
+                "bpk-svgs": "^6.9.2",
+                "bpk-tokens": "^27.6.4"
+              }
+            },
+            "bpk-react-utils": {
+              "version": "2.7.9",
+              "bundled": true,
+              "requires": {
+                "object-assign": "^4.1.1",
+                "prop-types": "^15.6.2"
+              }
+            },
+            "bpk-svgs": {
+              "version": "6.9.3",
+              "bundled": true
+            },
+            "bpk-tokens": {
+              "version": "27.6.5",
+              "bundled": true
+            },
+            "js-tokens": {
+              "version": "4.0.0",
+              "bundled": true
+            },
+            "loose-envify": {
+              "version": "1.4.0",
+              "bundled": true,
+              "requires": {
+                "js-tokens": "^3.0.0 || ^4.0.0"
+              }
+            },
+            "object-assign": {
+              "version": "4.1.1",
+              "bundled": true
+            },
+            "prop-types": {
+              "version": "15.6.2",
+              "bundled": true,
+              "requires": {
+                "loose-envify": "^1.3.1",
+                "object-assign": "^4.1.1"
+              }
+            }
+          }
+        },
+        "bpk-component-rtl-toggle": {
+          "version": "1.1.95",
+          "bundled": true,
+          "requires": {
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          },
+          "dependencies": {
+            "bpk-component-link": {
+              "version": "1.2.75",
+              "bundled": true,
+              "requires": {
+                "bpk-mixins": "^17.24.4",
+                "bpk-react-utils": "^2.7.9",
+                "prop-types": "^15.6.2"
+              }
+            },
+            "bpk-mixins": {
+              "version": "17.24.5",
+              "bundled": true,
+              "requires": {
+                "bpk-svgs": "^6.9.3",
+                "bpk-tokens": "^27.6.5"
+              }
+            },
+            "bpk-react-utils": {
+              "version": "2.7.9",
+              "bundled": true,
+              "requires": {
+                "object-assign": "^4.1.1",
+                "prop-types": "^15.6.2"
+              }
+            },
+            "bpk-svgs": {
+              "version": "6.9.3",
+              "bundled": true
+            },
+            "bpk-tokens": {
+              "version": "27.6.5",
+              "bundled": true
+            },
+            "js-tokens": {
+              "version": "4.0.0",
+              "bundled": true
+            },
+            "loose-envify": {
+              "version": "1.4.0",
+              "bundled": true,
+              "requires": {
+                "js-tokens": "^3.0.0 || ^4.0.0"
+              }
+            },
+            "object-assign": {
+              "version": "4.1.1",
+              "bundled": true
+            },
+            "prop-types": {
+              "version": "15.6.2",
+              "bundled": true,
+              "requires": {
+                "loose-envify": "^1.3.1",
+                "object-assign": "^4.1.1"
+              }
+            }
+          }
+        },
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
@@ -4119,26 +7105,87 @@
             "recompose": "^0.30.0"
           }
         },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
         "bpk-tokens": {
-          "version": "27.6.4",
-          "resolved": "https://registry.npmjs.org/bpk-tokens/-/bpk-tokens-27.6.4.tgz",
-          "integrity": "sha512-/7BXdfw5Ft2UxkpLlme4x2TXoTEtITeJX1IzxqdgKZF0+fb+WT4SywoO0g9iM/nfQ1893ZEdNkG25u49v43dsQ==",
+          "version": "27.6.5",
+          "bundled": true,
           "dev": true,
           "requires": {
             "color": "^3.0.0"
-          },
-          "dependencies": {
-            "color": {
-              "version": "3.1.2",
-              "resolved": "https://registry.npmjs.org/color/-/color-3.1.2.tgz",
-              "integrity": "sha512-vXTJhHebByxZn3lDvDJYw4lR5+uB3vuoHsuYA5AKuxRVn5wzzIfQKGLBmgdVRHKTJYeK5rvJcHnrd0Li49CFpg==",
-              "dev": true,
-              "requires": {
-                "color-convert": "^1.9.1",
-                "color-string": "^1.5.2"
-              }
-            }
           }
+        },
+        "dom-helpers": {
+          "version": "3.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.1.2"
+          }
+        },
+        "js-tokens": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "loose-envify": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "js-tokens": "^3.0.0 || ^4.0.0"
+          }
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "prop-types": {
+          "version": "15.6.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.3.1",
+            "object-assign": "^4.1.1"
+          }
+        },
+        "react-lifecycles-compat": {
+          "version": "3.0.4",
+          "bundled": true,
+          "dev": true
+        },
+        "react-transition-group": {
+          "version": "2.9.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "dom-helpers": "^3.4.0",
+            "loose-envify": "^1.4.0",
+            "prop-types": "^15.6.2",
+            "react-lifecycles-compat": "^3.0.4"
+          }
+        },
+        "recompose": {
+          "version": "0.30.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "change-emitter": "^0.1.2",
+            "fbjs": "^0.8.1",
+            "hoist-non-react-statics": "^2.3.1",
+            "react-lifecycles-compat": "^3.0.2",
+            "symbol-observable": "^1.0.4"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.3",
+          "bundled": true,
+          "dev": true
         }
       }
     },
@@ -4146,52 +7193,52 @@
       "version": "file:backpack/packages/bpk-component-nudger",
       "dev": true,
       "requires": {
-        "bpk-component-button": "^2.4.1",
-        "bpk-component-icon": "^3.31.4",
-        "bpk-mixins": "^17.24.4",
+        "bpk-component-button": "^2.4.2",
+        "bpk-component-icon": "^3.31.5",
+        "bpk-mixins": "^17.24.5",
         "bpk-react-utils": "^2.7.9",
-        "bpk-tokens": "^27.6.4",
+        "bpk-tokens": "^27.6.5",
         "lodash.clamp": "^4.0.3",
         "prop-types": "^15.6.2"
       },
       "dependencies": {
         "bpk-component-button": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/bpk-component-button/-/bpk-component-button-2.4.1.tgz",
-          "integrity": "sha512-4jJ5wxgquUUVGHpblXf0yWlpVFNtmDo0DjLMkGL5U4HxFIgc0XZp911KjIzUVeCh+3eGASeAthQgLCruQghzOg==",
+          "version": "2.4.2",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "bpk-mixins": "^17.24.4",
+            "bpk-mixins": "^17.24.5",
             "prop-types": "^15.6.2"
           }
         },
         "bpk-component-icon": {
-          "version": "3.31.4",
-          "resolved": "https://registry.npmjs.org/bpk-component-icon/-/bpk-component-icon-3.31.4.tgz",
-          "integrity": "sha512-DAiwhBYyyFmy2jonUFxEtxLpj2RlN17EDgd1zwZGpjfIhryyA+vL4XlSr8EkfPjZ6z+I6NWwbfmEUqDZgrn7Ag==",
+          "version": "3.31.5",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "bpk-mixins": "^17.24.4",
+            "bpk-mixins": "^17.24.5",
             "bpk-react-utils": "^2.7.9",
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4",
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5",
             "prop-types": "^15.6.2"
           }
         },
+        "bpk-component-label": {
+          "version": "3.2.145",
+          "bundled": true
+        },
         "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
+          "version": "17.24.5",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
@@ -4200,25 +7247,73 @@
             "recompose": "^0.30.0"
           }
         },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
         "bpk-tokens": {
-          "version": "27.6.4",
-          "resolved": "https://registry.npmjs.org/bpk-tokens/-/bpk-tokens-27.6.4.tgz",
-          "integrity": "sha512-/7BXdfw5Ft2UxkpLlme4x2TXoTEtITeJX1IzxqdgKZF0+fb+WT4SywoO0g9iM/nfQ1893ZEdNkG25u49v43dsQ==",
+          "version": "27.6.5",
+          "bundled": true,
           "dev": true,
           "requires": {
             "color": "^3.0.0"
-          },
-          "dependencies": {
-            "color": {
-              "version": "3.1.2",
-              "resolved": "https://registry.npmjs.org/color/-/color-3.1.2.tgz",
-              "integrity": "sha512-vXTJhHebByxZn3lDvDJYw4lR5+uB3vuoHsuYA5AKuxRVn5wzzIfQKGLBmgdVRHKTJYeK5rvJcHnrd0Li49CFpg==",
-              "dev": true,
-              "requires": {
-                "color-convert": "^1.9.1",
-                "color-string": "^1.5.2"
-              }
-            }
+          }
+        },
+        "js-tokens": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "lodash.clamp": {
+          "version": "4.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "loose-envify": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "js-tokens": "^3.0.0 || ^4.0.0"
+          }
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "prop-types": {
+          "version": "15.6.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.3.1",
+            "object-assign": "^4.1.1"
+          }
+        },
+        "react-transition-group": {
+          "version": "2.9.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "dom-helpers": "^3.4.0",
+            "loose-envify": "^1.4.0",
+            "prop-types": "^15.6.2",
+            "react-lifecycles-compat": "^3.0.4"
+          }
+        },
+        "recompose": {
+          "version": "0.30.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "change-emitter": "^0.1.2",
+            "fbjs": "^0.8.1",
+            "hoist-non-react-statics": "^2.3.1",
+            "react-lifecycles-compat": "^3.0.2",
+            "symbol-observable": "^1.0.4"
           }
         }
       }
@@ -4227,42 +7322,107 @@
       "version": "file:backpack/packages/bpk-component-pagination",
       "dev": true,
       "requires": {
-        "bpk-component-button": "^2.4.1",
-        "bpk-mixins": "^17.24.4",
+        "bpk-component-button": "^2.4.2",
+        "bpk-mixins": "^17.24.5",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
       },
       "dependencies": {
         "bpk-component-button": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/bpk-component-button/-/bpk-component-button-2.4.1.tgz",
-          "integrity": "sha512-4jJ5wxgquUUVGHpblXf0yWlpVFNtmDo0DjLMkGL5U4HxFIgc0XZp911KjIzUVeCh+3eGASeAthQgLCruQghzOg==",
+          "version": "2.4.2",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "bpk-mixins": "^17.24.4",
+            "bpk-mixins": "^17.24.5",
             "prop-types": "^15.6.2"
           }
         },
+        "bpk-component-icon": {
+          "version": "3.31.5",
+          "bundled": true
+        },
         "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
+          "version": "17.24.5",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
             "prop-types": "^15.6.2",
             "react-transition-group": "^2.5.3",
             "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        },
+        "js-tokens": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "loose-envify": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "js-tokens": "^3.0.0 || ^4.0.0"
+          }
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "prop-types": {
+          "version": "15.6.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.3.1",
+            "object-assign": "^4.1.1"
+          }
+        },
+        "react-transition-group": {
+          "version": "2.9.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "dom-helpers": "^3.4.0",
+            "loose-envify": "^1.4.0",
+            "prop-types": "^15.6.2",
+            "react-lifecycles-compat": "^3.0.4"
+          }
+        },
+        "recompose": {
+          "version": "0.30.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "change-emitter": "^0.1.2",
+            "fbjs": "^0.8.1",
+            "hoist-non-react-statics": "^2.3.1",
+            "react-lifecycles-compat": "^3.0.2",
+            "symbol-observable": "^1.0.4"
           }
         }
       }
@@ -4271,31 +7431,93 @@
       "version": "file:backpack/packages/bpk-component-panel",
       "dev": true,
       "requires": {
-        "bpk-mixins": "^17.24.4",
+        "bpk-mixins": "^17.24.5",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
       },
       "dependencies": {
         "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
+          "version": "17.24.5",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
             "prop-types": "^15.6.2",
             "react-transition-group": "^2.5.3",
             "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        },
+        "js-tokens": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "loose-envify": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "js-tokens": "^3.0.0 || ^4.0.0"
+          }
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "prop-types": {
+          "version": "15.6.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.3.1",
+            "object-assign": "^4.1.1"
+          }
+        },
+        "react-transition-group": {
+          "version": "2.9.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "dom-helpers": "^3.4.0",
+            "loose-envify": "^1.4.0",
+            "prop-types": "^15.6.2",
+            "react-lifecycles-compat": "^3.0.4"
+          }
+        },
+        "recompose": {
+          "version": "0.30.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "change-emitter": "^0.1.2",
+            "fbjs": "^0.8.1",
+            "hoist-non-react-statics": "^2.3.1",
+            "react-lifecycles-compat": "^3.0.2",
+            "symbol-observable": "^1.0.4"
           }
         }
       }
@@ -4304,75 +7526,536 @@
       "version": "file:backpack/packages/bpk-component-phone-input",
       "dev": true,
       "requires": {
-        "bpk-component-input": "^4.1.26",
-        "bpk-component-label": "^3.2.144",
-        "bpk-component-select": "^2.3.7",
-        "bpk-component-text": "^1.1.6",
-        "bpk-mixins": "^17.24.4",
+        "bpk-component-input": "^4.1.27",
+        "bpk-component-label": "^3.2.145",
+        "bpk-component-select": "^2.3.8",
+        "bpk-component-text": "^1.1.7",
+        "bpk-mixins": "^17.24.5",
         "bpk-react-utils": "^2.7.9",
-        "bpk-tokens": "^27.6.4",
+        "bpk-tokens": "^27.6.5",
         "prop-types": "^15.6.2"
       },
       "dependencies": {
-        "bpk-component-input": {
-          "version": "4.1.26",
-          "resolved": "https://registry.npmjs.org/bpk-component-input/-/bpk-component-input-4.1.26.tgz",
-          "integrity": "sha512-+5P8u4+tmf+pABR9fhqDvMcVDaThFZgiEk9yPOcv0m9rgPZMzWXxOcEpN7Wzr2fdW6P/kCAtFA0jwUKtuzEyWQ==",
+        "bpk-component-fieldset": {
+          "version": "1.1.113",
+          "bundled": true,
+          "requires": {
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          },
+          "dependencies": {
+            "bpk-animate-height": {
+              "version": "1.1.113",
+              "bundled": true,
+              "requires": {
+                "prop-types": "^15.6.2"
+              }
+            },
+            "bpk-component-checkbox": {
+              "version": "1.4.110",
+              "bundled": true,
+              "requires": {
+                "bpk-react-utils": "^2.7.9",
+                "prop-types": "^15.6.2"
+              },
+              "dependencies": {
+                "bpk-component-icon": {
+                  "version": "3.31.4",
+                  "bundled": true,
+                  "requires": {
+                    "bpk-mixins": "^17.24.4",
+                    "bpk-react-utils": "^2.7.9",
+                    "bpk-svgs": "^6.9.2",
+                    "bpk-tokens": "^27.6.4",
+                    "prop-types": "^15.6.2"
+                  }
+                },
+                "bpk-mixins": {
+                  "version": "17.24.4",
+                  "bundled": true,
+                  "requires": {
+                    "bpk-svgs": "^6.9.2",
+                    "bpk-tokens": "^27.6.4"
+                  }
+                },
+                "bpk-react-utils": {
+                  "version": "2.7.9",
+                  "bundled": true,
+                  "requires": {
+                    "object-assign": "^4.1.1",
+                    "prop-types": "^15.6.2"
+                  }
+                },
+                "bpk-svgs": {
+                  "version": "6.9.3",
+                  "bundled": true
+                },
+                "bpk-tokens": {
+                  "version": "27.6.5",
+                  "bundled": true
+                },
+                "js-tokens": {
+                  "version": "4.0.0",
+                  "bundled": true
+                },
+                "loose-envify": {
+                  "version": "1.4.0",
+                  "bundled": true,
+                  "requires": {
+                    "js-tokens": "^3.0.0 || ^4.0.0"
+                  }
+                },
+                "object-assign": {
+                  "version": "4.1.1",
+                  "bundled": true
+                },
+                "prop-types": {
+                  "version": "15.6.2",
+                  "bundled": true,
+                  "requires": {
+                    "loose-envify": "^1.3.1",
+                    "object-assign": "^4.1.1"
+                  }
+                }
+              }
+            },
+            "bpk-component-form-validation": {
+              "version": "2.0.26",
+              "bundled": true,
+              "requires": {
+                "bpk-animate-height": "^1.1.112",
+                "bpk-mixins": "^17.24.4",
+                "bpk-react-utils": "^2.7.9",
+                "prop-types": "^15.6.2"
+              },
+              "dependencies": {
+                "bpk-animate-height": {
+                  "version": "1.1.112",
+                  "bundled": true,
+                  "requires": {
+                    "prop-types": "^15.6.2"
+                  }
+                },
+                "bpk-component-button": {
+                  "version": "",
+                  "bundled": true
+                },
+                "bpk-component-icon": {
+                  "version": "",
+                  "bundled": true
+                },
+                "bpk-mixins": {
+                  "version": "17.24.4",
+                  "bundled": true,
+                  "requires": {
+                    "bpk-svgs": "^6.9.2",
+                    "bpk-tokens": "^27.6.4"
+                  }
+                },
+                "bpk-react-utils": {
+                  "version": "2.7.9",
+                  "bundled": true
+                },
+                "bpk-svgs": {
+                  "version": "6.9.3",
+                  "bundled": true
+                },
+                "bpk-tokens": {
+                  "version": "27.6.5",
+                  "bundled": true
+                },
+                "js-tokens": {
+                  "version": "4.0.0",
+                  "bundled": true
+                },
+                "loose-envify": {
+                  "version": "1.4.0",
+                  "bundled": true,
+                  "requires": {
+                    "js-tokens": "^3.0.0 || ^4.0.0"
+                  }
+                },
+                "object-assign": {
+                  "version": "4.1.1",
+                  "bundled": true
+                },
+                "prop-types": {
+                  "version": "15.6.2",
+                  "bundled": true,
+                  "requires": {
+                    "loose-envify": "^1.3.1",
+                    "object-assign": "^4.1.1"
+                  }
+                }
+              }
+            },
+            "bpk-component-input": {
+              "version": "4.1.27",
+              "bundled": true
+            },
+            "bpk-component-label": {
+              "version": "3.2.144",
+              "bundled": true,
+              "requires": {
+                "bpk-mixins": "^17.24.4",
+                "bpk-react-utils": "^2.7.9",
+                "prop-types": "^15.6.2"
+              },
+              "dependencies": {
+                "bpk-mixins": {
+                  "version": "17.24.4",
+                  "bundled": true,
+                  "requires": {
+                    "bpk-svgs": "^6.9.2",
+                    "bpk-tokens": "^27.6.4"
+                  }
+                },
+                "bpk-react-utils": {
+                  "version": "2.7.9",
+                  "bundled": true
+                },
+                "bpk-svgs": {
+                  "version": "6.9.3",
+                  "bundled": true
+                },
+                "bpk-tokens": {
+                  "version": "27.6.5",
+                  "bundled": true
+                },
+                "js-tokens": {
+                  "version": "4.0.0",
+                  "bundled": true
+                },
+                "loose-envify": {
+                  "version": "1.4.0",
+                  "bundled": true,
+                  "requires": {
+                    "js-tokens": "^3.0.0 || ^4.0.0"
+                  }
+                },
+                "object-assign": {
+                  "version": "4.1.1",
+                  "bundled": true
+                },
+                "prop-types": {
+                  "version": "15.6.2",
+                  "bundled": true,
+                  "requires": {
+                    "loose-envify": "^1.3.1",
+                    "object-assign": "^4.1.1"
+                  }
+                }
+              }
+            },
+            "bpk-component-select": {
+              "version": "2.3.8",
+              "bundled": true
+            },
+            "bpk-mixins": {
+              "version": "17.24.4",
+              "bundled": true,
+              "requires": {
+                "bpk-svgs": "^6.9.2",
+                "bpk-tokens": "^27.6.4"
+              }
+            },
+            "bpk-react-utils": {
+              "version": "2.7.9",
+              "bundled": true,
+              "requires": {
+                "object-assign": "^4.1.1",
+                "prop-types": "^15.6.2"
+              }
+            },
+            "bpk-svgs": {
+              "version": "6.9.3",
+              "bundled": true
+            },
+            "bpk-tokens": {
+              "version": "27.6.5",
+              "bundled": true
+            },
+            "js-tokens": {
+              "version": "4.0.0",
+              "bundled": true
+            },
+            "loose-envify": {
+              "version": "1.4.0",
+              "bundled": true,
+              "requires": {
+                "js-tokens": "^3.0.0 || ^4.0.0"
+              }
+            },
+            "object-assign": {
+              "version": "4.1.1",
+              "bundled": true
+            },
+            "prop-types": {
+              "version": "15.6.2",
+              "bundled": true,
+              "requires": {
+                "loose-envify": "^1.3.1",
+                "object-assign": "^4.1.1"
+              }
+            }
+          }
+        },
+        "bpk-component-icon": {
+          "version": "3.31.5",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "bpk-component-icon": "^3.31.4",
-            "bpk-mixins": "^17.24.4",
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5",
+            "prop-types": "^15.6.2"
+          },
+          "dependencies": {
+            "bpk-mixins": {
+              "version": "17.24.5",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "bpk-svgs": "^6.9.3",
+                "bpk-tokens": "^27.6.5"
+              }
+            },
+            "bpk-tokens": {
+              "version": "27.6.5",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "color": "^3.0.0"
+              }
+            }
+          }
+        },
+        "bpk-component-image": {
+          "version": "2.2.8",
+          "bundled": true,
+          "requires": {
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3"
+          },
+          "dependencies": {
+            "@babel/runtime": {
+              "version": "7.5.5",
+              "bundled": true,
+              "requires": {
+                "regenerator-runtime": "^0.13.2"
+              }
+            },
+            "bpk-component-mobile-scroll-container": {
+              "version": "1.1.82",
+              "bundled": true,
+              "requires": {
+                "bpk-react-utils": "^2.7.9"
+              },
+              "dependencies": {
+                "bpk-react-utils": {
+                  "version": "2.7.9",
+                  "bundled": true
+                }
+              }
+            },
+            "bpk-component-spinner": {
+              "version": "2.2.106",
+              "bundled": true,
+              "requires": {
+                "bpk-mixins": "^17.24.4",
+                "bpk-react-utils": "^2.7.9",
+                "bpk-svgs": "^6.9.2",
+                "prop-types": "^15.6.2"
+              },
+              "dependencies": {
+                "bpk-mixins": {
+                  "version": "17.24.4",
+                  "bundled": true,
+                  "requires": {
+                    "bpk-svgs": "^6.9.2",
+                    "bpk-tokens": "^27.6.4"
+                  }
+                },
+                "bpk-react-utils": {
+                  "version": "2.7.9",
+                  "bundled": true
+                },
+                "bpk-svgs": {
+                  "version": "6.9.2",
+                  "bundled": true
+                },
+                "bpk-tokens": {
+                  "version": "27.6.5",
+                  "bundled": true
+                },
+                "js-tokens": {
+                  "version": "4.0.0",
+                  "bundled": true
+                },
+                "loose-envify": {
+                  "version": "1.4.0",
+                  "bundled": true,
+                  "requires": {
+                    "js-tokens": "^3.0.0 || ^4.0.0"
+                  }
+                },
+                "object-assign": {
+                  "version": "4.1.1",
+                  "bundled": true
+                },
+                "prop-types": {
+                  "version": "15.6.2",
+                  "bundled": true,
+                  "requires": {
+                    "loose-envify": "^1.3.1",
+                    "object-assign": "^4.1.1"
+                  }
+                }
+              }
+            },
+            "bpk-component-text": {
+              "version": "1.1.7",
+              "bundled": true,
+              "requires": {
+                "bpk-react-utils": "^2.7.9"
+              },
+              "dependencies": {
+                "bpk-react-utils": {
+                  "version": "2.7.9",
+                  "bundled": true
+                }
+              }
+            },
+            "bpk-mixins": {
+              "version": "17.24.4",
+              "bundled": true,
+              "requires": {
+                "bpk-svgs": "^6.9.2",
+                "bpk-tokens": "^27.6.4"
+              }
+            },
+            "bpk-react-utils": {
+              "version": "2.7.9",
+              "bundled": true,
+              "requires": {
+                "object-assign": "^4.1.1",
+                "prop-types": "^15.6.2",
+                "react-transition-group": "^2.5.3"
+              }
+            },
+            "bpk-svgs": {
+              "version": "6.9.3",
+              "bundled": true
+            },
+            "bpk-tokens": {
+              "version": "27.6.5",
+              "bundled": true
+            },
+            "dom-helpers": {
+              "version": "3.4.0",
+              "bundled": true,
+              "requires": {
+                "@babel/runtime": "^7.1.2"
+              }
+            },
+            "js-tokens": {
+              "version": "4.0.0",
+              "bundled": true
+            },
+            "loose-envify": {
+              "version": "1.4.0",
+              "bundled": true,
+              "requires": {
+                "js-tokens": "^3.0.0 || ^4.0.0"
+              }
+            },
+            "object-assign": {
+              "version": "4.1.1",
+              "bundled": true
+            },
+            "prop-types": {
+              "version": "15.6.2",
+              "bundled": true,
+              "requires": {
+                "loose-envify": "^1.3.1",
+                "object-assign": "^4.1.1"
+              }
+            },
+            "react-lifecycles-compat": {
+              "version": "3.0.4",
+              "bundled": true
+            },
+            "react-transition-group": {
+              "version": "2.9.0",
+              "bundled": true,
+              "requires": {
+                "dom-helpers": "^3.4.0",
+                "loose-envify": "^1.4.0",
+                "prop-types": "^15.6.2",
+                "react-lifecycles-compat": "^3.0.4"
+              }
+            },
+            "regenerator-runtime": {
+              "version": "0.13.3",
+              "bundled": true
+            }
+          }
+        },
+        "bpk-component-input": {
+          "version": "4.1.27",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-component-icon": "^3.31.5",
+            "bpk-mixins": "^17.24.5",
             "bpk-react-utils": "^2.7.9",
             "prop-types": "^15.6.2"
           }
         },
         "bpk-component-label": {
-          "version": "3.2.144",
-          "resolved": "https://registry.npmjs.org/bpk-component-label/-/bpk-component-label-3.2.144.tgz",
-          "integrity": "sha512-78mIbPwaeOwidu76SlPVo4fJG6d7kfSQ2JGlvZ4yU70it793xmj/ll0E2+PcAaAWoeNTVwreQmctg/RkwgNTRQ==",
+          "version": "3.2.145",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "bpk-mixins": "^17.24.4",
+            "bpk-mixins": "^17.24.5",
             "bpk-react-utils": "^2.7.9",
             "prop-types": "^15.6.2"
           }
         },
         "bpk-component-select": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/bpk-component-select/-/bpk-component-select-2.3.7.tgz",
-          "integrity": "sha512-5A3duQQ58GmdgHfI8GCvbMA8b8IzyUh+b+7mRQVR0NBCqY2HUL1rrjly95ejfZx1OhUWfEwwYU3fAOFgpj6o3A==",
+          "version": "2.3.8",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "bpk-mixins": "^17.24.4",
+            "bpk-mixins": "^17.24.5",
             "bpk-react-utils": "^2.7.9",
             "prop-types": "^15.6.2"
           }
         },
         "bpk-component-text": {
-          "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/bpk-component-text/-/bpk-component-text-1.1.6.tgz",
-          "integrity": "sha512-U4wp5+Fz1Rd9LeJphQRKwKx2ekIbzGj0SFdvjDkVOkG120YVtVb4YQN/3xEl/zb7Csku5HLvkJIJK4C+wR22nQ==",
+          "version": "1.1.7",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "bpk-mixins": "^17.24.4",
+            "bpk-mixins": "^17.24.5",
             "bpk-react-utils": "^2.7.9",
             "prop-types": "^15.6.2"
           }
         },
         "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
+          "version": "17.24.5",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
@@ -4381,25 +8064,68 @@
             "recompose": "^0.30.0"
           }
         },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
         "bpk-tokens": {
-          "version": "27.6.4",
-          "resolved": "https://registry.npmjs.org/bpk-tokens/-/bpk-tokens-27.6.4.tgz",
-          "integrity": "sha512-/7BXdfw5Ft2UxkpLlme4x2TXoTEtITeJX1IzxqdgKZF0+fb+WT4SywoO0g9iM/nfQ1893ZEdNkG25u49v43dsQ==",
+          "version": "27.6.5",
+          "bundled": true,
           "dev": true,
           "requires": {
             "color": "^3.0.0"
-          },
-          "dependencies": {
-            "color": {
-              "version": "3.1.2",
-              "resolved": "https://registry.npmjs.org/color/-/color-3.1.2.tgz",
-              "integrity": "sha512-vXTJhHebByxZn3lDvDJYw4lR5+uB3vuoHsuYA5AKuxRVn5wzzIfQKGLBmgdVRHKTJYeK5rvJcHnrd0Li49CFpg==",
-              "dev": true,
-              "requires": {
-                "color-convert": "^1.9.1",
-                "color-string": "^1.5.2"
-              }
-            }
+          }
+        },
+        "js-tokens": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "loose-envify": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "js-tokens": "^3.0.0 || ^4.0.0"
+          }
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "prop-types": {
+          "version": "15.6.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.3.1",
+            "object-assign": "^4.1.1"
+          }
+        },
+        "react-transition-group": {
+          "version": "2.9.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "dom-helpers": "^3.4.0",
+            "loose-envify": "^1.4.0",
+            "prop-types": "^15.6.2",
+            "react-lifecycles-compat": "^3.0.4"
+          }
+        },
+        "recompose": {
+          "version": "0.30.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "change-emitter": "^0.1.2",
+            "fbjs": "^0.8.1",
+            "hoist-non-react-statics": "^2.3.1",
+            "react-lifecycles-compat": "^3.0.2",
+            "symbol-observable": "^1.0.4"
           }
         }
       }
@@ -4411,68 +8137,90 @@
         "@skyscanner/popper.js": "^1.12.9-beta.1",
         "a11y-focus-scope": "^1.1.3",
         "a11y-focus-store": "^1.0.0",
-        "bpk-component-close-button": "^1.0.141",
-        "bpk-component-link": "^1.2.75",
-        "bpk-component-text": "^1.1.6",
-        "bpk-mixins": "^17.24.4",
+        "bpk-component-close-button": "^1.0.142",
+        "bpk-component-link": "^1.2.76",
+        "bpk-component-text": "^1.1.7",
+        "bpk-mixins": "^17.24.5",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
       },
       "dependencies": {
         "bpk-component-close-button": {
-          "version": "1.0.141",
-          "resolved": "https://registry.npmjs.org/bpk-component-close-button/-/bpk-component-close-button-1.0.141.tgz",
-          "integrity": "sha512-Yd2kQnwuEQ3Myoqk2z/NDVIxB3YebCZrtgFJlQ/C6otp3sH3lbWLg4INREQqAyK1ZU5GK96qhvneubMA1tPLqQ==",
+          "version": "1.0.142",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "bpk-component-icon": "^3.31.4",
-            "bpk-mixins": "^17.24.4",
+            "bpk-component-icon": "^3.31.5",
+            "bpk-mixins": "^17.24.5",
             "bpk-react-utils": "^2.7.9",
             "prop-types": "^15.6.2"
           }
         },
-        "bpk-component-link": {
-          "version": "1.2.75",
-          "resolved": "https://registry.npmjs.org/bpk-component-link/-/bpk-component-link-1.2.75.tgz",
-          "integrity": "sha512-qoosptvwz8ZjxRt2WvoERb2E71zrBhs5+USNjy6FtDl+cXndmMOsINB1JiAmMB9TO6PgUZJkj7FBN7Vm7rZ+bQ==",
+        "bpk-component-icon": {
+          "version": "3.31.5",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "bpk-mixins": "^17.24.4",
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-link": {
+          "version": "1.2.76",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
             "bpk-react-utils": "^2.7.9",
             "prop-types": "^15.6.2"
           }
         },
         "bpk-component-text": {
-          "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/bpk-component-text/-/bpk-component-text-1.1.6.tgz",
-          "integrity": "sha512-U4wp5+Fz1Rd9LeJphQRKwKx2ekIbzGj0SFdvjDkVOkG120YVtVb4YQN/3xEl/zb7Csku5HLvkJIJK4C+wR22nQ==",
+          "version": "1.1.7",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "bpk-mixins": "^17.24.4",
+            "bpk-mixins": "^17.24.5",
             "bpk-react-utils": "^2.7.9",
             "prop-types": "^15.6.2"
           }
         },
-        "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
-          }
-        },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
             "prop-types": "^15.6.2",
             "react-transition-group": "^2.5.3",
             "recompose": "^0.30.0"
+          }
+        },
+        "react-transition-group": {
+          "version": "2.9.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "dom-helpers": "^3.4.0",
+            "loose-envify": "^1.4.0",
+            "prop-types": "^15.6.2",
+            "react-lifecycles-compat": "^3.0.4"
+          }
+        },
+        "recompose": {
+          "version": "0.30.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "change-emitter": "^0.1.2",
+            "fbjs": "^0.8.1",
+            "hoist-non-react-statics": "^2.3.1",
+            "react-lifecycles-compat": "^3.0.2",
+            "symbol-observable": "^1.0.4"
           }
         }
       }
@@ -4481,414 +8229,29 @@
       "version": "file:backpack/packages/bpk-component-progress",
       "dev": true,
       "requires": {
-        "bpk-mixins": "^17.24.4",
+        "bpk-mixins": "^17.24.5",
         "bpk-react-utils": "^2.7.9",
-        "bpk-tokens": "^27.6.4",
+        "bpk-tokens": "^27.6.5",
         "lodash.clamp": "^4.0.3",
         "prop-types": "^15.6.2"
       },
       "dependencies": {
-        "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        },
-        "bpk-tokens": {
-          "version": "27.6.4",
-          "resolved": "https://registry.npmjs.org/bpk-tokens/-/bpk-tokens-27.6.4.tgz",
-          "integrity": "sha512-/7BXdfw5Ft2UxkpLlme4x2TXoTEtITeJX1IzxqdgKZF0+fb+WT4SywoO0g9iM/nfQ1893ZEdNkG25u49v43dsQ==",
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
-          },
-          "dependencies": {
-            "color": {
-              "version": "3.1.2",
-              "resolved": "https://registry.npmjs.org/color/-/color-3.1.2.tgz",
-              "integrity": "sha512-vXTJhHebByxZn3lDvDJYw4lR5+uB3vuoHsuYA5AKuxRVn5wzzIfQKGLBmgdVRHKTJYeK5rvJcHnrd0Li49CFpg==",
-              "dev": true,
-              "requires": {
-                "color-convert": "^1.9.1",
-                "color-string": "^1.5.2"
-              }
-            }
-          }
-        }
-      }
-    },
-    "bpk-component-radio": {
-      "version": "file:backpack/packages/bpk-component-radio",
-      "dev": true,
-      "requires": {
-        "bpk-mixins": "^17.24.4",
-        "bpk-react-utils": "^2.7.9",
-        "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        }
-      }
-    },
-    "bpk-component-router-link": {
-      "version": "file:backpack/packages/bpk-component-router-link",
-      "dev": true,
-      "requires": {
-        "bpk-mixins": "^17.24.4",
-        "bpk-react-utils": "^2.7.9",
-        "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        }
-      }
-    },
-    "bpk-component-rtl-toggle": {
-      "version": "file:backpack/packages/bpk-component-rtl-toggle",
-      "dev": true,
-      "requires": {
-        "bpk-component-link": "^1.2.75",
-        "bpk-react-utils": "^2.7.9",
-        "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-component-link": {
-          "version": "1.2.75",
-          "resolved": "https://registry.npmjs.org/bpk-component-link/-/bpk-component-link-1.2.75.tgz",
-          "integrity": "sha512-qoosptvwz8ZjxRt2WvoERb2E71zrBhs5+USNjy6FtDl+cXndmMOsINB1JiAmMB9TO6PgUZJkj7FBN7Vm7rZ+bQ==",
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.4",
-            "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        }
-      }
-    },
-    "bpk-component-scrollable-calendar": {
-      "version": "file:backpack/packages/bpk-component-scrollable-calendar",
-      "dev": true,
-      "requires": {
-        "bpk-component-calendar": "^5.0.26",
-        "bpk-component-text": "^1.1.6",
-        "bpk-mixins": "^17.24.4",
-        "bpk-react-utils": "^2.7.9",
-        "prop-types": "^15.5.8",
-        "react-window": "^1.5.0"
-      },
-      "dependencies": {
-        "bpk-component-calendar": {
-          "version": "5.0.26",
-          "resolved": "https://registry.npmjs.org/bpk-component-calendar/-/bpk-component-calendar-5.0.26.tgz",
-          "integrity": "sha512-eBo5tfZyTczqZn0EH5Xv1Weahf1S/hR92PpZlJV3GPs7yMrYsf0C+Bxn1edkvCKZu4lX83bl2Er6zfPAgfkUdg==",
-          "dev": true,
-          "requires": {
-            "bpk-component-icon": "^3.31.4",
-            "bpk-component-select": "^2.3.7",
-            "bpk-mixins": "^17.24.4",
-            "bpk-react-utils": "^2.7.9",
-            "bpk-tokens": "^27.6.4",
-            "date-fns": "^1.29.0",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-component-text": {
-          "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/bpk-component-text/-/bpk-component-text-1.1.6.tgz",
-          "integrity": "sha512-U4wp5+Fz1Rd9LeJphQRKwKx2ekIbzGj0SFdvjDkVOkG120YVtVb4YQN/3xEl/zb7Csku5HLvkJIJK4C+wR22nQ==",
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.4",
-            "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
-          }
+        "bpk-component-button": {
+          "version": "2.4.2",
+          "bundled": true
         },
         "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
+          "version": "17.24.5",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        }
-      }
-    },
-    "bpk-component-section-list": {
-      "version": "file:backpack/packages/bpk-component-section-list",
-      "dev": true,
-      "requires": {
-        "bpk-component-icon": "^3.31.4",
-        "bpk-component-text": "^1.1.6",
-        "bpk-mixins": "^17.24.4",
-        "bpk-react-utils": "^2.7.9",
-        "bpk-tokens": "^27.6.4",
-        "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-component-icon": {
-          "version": "3.31.4",
-          "resolved": "https://registry.npmjs.org/bpk-component-icon/-/bpk-component-icon-3.31.4.tgz",
-          "integrity": "sha512-DAiwhBYyyFmy2jonUFxEtxLpj2RlN17EDgd1zwZGpjfIhryyA+vL4XlSr8EkfPjZ6z+I6NWwbfmEUqDZgrn7Ag==",
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.4",
-            "bpk-react-utils": "^2.7.9",
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-component-text": {
-          "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/bpk-component-text/-/bpk-component-text-1.1.6.tgz",
-          "integrity": "sha512-U4wp5+Fz1Rd9LeJphQRKwKx2ekIbzGj0SFdvjDkVOkG120YVtVb4YQN/3xEl/zb7Csku5HLvkJIJK4C+wR22nQ==",
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.4",
-            "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        },
-        "bpk-tokens": {
-          "version": "27.6.4",
-          "resolved": "https://registry.npmjs.org/bpk-tokens/-/bpk-tokens-27.6.4.tgz",
-          "integrity": "sha512-/7BXdfw5Ft2UxkpLlme4x2TXoTEtITeJX1IzxqdgKZF0+fb+WT4SywoO0g9iM/nfQ1893ZEdNkG25u49v43dsQ==",
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
-          },
-          "dependencies": {
-            "color": {
-              "version": "3.1.2",
-              "resolved": "https://registry.npmjs.org/color/-/color-3.1.2.tgz",
-              "integrity": "sha512-vXTJhHebByxZn3lDvDJYw4lR5+uB3vuoHsuYA5AKuxRVn5wzzIfQKGLBmgdVRHKTJYeK5rvJcHnrd0Li49CFpg==",
-              "dev": true,
-              "requires": {
-                "color-convert": "^1.9.1",
-                "color-string": "^1.5.2"
-              }
-            }
-          }
-        }
-      }
-    },
-    "bpk-component-select": {
-      "version": "file:backpack/packages/bpk-component-select",
-      "dev": true,
-      "requires": {
-        "bpk-mixins": "^17.24.4",
-        "bpk-react-utils": "^2.7.9",
-        "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        }
-      }
-    },
-    "bpk-component-slider": {
-      "version": "file:backpack/packages/bpk-component-slider",
-      "dev": true,
-      "requires": {
-        "bpk-mixins": "^17.24.4",
-        "bpk-react-utils": "^2.7.9",
-        "bpk-tokens": "^27.6.4",
-        "prop-types": "^15.6.2",
-        "react-slider": "^0.11.2"
-      },
-      "dependencies": {
-        "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        },
-        "bpk-tokens": {
-          "version": "27.6.4",
-          "resolved": "https://registry.npmjs.org/bpk-tokens/-/bpk-tokens-27.6.4.tgz",
-          "integrity": "sha512-/7BXdfw5Ft2UxkpLlme4x2TXoTEtITeJX1IzxqdgKZF0+fb+WT4SywoO0g9iM/nfQ1893ZEdNkG25u49v43dsQ==",
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
-          },
-          "dependencies": {
-            "color": {
-              "version": "3.1.2",
-              "resolved": "https://registry.npmjs.org/color/-/color-3.1.2.tgz",
-              "integrity": "sha512-vXTJhHebByxZn3lDvDJYw4lR5+uB3vuoHsuYA5AKuxRVn5wzzIfQKGLBmgdVRHKTJYeK5rvJcHnrd0Li49CFpg==",
-              "dev": true,
-              "requires": {
-                "color-convert": "^1.9.1",
-                "color-string": "^1.5.2"
-              }
-            }
-          }
-        }
-      }
-    },
-    "bpk-component-spinner": {
-      "version": "file:backpack/packages/bpk-component-spinner",
-      "dev": true,
-      "requires": {
-        "bpk-mixins": "^17.24.4",
-        "bpk-react-utils": "^2.7.9",
-        "bpk-svgs": "^6.9.2",
-        "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
@@ -4898,10 +8261,991 @@
           }
         },
         "bpk-svgs": {
-          "version": "6.9.2",
-          "resolved": "https://registry.npmjs.org/bpk-svgs/-/bpk-svgs-6.9.2.tgz",
-          "integrity": "sha512-gicoSPPzsQVc0eBUtpn0vGfs/azztQIsA5IDeJaW50G1MHst9C7KBUdegnf64oRwjuVRZbdXsTz5I7h1UqgXKA==",
+          "version": "6.9.3",
+          "bundled": true,
           "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        },
+        "js-tokens": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "lodash.clamp": {
+          "version": "4.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "loose-envify": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "js-tokens": "^3.0.0 || ^4.0.0"
+          }
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "prop-types": {
+          "version": "15.6.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.3.1",
+            "object-assign": "^4.1.1"
+          }
+        },
+        "react-transition-group": {
+          "version": "2.9.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "dom-helpers": "^3.4.0",
+            "loose-envify": "^1.4.0",
+            "prop-types": "^15.6.2",
+            "react-lifecycles-compat": "^3.0.4"
+          }
+        },
+        "recompose": {
+          "version": "0.30.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "change-emitter": "^0.1.2",
+            "fbjs": "^0.8.1",
+            "hoist-non-react-statics": "^2.3.1",
+            "react-lifecycles-compat": "^3.0.2",
+            "symbol-observable": "^1.0.4"
+          }
+        }
+      }
+    },
+    "bpk-component-radio": {
+      "version": "file:backpack/packages/bpk-component-radio",
+      "dev": true,
+      "requires": {
+        "bpk-mixins": "^17.24.5",
+        "bpk-react-utils": "^2.7.9",
+        "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        },
+        "js-tokens": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "loose-envify": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "js-tokens": "^3.0.0 || ^4.0.0"
+          }
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "prop-types": {
+          "version": "15.6.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.3.1",
+            "object-assign": "^4.1.1"
+          }
+        },
+        "react-transition-group": {
+          "version": "2.9.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "dom-helpers": "^3.4.0",
+            "loose-envify": "^1.4.0",
+            "prop-types": "^15.6.2",
+            "react-lifecycles-compat": "^3.0.4"
+          }
+        },
+        "recompose": {
+          "version": "0.30.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "change-emitter": "^0.1.2",
+            "fbjs": "^0.8.1",
+            "hoist-non-react-statics": "^2.3.1",
+            "react-lifecycles-compat": "^3.0.2",
+            "symbol-observable": "^1.0.4"
+          }
+        }
+      }
+    },
+    "bpk-component-router-link": {
+      "version": "file:backpack/packages/bpk-component-router-link",
+      "dev": true,
+      "requires": {
+        "bpk-mixins": "^17.24.5",
+        "bpk-react-utils": "^2.7.9",
+        "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        },
+        "js-tokens": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "loose-envify": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "js-tokens": "^3.0.0 || ^4.0.0"
+          }
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "prop-types": {
+          "version": "15.6.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.3.1",
+            "object-assign": "^4.1.1"
+          }
+        },
+        "react-transition-group": {
+          "version": "2.9.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "dom-helpers": "^3.4.0",
+            "loose-envify": "^1.4.0",
+            "prop-types": "^15.6.2",
+            "react-lifecycles-compat": "^3.0.4"
+          }
+        },
+        "recompose": {
+          "version": "0.30.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "change-emitter": "^0.1.2",
+            "fbjs": "^0.8.1",
+            "hoist-non-react-statics": "^2.3.1",
+            "react-lifecycles-compat": "^3.0.2",
+            "symbol-observable": "^1.0.4"
+          }
+        }
+      }
+    },
+    "bpk-component-rtl-toggle": {
+      "version": "file:backpack/packages/bpk-component-rtl-toggle",
+      "dev": true,
+      "requires": {
+        "bpk-component-link": "^1.2.76",
+        "bpk-react-utils": "^2.7.9",
+        "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-component-link": {
+          "version": "1.2.76",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        },
+        "js-tokens": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "loose-envify": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "js-tokens": "^3.0.0 || ^4.0.0"
+          }
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "prop-types": {
+          "version": "15.6.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.3.1",
+            "object-assign": "^4.1.1"
+          }
+        },
+        "react-transition-group": {
+          "version": "2.9.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "dom-helpers": "^3.4.0",
+            "loose-envify": "^1.4.0",
+            "prop-types": "^15.6.2",
+            "react-lifecycles-compat": "^3.0.4"
+          }
+        },
+        "recompose": {
+          "version": "0.30.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "change-emitter": "^0.1.2",
+            "fbjs": "^0.8.1",
+            "hoist-non-react-statics": "^2.3.1",
+            "react-lifecycles-compat": "^3.0.2",
+            "symbol-observable": "^1.0.4"
+          }
+        }
+      }
+    },
+    "bpk-component-scrollable-calendar": {
+      "version": "file:backpack/packages/bpk-component-scrollable-calendar",
+      "dev": true,
+      "requires": {
+        "bpk-component-calendar": "^5.0.27",
+        "bpk-component-text": "^1.1.7",
+        "bpk-mixins": "^17.24.5",
+        "bpk-react-utils": "^2.7.9",
+        "prop-types": "^15.5.8",
+        "react-window": "^1.5.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.2.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.12.0"
+          },
+          "dependencies": {
+            "regenerator-runtime": {
+              "version": "0.12.1",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "bpk-component-calendar": {
+          "version": "5.0.27",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-component-icon": "^3.31.5",
+            "bpk-component-select": "^2.3.8",
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "bpk-tokens": "^27.6.5",
+            "date-fns": "^1.29.0",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-icon": {
+          "version": "3.31.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5",
+            "prop-types": "^15.6.2"
+          },
+          "dependencies": {
+            "bpk-mixins": {
+              "version": "17.24.5",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "bpk-svgs": "^6.9.3",
+                "bpk-tokens": "^27.6.5"
+              }
+            }
+          }
+        },
+        "bpk-component-select": {
+          "version": "2.3.8",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          },
+          "dependencies": {
+            "bpk-mixins": {
+              "version": "17.24.5",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "bpk-svgs": "^6.9.3",
+                "bpk-tokens": "^27.6.5"
+              }
+            }
+          }
+        },
+        "bpk-component-text": {
+          "version": "1.1.7",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        },
+        "js-tokens": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "loose-envify": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "js-tokens": "^3.0.0 || ^4.0.0"
+          }
+        },
+        "memoize-one": {
+          "version": "3.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "prop-types": {
+          "version": "15.6.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.3.1",
+            "object-assign": "^4.1.1"
+          }
+        },
+        "react-transition-group": {
+          "version": "2.9.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "dom-helpers": "^3.4.0",
+            "loose-envify": "^1.4.0",
+            "prop-types": "^15.6.2",
+            "react-lifecycles-compat": "^3.0.4"
+          }
+        },
+        "react-window": {
+          "version": "1.5.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "memoize-one": "^3.1.1"
+          }
+        },
+        "recompose": {
+          "version": "0.30.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "change-emitter": "^0.1.2",
+            "fbjs": "^0.8.1",
+            "hoist-non-react-statics": "^2.3.1",
+            "react-lifecycles-compat": "^3.0.2",
+            "symbol-observable": "^1.0.4"
+          }
+        }
+      }
+    },
+    "bpk-component-section-list": {
+      "version": "file:backpack/packages/bpk-component-section-list",
+      "dev": true,
+      "requires": {
+        "bpk-component-icon": "^3.31.5",
+        "bpk-component-text": "^1.1.7",
+        "bpk-mixins": "^17.24.5",
+        "bpk-react-utils": "^2.7.9",
+        "bpk-tokens": "^27.6.5",
+        "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-component-icon": {
+          "version": "3.31.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-component-text": {
+          "version": "1.1.7",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-mixins": "^17.24.5",
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        },
+        "js-tokens": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "loose-envify": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "js-tokens": "^3.0.0 || ^4.0.0"
+          }
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "prop-types": {
+          "version": "15.6.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.3.1",
+            "object-assign": "^4.1.1"
+          }
+        },
+        "react-transition-group": {
+          "version": "2.9.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "dom-helpers": "^3.4.0",
+            "loose-envify": "^1.4.0",
+            "prop-types": "^15.6.2",
+            "react-lifecycles-compat": "^3.0.4"
+          }
+        },
+        "recompose": {
+          "version": "0.30.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "change-emitter": "^0.1.2",
+            "fbjs": "^0.8.1",
+            "hoist-non-react-statics": "^2.3.1",
+            "react-lifecycles-compat": "^3.0.2",
+            "symbol-observable": "^1.0.4"
+          }
+        }
+      }
+    },
+    "bpk-component-select": {
+      "version": "file:backpack/packages/bpk-component-select",
+      "dev": true,
+      "requires": {
+        "bpk-mixins": "^17.24.5",
+        "bpk-react-utils": "^2.7.9",
+        "prop-types": "^15.6.2"
+      }
+    },
+    "bpk-component-slider": {
+      "version": "file:backpack/packages/bpk-component-slider",
+      "dev": true,
+      "requires": {
+        "bpk-mixins": "^17.24.5",
+        "bpk-react-utils": "^2.7.9",
+        "bpk-tokens": "^27.6.5",
+        "prop-types": "^15.6.2",
+        "react-slider": "^0.11.2"
+      },
+      "dependencies": {
+        "asap": {
+          "version": "2.0.6",
+          "bundled": true
+        },
+        "bpk-component-rtl-toggle": {
+          "version": "1.1.95",
+          "bundled": true,
+          "requires": {
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          },
+          "dependencies": {
+            "bpk-component-link": {
+              "version": "1.2.75",
+              "bundled": true,
+              "requires": {
+                "bpk-mixins": "^17.24.4",
+                "bpk-react-utils": "^2.7.9",
+                "prop-types": "^15.6.2"
+              }
+            },
+            "bpk-mixins": {
+              "version": "17.24.5",
+              "bundled": true,
+              "requires": {
+                "bpk-svgs": "^6.9.3",
+                "bpk-tokens": "^27.6.5"
+              }
+            },
+            "bpk-react-utils": {
+              "version": "2.7.9",
+              "bundled": true,
+              "requires": {
+                "object-assign": "^4.1.1",
+                "prop-types": "^15.6.2"
+              }
+            },
+            "bpk-svgs": {
+              "version": "6.9.3",
+              "bundled": true
+            },
+            "bpk-tokens": {
+              "version": "27.6.5",
+              "bundled": true
+            },
+            "js-tokens": {
+              "version": "4.0.0",
+              "bundled": true
+            },
+            "loose-envify": {
+              "version": "1.4.0",
+              "bundled": true,
+              "requires": {
+                "js-tokens": "^3.0.0 || ^4.0.0"
+              }
+            },
+            "object-assign": {
+              "version": "4.1.1",
+              "bundled": true
+            },
+            "prop-types": {
+              "version": "15.6.2",
+              "bundled": true,
+              "requires": {
+                "loose-envify": "^1.3.1",
+                "object-assign": "^4.1.1"
+              }
+            }
+          }
+        },
+        "bpk-mixins": {
+          "version": "17.24.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
+          }
+        },
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        },
+        "core-js": {
+          "version": "1.2.7",
+          "bundled": true
+        },
+        "create-react-class": {
+          "version": "15.6.3",
+          "bundled": true,
+          "requires": {
+            "fbjs": "^0.8.9",
+            "loose-envify": "^1.3.1",
+            "object-assign": "^4.1.1"
+          }
+        },
+        "encoding": {
+          "version": "0.1.12",
+          "bundled": true,
+          "requires": {
+            "iconv-lite": "~0.4.13"
+          }
+        },
+        "fbjs": {
+          "version": "0.8.17",
+          "bundled": true,
+          "requires": {
+            "core-js": "^1.0.0",
+            "isomorphic-fetch": "^2.1.1",
+            "loose-envify": "^1.0.0",
+            "object-assign": "^4.1.0",
+            "promise": "^7.1.1",
+            "setimmediate": "^1.0.5",
+            "ua-parser-js": "^0.7.18"
+          }
+        },
+        "iconv-lite": {
+          "version": "0.4.24",
+          "bundled": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        },
+        "is-stream": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "isomorphic-fetch": {
+          "version": "2.2.1",
+          "bundled": true,
+          "requires": {
+            "node-fetch": "^1.0.1",
+            "whatwg-fetch": ">=0.10.0"
+          }
+        },
+        "js-tokens": {
+          "version": "4.0.0",
+          "bundled": true
+        },
+        "loose-envify": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "js-tokens": "^3.0.0 || ^4.0.0"
+          }
+        },
+        "node-fetch": {
+          "version": "1.7.3",
+          "bundled": true,
+          "requires": {
+            "encoding": "^0.1.11",
+            "is-stream": "^1.0.1"
+          }
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true
+        },
+        "promise": {
+          "version": "7.3.1",
+          "bundled": true,
+          "requires": {
+            "asap": "~2.0.3"
+          }
+        },
+        "prop-types": {
+          "version": "15.6.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.3.1",
+            "object-assign": "^4.1.1"
+          }
+        },
+        "react-slider": {
+          "version": "0.11.2",
+          "bundled": true,
+          "dev": true
+        },
+        "react-transition-group": {
+          "version": "2.9.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "dom-helpers": "^3.4.0",
+            "loose-envify": "^1.4.0",
+            "prop-types": "^15.6.2",
+            "react-lifecycles-compat": "^3.0.4"
+          }
+        },
+        "recompose": {
+          "version": "0.30.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "change-emitter": "^0.1.2",
+            "fbjs": "^0.8.1",
+            "hoist-non-react-statics": "^2.3.1",
+            "react-lifecycles-compat": "^3.0.2",
+            "symbol-observable": "^1.0.4"
+          }
+        },
+        "safer-buffer": {
+          "version": "2.1.2",
+          "bundled": true
+        },
+        "setimmediate": {
+          "version": "1.0.5",
+          "bundled": true
+        },
+        "ua-parser-js": {
+          "version": "0.7.20",
+          "bundled": true
+        },
+        "whatwg-fetch": {
+          "version": "3.0.0",
+          "bundled": true
+        }
+      }
+    },
+    "bpk-component-spinner": {
+      "version": "file:backpack/packages/bpk-component-spinner",
+      "dev": true,
+      "requires": {
+        "bpk-mixins": "^17.24.5",
+        "bpk-react-utils": "^2.7.9",
+        "bpk-svgs": "^6.9.3",
+        "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "bpk-react-utils": {
+          "version": "2.7.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-transition-group": "^2.5.3",
+            "recompose": "^0.30.0"
+          }
+        },
+        "react-transition-group": {
+          "version": "2.9.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "dom-helpers": "^3.4.0",
+            "loose-envify": "^1.4.0",
+            "prop-types": "^15.6.2",
+            "react-lifecycles-compat": "^3.0.4"
+          }
+        },
+        "recompose": {
+          "version": "0.30.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "change-emitter": "^0.1.2",
+            "fbjs": "^0.8.1",
+            "hoist-non-react-statics": "^2.3.1",
+            "react-lifecycles-compat": "^3.0.2",
+            "symbol-observable": "^1.0.4"
+          }
         }
       }
     },
@@ -4909,45 +9253,163 @@
       "version": "file:backpack/packages/bpk-component-star-rating",
       "dev": true,
       "requires": {
-        "bpk-component-icon": "^3.31.4",
-        "bpk-mixins": "^17.24.4",
+        "bpk-component-icon": "^3.31.5",
+        "bpk-mixins": "^17.24.5",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
       },
       "dependencies": {
         "bpk-component-icon": {
-          "version": "3.31.4",
-          "resolved": "https://registry.npmjs.org/bpk-component-icon/-/bpk-component-icon-3.31.4.tgz",
-          "integrity": "sha512-DAiwhBYyyFmy2jonUFxEtxLpj2RlN17EDgd1zwZGpjfIhryyA+vL4XlSr8EkfPjZ6z+I6NWwbfmEUqDZgrn7Ag==",
+          "version": "3.31.5",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "bpk-mixins": "^17.24.4",
+            "bpk-mixins": "^17.24.5",
             "bpk-react-utils": "^2.7.9",
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4",
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5",
             "prop-types": "^15.6.2"
           }
         },
+        "bpk-component-table": {
+          "version": "1.1.81",
+          "bundled": true,
+          "requires": {
+            "bpk-react-utils": "^2.7.9",
+            "prop-types": "^15.6.2"
+          },
+          "dependencies": {
+            "bpk-mixins": {
+              "version": "17.24.4",
+              "bundled": true,
+              "requires": {
+                "bpk-svgs": "^6.9.2",
+                "bpk-tokens": "^27.6.4"
+              }
+            },
+            "bpk-react-utils": {
+              "version": "2.7.9",
+              "bundled": true,
+              "requires": {
+                "object-assign": "^4.1.1",
+                "prop-types": "^15.6.2"
+              }
+            },
+            "bpk-svgs": {
+              "version": "6.9.3",
+              "bundled": true
+            },
+            "bpk-tokens": {
+              "version": "27.6.5",
+              "bundled": true
+            },
+            "js-tokens": {
+              "version": "4.0.0",
+              "bundled": true
+            },
+            "loose-envify": {
+              "version": "1.4.0",
+              "bundled": true,
+              "requires": {
+                "js-tokens": "^3.0.0 || ^4.0.0"
+              }
+            },
+            "object-assign": {
+              "version": "4.1.1",
+              "bundled": true
+            },
+            "prop-types": {
+              "version": "15.6.2",
+              "bundled": true,
+              "requires": {
+                "loose-envify": "^1.3.1",
+                "object-assign": "^4.1.1"
+              }
+            }
+          }
+        },
         "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
+          "version": "17.24.5",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
             "prop-types": "^15.6.2",
             "react-transition-group": "^2.5.3",
             "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        },
+        "js-tokens": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "loose-envify": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "js-tokens": "^3.0.0 || ^4.0.0"
+          }
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "prop-types": {
+          "version": "15.6.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.3.1",
+            "object-assign": "^4.1.1"
+          }
+        },
+        "react-transition-group": {
+          "version": "2.9.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "dom-helpers": "^3.4.0",
+            "loose-envify": "^1.4.0",
+            "prop-types": "^15.6.2",
+            "react-lifecycles-compat": "^3.0.4"
+          }
+        },
+        "recompose": {
+          "version": "0.30.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "change-emitter": "^0.1.2",
+            "fbjs": "^0.8.1",
+            "hoist-non-react-statics": "^2.3.1",
+            "react-lifecycles-compat": "^3.0.2",
+            "symbol-observable": "^1.0.4"
           }
         }
       }
@@ -4956,31 +9418,93 @@
       "version": "file:backpack/packages/bpk-component-table",
       "dev": true,
       "requires": {
-        "bpk-mixins": "^17.24.4",
+        "bpk-mixins": "^17.24.5",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
       },
       "dependencies": {
         "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
+          "version": "17.24.5",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
             "prop-types": "^15.6.2",
             "react-transition-group": "^2.5.3",
             "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        },
+        "js-tokens": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "loose-envify": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "js-tokens": "^3.0.0 || ^4.0.0"
+          }
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "prop-types": {
+          "version": "15.6.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.3.1",
+            "object-assign": "^4.1.1"
+          }
+        },
+        "react-transition-group": {
+          "version": "2.9.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "dom-helpers": "^3.4.0",
+            "loose-envify": "^1.4.0",
+            "prop-types": "^15.6.2",
+            "react-lifecycles-compat": "^3.0.4"
+          }
+        },
+        "recompose": {
+          "version": "0.30.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "change-emitter": "^0.1.2",
+            "fbjs": "^0.8.1",
+            "hoist-non-react-statics": "^2.3.1",
+            "react-lifecycles-compat": "^3.0.2",
+            "symbol-observable": "^1.0.4"
           }
         }
       }
@@ -4989,31 +9513,44 @@
       "version": "file:backpack/packages/bpk-component-text",
       "dev": true,
       "requires": {
-        "bpk-mixins": "^17.24.4",
+        "bpk-mixins": "^17.24.5",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
       },
       "dependencies": {
-        "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
-          }
-        },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
             "prop-types": "^15.6.2",
             "react-transition-group": "^2.5.3",
             "recompose": "^0.30.0"
+          }
+        },
+        "react-transition-group": {
+          "version": "2.9.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "dom-helpers": "^3.4.0",
+            "loose-envify": "^1.4.0",
+            "prop-types": "^15.6.2",
+            "react-lifecycles-compat": "^3.0.4"
+          }
+        },
+        "recompose": {
+          "version": "0.30.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "change-emitter": "^0.1.2",
+            "fbjs": "^0.8.1",
+            "hoist-non-react-statics": "^2.3.1",
+            "react-lifecycles-compat": "^3.0.2",
+            "symbol-observable": "^1.0.4"
           }
         }
       }
@@ -5022,31 +9559,93 @@
       "version": "file:backpack/packages/bpk-component-textarea",
       "dev": true,
       "requires": {
-        "bpk-mixins": "^17.24.4",
+        "bpk-mixins": "^17.24.5",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
       },
       "dependencies": {
         "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
+          "version": "17.24.5",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
             "prop-types": "^15.6.2",
             "react-transition-group": "^2.5.3",
             "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        },
+        "js-tokens": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "loose-envify": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "js-tokens": "^3.0.0 || ^4.0.0"
+          }
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "prop-types": {
+          "version": "15.6.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.3.1",
+            "object-assign": "^4.1.1"
+          }
+        },
+        "react-transition-group": {
+          "version": "2.9.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "dom-helpers": "^3.4.0",
+            "loose-envify": "^1.4.0",
+            "prop-types": "^15.6.2",
+            "react-lifecycles-compat": "^3.0.4"
+          }
+        },
+        "recompose": {
+          "version": "0.30.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "change-emitter": "^0.1.2",
+            "fbjs": "^0.8.1",
+            "hoist-non-react-statics": "^2.3.1",
+            "react-lifecycles-compat": "^3.0.2",
+            "symbol-observable": "^1.0.4"
           }
         }
       }
@@ -5055,50 +9654,46 @@
       "version": "file:backpack/packages/bpk-component-theme-toggle",
       "dev": true,
       "requires": {
-        "bpk-component-label": "^3.2.144",
-        "bpk-component-select": "^2.3.7",
-        "bpk-mixins": "^17.24.4",
+        "bpk-component-label": "^3.2.145",
+        "bpk-component-select": "^2.3.8",
+        "bpk-mixins": "^17.24.5",
         "bpk-react-utils": "^2.7.9",
-        "bpk-tokens": "^27.6.4",
+        "bpk-tokens": "^27.6.5",
         "prop-types": "^15.6.2"
       },
       "dependencies": {
         "bpk-component-label": {
-          "version": "3.2.144",
-          "resolved": "https://registry.npmjs.org/bpk-component-label/-/bpk-component-label-3.2.144.tgz",
-          "integrity": "sha512-78mIbPwaeOwidu76SlPVo4fJG6d7kfSQ2JGlvZ4yU70it793xmj/ll0E2+PcAaAWoeNTVwreQmctg/RkwgNTRQ==",
+          "version": "3.2.145",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "bpk-mixins": "^17.24.4",
+            "bpk-mixins": "^17.24.5",
             "bpk-react-utils": "^2.7.9",
             "prop-types": "^15.6.2"
           }
         },
         "bpk-component-select": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/bpk-component-select/-/bpk-component-select-2.3.7.tgz",
-          "integrity": "sha512-5A3duQQ58GmdgHfI8GCvbMA8b8IzyUh+b+7mRQVR0NBCqY2HUL1rrjly95ejfZx1OhUWfEwwYU3fAOFgpj6o3A==",
+          "version": "2.3.8",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "bpk-mixins": "^17.24.4",
+            "bpk-mixins": "^17.24.5",
             "bpk-react-utils": "^2.7.9",
             "prop-types": "^15.6.2"
           }
         },
         "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
+          "version": "17.24.5",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
@@ -5107,25 +9702,68 @@
             "recompose": "^0.30.0"
           }
         },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
         "bpk-tokens": {
-          "version": "27.6.4",
-          "resolved": "https://registry.npmjs.org/bpk-tokens/-/bpk-tokens-27.6.4.tgz",
-          "integrity": "sha512-/7BXdfw5Ft2UxkpLlme4x2TXoTEtITeJX1IzxqdgKZF0+fb+WT4SywoO0g9iM/nfQ1893ZEdNkG25u49v43dsQ==",
+          "version": "27.6.5",
+          "bundled": true,
           "dev": true,
           "requires": {
             "color": "^3.0.0"
-          },
-          "dependencies": {
-            "color": {
-              "version": "3.1.2",
-              "resolved": "https://registry.npmjs.org/color/-/color-3.1.2.tgz",
-              "integrity": "sha512-vXTJhHebByxZn3lDvDJYw4lR5+uB3vuoHsuYA5AKuxRVn5wzzIfQKGLBmgdVRHKTJYeK5rvJcHnrd0Li49CFpg==",
-              "dev": true,
-              "requires": {
-                "color-convert": "^1.9.1",
-                "color-string": "^1.5.2"
-              }
-            }
+          }
+        },
+        "js-tokens": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "loose-envify": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "js-tokens": "^3.0.0 || ^4.0.0"
+          }
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "prop-types": {
+          "version": "15.6.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.3.1",
+            "object-assign": "^4.1.1"
+          }
+        },
+        "react-transition-group": {
+          "version": "2.9.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "dom-helpers": "^3.4.0",
+            "loose-envify": "^1.4.0",
+            "prop-types": "^15.6.2",
+            "react-lifecycles-compat": "^3.0.4"
+          }
+        },
+        "recompose": {
+          "version": "0.30.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "change-emitter": "^0.1.2",
+            "fbjs": "^0.8.1",
+            "hoist-non-react-statics": "^2.3.1",
+            "react-lifecycles-compat": "^3.0.2",
+            "symbol-observable": "^1.0.4"
           }
         }
       }
@@ -5134,31 +9772,101 @@
       "version": "file:backpack/packages/bpk-component-ticket",
       "dev": true,
       "requires": {
-        "bpk-mixins": "^17.24.4",
+        "bpk-mixins": "^17.24.5",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
       },
       "dependencies": {
+        "bpk-component-button": {
+          "version": "2.4.2",
+          "bundled": true
+        },
+        "bpk-component-icon": {
+          "version": "3.31.5",
+          "bundled": true
+        },
         "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
+          "version": "17.24.5",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
             "prop-types": "^15.6.2",
             "react-transition-group": "^2.5.3",
             "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        },
+        "js-tokens": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "loose-envify": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "js-tokens": "^3.0.0 || ^4.0.0"
+          }
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "prop-types": {
+          "version": "15.6.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.3.1",
+            "object-assign": "^4.1.1"
+          }
+        },
+        "react-transition-group": {
+          "version": "2.9.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "dom-helpers": "^3.4.0",
+            "loose-envify": "^1.4.0",
+            "prop-types": "^15.6.2",
+            "react-lifecycles-compat": "^3.0.4"
+          }
+        },
+        "recompose": {
+          "version": "0.30.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "change-emitter": "^0.1.2",
+            "fbjs": "^0.8.1",
+            "hoist-non-react-statics": "^2.3.1",
+            "react-lifecycles-compat": "^3.0.2",
+            "symbol-observable": "^1.0.4"
           }
         }
       }
@@ -5168,31 +9876,111 @@
       "dev": true,
       "requires": {
         "@skyscanner/popper.js": "^1.12.9-beta.1",
-        "bpk-mixins": "^17.24.4",
+        "bpk-mixins": "^17.24.5",
         "bpk-react-utils": "^2.7.9",
         "prop-types": "^15.6.2"
       },
       "dependencies": {
+        "@skyscanner/popper.js": {
+          "version": "1.12.9-beta.1",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-component-text": {
+          "version": "1.1.7",
+          "bundled": true,
+          "requires": {
+            "bpk-react-utils": "^2.7.9"
+          },
+          "dependencies": {
+            "bpk-react-utils": {
+              "version": "2.7.9",
+              "bundled": true
+            }
+          }
+        },
         "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
+          "version": "17.24.5",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
             "prop-types": "^15.6.2",
             "react-transition-group": "^2.5.3",
             "recompose": "^0.30.0"
+          }
+        },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bpk-tokens": {
+          "version": "27.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^3.0.0"
+          }
+        },
+        "js-tokens": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "loose-envify": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "js-tokens": "^3.0.0 || ^4.0.0"
+          }
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "prop-types": {
+          "version": "15.6.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.3.1",
+            "object-assign": "^4.1.1"
+          }
+        },
+        "react-transition-group": {
+          "version": "2.9.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "dom-helpers": "^3.4.0",
+            "loose-envify": "^1.4.0",
+            "prop-types": "^15.6.2",
+            "react-lifecycles-compat": "^3.0.4"
+          }
+        },
+        "recompose": {
+          "version": "0.30.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "change-emitter": "^0.1.2",
+            "fbjs": "^0.8.1",
+            "hoist-non-react-statics": "^2.3.1",
+            "react-lifecycles-compat": "^3.0.2",
+            "symbol-observable": "^1.0.4"
           }
         }
       }
@@ -5201,37 +9989,8 @@
       "version": "file:backpack/packages/bpk-mixins",
       "dev": true,
       "requires": {
-        "bpk-svgs": "^6.9.2",
-        "bpk-tokens": "^27.6.4"
-      },
-      "dependencies": {
-        "bpk-svgs": {
-          "version": "6.9.2",
-          "resolved": "https://registry.npmjs.org/bpk-svgs/-/bpk-svgs-6.9.2.tgz",
-          "integrity": "sha512-gicoSPPzsQVc0eBUtpn0vGfs/azztQIsA5IDeJaW50G1MHst9C7KBUdegnf64oRwjuVRZbdXsTz5I7h1UqgXKA==",
-          "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.4",
-          "resolved": "https://registry.npmjs.org/bpk-tokens/-/bpk-tokens-27.6.4.tgz",
-          "integrity": "sha512-/7BXdfw5Ft2UxkpLlme4x2TXoTEtITeJX1IzxqdgKZF0+fb+WT4SywoO0g9iM/nfQ1893ZEdNkG25u49v43dsQ==",
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
-          },
-          "dependencies": {
-            "color": {
-              "version": "3.1.2",
-              "resolved": "https://registry.npmjs.org/color/-/color-3.1.2.tgz",
-              "integrity": "sha512-vXTJhHebByxZn3lDvDJYw4lR5+uB3vuoHsuYA5AKuxRVn5wzzIfQKGLBmgdVRHKTJYeK5rvJcHnrd0Li49CFpg==",
-              "dev": true,
-              "requires": {
-                "color-convert": "^1.9.1",
-                "color-string": "^1.5.2"
-              }
-            }
-          }
-        }
+        "bpk-svgs": "^6.9.3",
+        "bpk-tokens": "^27.6.5"
       }
     },
     "bpk-react-utils": {
@@ -5242,47 +10001,81 @@
         "prop-types": "^15.6.2",
         "react-transition-group": "^2.5.3",
         "recompose": "^0.30.0"
+      },
+      "dependencies": {
+        "react-transition-group": {
+          "version": "2.9.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "dom-helpers": "^3.4.0",
+            "loose-envify": "^1.4.0",
+            "prop-types": "^15.6.2",
+            "react-lifecycles-compat": "^3.0.4"
+          }
+        },
+        "recompose": {
+          "version": "0.30.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "change-emitter": "^0.1.2",
+            "fbjs": "^0.8.1",
+            "hoist-non-react-statics": "^2.3.1",
+            "react-lifecycles-compat": "^3.0.2",
+            "symbol-observable": "^1.0.4"
+          }
+        }
+      }
+    },
+    "bpk-scrim-utils": {
+      "version": "3.2.76",
+      "resolved": "https://registry.npmjs.org/bpk-scrim-utils/-/bpk-scrim-utils-3.2.76.tgz",
+      "integrity": "sha512-aDl5SN+smHgLXYf2IzjOKnmgNlxQVZ8tNR/uxlpzld5Uigl55eBlzJ+IfMVZlMIHmN0esm8xX2qpnEhG0jTkyw==",
+      "dev": true,
+      "requires": {
+        "a11y-focus-scope": "^1.1.3",
+        "a11y-focus-store": "^1.0.0",
+        "bpk-mixins": "^17.24.5",
+        "bpk-react-utils": "^2.7.9"
       }
     },
     "bpk-stylesheets": {
       "version": "file:backpack/packages/bpk-stylesheets",
       "dev": true,
       "requires": {
-        "bpk-mixins": "^17.24.4",
-        "bpk-tokens": "^27.6.4",
+        "bpk-mixins": "^17.24.5",
+        "bpk-tokens": "^27.6.5",
         "normalize.css": "4.2.0"
       },
       "dependencies": {
         "bpk-mixins": {
-          "version": "17.24.4",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
-          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
+          "version": "17.24.5",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.2",
-            "bpk-tokens": "^27.6.4"
+            "bpk-svgs": "^6.9.3",
+            "bpk-tokens": "^27.6.5"
           }
         },
+        "bpk-svgs": {
+          "version": "6.9.3",
+          "bundled": true,
+          "dev": true
+        },
         "bpk-tokens": {
-          "version": "27.6.4",
-          "resolved": "https://registry.npmjs.org/bpk-tokens/-/bpk-tokens-27.6.4.tgz",
-          "integrity": "sha512-/7BXdfw5Ft2UxkpLlme4x2TXoTEtITeJX1IzxqdgKZF0+fb+WT4SywoO0g9iM/nfQ1893ZEdNkG25u49v43dsQ==",
+          "version": "27.6.5",
+          "bundled": true,
           "dev": true,
           "requires": {
             "color": "^3.0.0"
-          },
-          "dependencies": {
-            "color": {
-              "version": "3.1.2",
-              "resolved": "https://registry.npmjs.org/color/-/color-3.1.2.tgz",
-              "integrity": "sha512-vXTJhHebByxZn3lDvDJYw4lR5+uB3vuoHsuYA5AKuxRVn5wzzIfQKGLBmgdVRHKTJYeK5rvJcHnrd0Li49CFpg==",
-              "dev": true,
-              "requires": {
-                "color-convert": "^1.9.1",
-                "color-string": "^1.5.2"
-              }
-            }
           }
+        },
+        "normalize.css": {
+          "version": "4.2.0",
+          "bundled": true,
+          "dev": true
         }
       }
     },
@@ -5294,29 +10087,43 @@
       "version": "file:backpack/packages/bpk-theming",
       "dev": true,
       "requires": {
-        "bpk-tokens": "^27.6.4",
+        "bpk-tokens": "^27.6.5",
         "prop-types": "^15.6.2"
       },
       "dependencies": {
         "bpk-tokens": {
-          "version": "27.6.4",
-          "resolved": "https://registry.npmjs.org/bpk-tokens/-/bpk-tokens-27.6.4.tgz",
-          "integrity": "sha512-/7BXdfw5Ft2UxkpLlme4x2TXoTEtITeJX1IzxqdgKZF0+fb+WT4SywoO0g9iM/nfQ1893ZEdNkG25u49v43dsQ==",
+          "version": "27.6.5",
+          "bundled": true,
           "dev": true,
           "requires": {
             "color": "^3.0.0"
-          },
-          "dependencies": {
-            "color": {
-              "version": "3.1.2",
-              "resolved": "https://registry.npmjs.org/color/-/color-3.1.2.tgz",
-              "integrity": "sha512-vXTJhHebByxZn3lDvDJYw4lR5+uB3vuoHsuYA5AKuxRVn5wzzIfQKGLBmgdVRHKTJYeK5rvJcHnrd0Li49CFpg==",
-              "dev": true,
-              "requires": {
-                "color-convert": "^1.9.1",
-                "color-string": "^1.5.2"
-              }
-            }
+          }
+        },
+        "js-tokens": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "loose-envify": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "js-tokens": "^3.0.0 || ^4.0.0"
+          }
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "prop-types": {
+          "version": "15.6.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.3.1",
+            "object-assign": "^4.1.1"
           }
         }
       }
@@ -5326,28 +10133,6 @@
       "dev": true,
       "requires": {
         "color": "^3.0.0"
-      },
-      "dependencies": {
-        "color": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/color/-/color-3.1.1.tgz",
-          "integrity": "sha512-PvUltIXRjehRKPSy89VnDWFKY58xyhTLyxIg21vwQBI6qLwZNPmC8k3C1uytIgFKEpOIzN4y32iPm8231zFHIg==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^1.9.1",
-            "color-string": "^1.5.2"
-          }
-        },
-        "color-string": {
-          "version": "1.5.3",
-          "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.3.tgz",
-          "integrity": "sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==",
-          "dev": true,
-          "requires": {
-            "color-name": "^1.0.0",
-            "simple-swizzle": "^0.2.2"
-          }
-        }
       }
     },
     "brace-expansion": {
@@ -5358,43 +10143,17 @@
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
-      },
-      "dependencies": {
-        "balanced-match": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true
-        }
       }
     },
     "braces": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-      "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+      "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
       "dev": true,
       "requires": {
-        "arr-flatten": "^1.1.0",
-        "array-unique": "^0.3.2",
-        "extend-shallow": "^2.0.1",
-        "fill-range": "^4.0.0",
-        "isobject": "^3.0.1",
-        "repeat-element": "^1.1.2",
-        "snapdragon": "^0.8.1",
-        "snapdragon-node": "^2.0.1",
-        "split-string": "^3.0.2",
-        "to-regex": "^3.0.1"
-      },
-      "dependencies": {
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "dev": true,
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
-        }
+        "expand-range": "^1.8.1",
+        "preserve": "^0.2.0",
+        "repeat-element": "^1.1.2"
       }
     },
     "brorand": {
@@ -5491,10 +10250,21 @@
         "pako": "~1.0.5"
       }
     },
+    "browserslist": {
+      "version": "4.6.6",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.6.6.tgz",
+      "integrity": "sha512-D2Nk3W9JL9Fp/gIcWei8LrERCS+eXu9AM5cfXA8WEZ84lFks+ARnZ0q/R69m2SV3Wjma83QDDPxsNKXUwdIsyA==",
+      "dev": true,
+      "requires": {
+        "caniuse-lite": "^1.0.30000984",
+        "electron-to-chromium": "^1.3.191",
+        "node-releases": "^1.1.25"
+      }
+    },
     "bser": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/bser/-/bser-2.0.0.tgz",
-      "integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.0.tgz",
+      "integrity": "sha512-8zsjWrQkkBoLK6uxASk1nJ2SKv97ltiGDo6A3wA0/yRPz+CwmEyDo0hUrhIuukG2JHpAl3bvFIixw2/3Hi0DOg==",
       "dev": true,
       "requires": {
         "node-int64": "^0.4.0"
@@ -5539,12 +10309,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.1.tgz",
       "integrity": "sha1-qfuAbOgUXVQoUQznLyeLs2OmOL8=",
-      "dev": true
-    },
-    "buffer-shims": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-      "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
       "dev": true
     },
     "buffer-xor": {
@@ -5596,14 +10360,6 @@
         "ssri": "^5.2.4",
         "unique-filename": "^1.1.0",
         "y18n": "^4.0.0"
-      },
-      "dependencies": {
-        "y18n": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-          "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
-          "dev": true
-        }
       }
     },
     "cache-base": {
@@ -5621,6 +10377,43 @@
         "to-object-path": "^0.3.0",
         "union-value": "^1.0.0",
         "unset-value": "^1.0.0"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        }
+      }
+    },
+    "cacheable-request": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-2.1.4.tgz",
+      "integrity": "sha1-DYCIAbY0KtM8kd+dC0TcCbkeXD0=",
+      "dev": true,
+      "requires": {
+        "clone-response": "1.0.2",
+        "get-stream": "3.0.0",
+        "http-cache-semantics": "3.8.1",
+        "keyv": "3.0.0",
+        "lowercase-keys": "1.0.0",
+        "normalize-url": "2.0.1",
+        "responselike": "1.0.2"
+      },
+      "dependencies": {
+        "get-stream": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+          "dev": true
+        },
+        "lowercase-keys": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
+          "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY=",
+          "dev": true
+        }
       }
     },
     "call-me-maybe": {
@@ -5636,6 +10429,14 @@
       "dev": true,
       "requires": {
         "callsites": "^2.0.0"
+      },
+      "dependencies": {
+        "callsites": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+          "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
+          "dev": true
+        }
       }
     },
     "caller-path": {
@@ -5648,15 +10449,15 @@
       }
     },
     "callsites": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
-      "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true
     },
     "camelcase": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-      "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+      "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
       "dev": true
     },
     "camelcase-keys": {
@@ -5677,22 +10478,16 @@
         }
       }
     },
-    "can-use-dom": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/can-use-dom/-/can-use-dom-0.1.0.tgz",
-      "integrity": "sha1-IsxKNKCrxDlQ9CxkEQJKP2NmtFo=",
-      "dev": true
-    },
     "caniuse-db": {
-      "version": "1.0.30000966",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000966.tgz",
-      "integrity": "sha512-PDXDry9EACH5Ld4s1JZMKR9BOnhO5qX/2Saqq9SeQhOSJbauFDwUzSefVyDuXN3trnR9MOicR9apPKcb1sihEA==",
+      "version": "1.0.30000985",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000985.tgz",
+      "integrity": "sha512-1m3CC9+dYNh/FHd0V1/McOB73CxjmzzrcXi360x8mKoApUY8QIOYXg4bU5QeJmlenn++20GBI38EKw6qQpJ3kQ==",
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30000966",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000966.tgz",
-      "integrity": "sha512-qqLQ/uYrpZmFhPY96VuBkMEo8NhVFBZ9y/Bh+KnvGzGJ5I8hvpIaWlF2pw5gqe4PLAL+ZjsPgMOvoXSpX21Keg==",
+      "version": "1.0.30000985",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000985.tgz",
+      "integrity": "sha512-1ngiwkgqAYPG0JSSUp3PUDGPKKY59EK7NrGGX+VOxaKCNzRbNc7uXMny+c3VJfZxtoK3wSImTvG9T9sXiTw2+w==",
       "dev": true
     },
     "capture-exit": {
@@ -5711,9 +10506,9 @@
       "dev": true
     },
     "ccount": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/ccount/-/ccount-1.0.3.tgz",
-      "integrity": "sha512-Jt9tIBkRc9POUof7QA/VwWd+58fKkEEfI+/t1/eOlxKM7ZhrczNzMFefge7Ai+39y1pR/pP6cI19guHy3FSLmw==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-1.0.4.tgz",
+      "integrity": "sha512-fpZ81yYfzentuieinmGnphk0pLkOTMm6MZdVqwd77ROvhko6iujLNGrHH5E7utq3ygWklwfmwuG+A7P+NpqT6w==",
       "dev": true
     },
     "center-align": {
@@ -5749,13 +10544,12 @@
     "change-emitter": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/change-emitter/-/change-emitter-0.1.6.tgz",
-      "integrity": "sha1-6LL+PX8at9aaMhma/5HqaTFAlRU=",
-      "dev": true
+      "integrity": "sha1-6LL+PX8at9aaMhma/5HqaTFAlRU="
     },
     "character-entities": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.2.tgz",
-      "integrity": "sha512-sMoHX6/nBiy3KKfC78dnEalnpn0Az0oSNvqUWYTtYrhRI5iUIYsROU48G+E+kMFQzqXaJ8kHJZ85n7y6/PHgwQ==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.3.tgz",
+      "integrity": "sha512-yB4oYSAa9yLcGyTbB4ItFwHw43QHdH129IJ5R+WvxOkWlyFnR5FAaBNnUq4mcxsTVZGh28bHoeTHMKXH1wZf3w==",
       "dev": true
     },
     "character-entities-html4": {
@@ -5765,15 +10559,21 @@
       "dev": true
     },
     "character-entities-legacy": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.2.tgz",
-      "integrity": "sha512-9NB2VbXtXYWdXzqrvAHykE/f0QJxzaKIpZ5QzNZrrgQ7Iyxr2vnfS8fCBNVW9nUEZE0lo57nxKRqnzY/dKrwlA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.3.tgz",
+      "integrity": "sha512-YAxUpPoPwxYFsslbdKkhrGnXAtXoHNgYjlBM3WMXkWGTl5RsY3QmOyhwAgL8Nxm9l5LBThXGawxKPn68y6/fww==",
       "dev": true
     },
     "character-reference-invalid": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.2.tgz",
-      "integrity": "sha512-7I/xceXfKyUJmSAn/jw8ve/9DyOP7XxufNYLI9Px7CmsKgEUaZLUTax6nZxGQtaoiZCjpu6cHPj20xC/vqRReQ==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.3.tgz",
+      "integrity": "sha512-VOq6PRzQBam/8Jm6XBGk2fNEnHXAdGd6go0rtd4weAGECBamHDwwCQSOT12TACIYUZegUXnV6xBXqUssijtxIg==",
+      "dev": true
+    },
+    "chardet": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
     },
     "charenc": {
@@ -5797,9 +10597,9 @@
       }
     },
     "chokidar": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.5.tgz",
-      "integrity": "sha512-i0TprVWp+Kj4WRPtInjexJ8Q+BqTE909VpH8xVhXrJkoc5QC8VO9TryGOqTr+2hljzc1sC62t22h5tZePodM/A==",
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.6.tgz",
+      "integrity": "sha512-V2jUo67OKkc6ySiRpJrjlpJKl9kDuG+Xb8VgsGzb+aEouhgS1D0weyPU4lEzdAcsCAvrih2J2BqyXqHWvVLw5g==",
       "dev": true,
       "requires": {
         "anymatch": "^2.0.0",
@@ -5814,12 +10614,117 @@
         "path-is-absolute": "^1.0.0",
         "readdirp": "^2.2.1",
         "upath": "^1.1.1"
+      },
+      "dependencies": {
+        "array-unique": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+          "dev": true
+        },
+        "braces": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
+          }
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "dev": true,
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
+          }
+        },
+        "glob-parent": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+          "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+          "dev": true,
+          "requires": {
+            "is-glob": "^3.1.0",
+            "path-dirname": "^1.0.0"
+          },
+          "dependencies": {
+            "is-glob": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+              "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+              "dev": true,
+              "requires": {
+                "is-extglob": "^2.1.0"
+              }
+            }
+          }
+        },
+        "is-extglob": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+          "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+          "dev": true,
+          "requires": {
+            "is-extglob": "^2.1.1"
+          }
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          }
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        },
+        "normalize-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+          "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+          "dev": true
+        },
+        "to-regex-range": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+          "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+          "dev": true,
+          "requires": {
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1"
+          }
+        }
       }
     },
     "chownr": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
-      "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.2.tgz",
+      "integrity": "sha512-GkfeAQh+QNy3wquu9oIZr6SS5x7wGdSgNQvD10X3r+AZr1Oys22HW8kAmDMvNg2+Dm0TeGaEuO8gFwdBXxwO8A==",
       "dev": true
     },
     "ci-info": {
@@ -5864,6 +10769,12 @@
           "requires": {
             "is-descriptor": "^0.1.0"
           }
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
         }
       }
     },
@@ -5886,11 +10797,31 @@
         "string-width": "^1.0.1"
       },
       "dependencies": {
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
         "slice-ansi": {
           "version": "0.0.4",
           "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
           "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
           "dev": true
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
         }
       }
     },
@@ -5901,14 +10832,31 @@
       "dev": true
     },
     "cliui": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-      "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+      "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
       "dev": true,
       "requires": {
-        "center-align": "^0.1.1",
-        "right-align": "^0.1.1",
-        "wordwrap": "0.0.2"
+        "string-width": "^2.1.1",
+        "strip-ansi": "^4.0.0",
+        "wrap-ansi": "^2.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
       }
     },
     "clone-deep": {
@@ -5950,6 +10898,15 @@
         "is-supported-regexp-flag": "^1.0.0"
       }
     },
+    "clone-response": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
+      "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
+      "dev": true,
+      "requires": {
+        "mimic-response": "^1.0.0"
+      }
+    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -5989,11 +10946,19 @@
         "object-visit": "^1.0.0"
       }
     },
+    "color": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/color/-/color-3.1.2.tgz",
+      "integrity": "sha512-vXTJhHebByxZn3lDvDJYw4lR5+uB3vuoHsuYA5AKuxRVn5wzzIfQKGLBmgdVRHKTJYeK5rvJcHnrd0Li49CFpg==",
+      "requires": {
+        "color-convert": "^1.9.1",
+        "color-string": "^1.5.2"
+      }
+    },
     "color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -6007,14 +10972,12 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "color-string": {
       "version": "1.5.3",
       "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.3.tgz",
       "integrity": "sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==",
-      "dev": true,
       "requires": {
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
@@ -6134,9 +11097,9 @@
       "dev": true
     },
     "combined-stream": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
-      "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
@@ -6202,6 +11165,12 @@
         "typedarray": "^0.0.6"
       }
     },
+    "confusing-browser-globals": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.7.tgz",
+      "integrity": "sha512-cgHI1azax5ATrZ8rJ+ODDML9Fvu67PimB6aNxBrc/QwSaDaM9eTfIEUHx3bBLJJ82ioSb+/5zfsMCCEJax3ByQ==",
+      "dev": true
+    },
     "connect-history-api-fallback": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz",
@@ -6236,10 +11205,13 @@
       "dev": true
     },
     "content-disposition": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
-      "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ=",
-      "dev": true
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
+      "integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.2"
+      }
     },
     "content-type": {
       "version": "1.0.4",
@@ -6263,9 +11235,9 @@
       }
     },
     "cookie": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
+      "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==",
       "dev": true
     },
     "cookie-signature": {
@@ -6324,6 +11296,21 @@
             "slash": "^1.0.0"
           }
         },
+        "is-extglob": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+          "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+          "dev": true,
+          "requires": {
+            "is-extglob": "^2.1.1"
+          }
+        },
         "pify": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
@@ -6333,9 +11320,9 @@
       }
     },
     "core-js": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.0.1.tgz",
-      "integrity": "sha512-sco40rF+2KlE0ROMvydjkrVMMG1vYilP2ALoRXcYR4obqbYIuV3Bg+51GEDW+HF8n7NRA+iaA4qD0nD9lo9mew==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.1.4.tgz",
+      "integrity": "sha512-YNZN8lt82XIMLnLirj9MhKDFZHalwzzrL9YLt6eb0T5D0EDl4IQ90IGkua8mHbnxNrkj1d8hbdizMc0Qmg1WnQ==",
       "dev": true
     },
     "core-util-is": {
@@ -6354,15 +11341,43 @@
       }
     },
     "cosmiconfig": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-4.0.0.tgz",
-      "integrity": "sha512-6e5vDdrXZD+t5v0L8CrurPeybg4Fmf+FCSYxXKYVAqLUtyCSbuyqE059d0kDthTNRzKVjL7QMgNpEUlsoYH3iQ==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
+      "integrity": "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==",
       "dev": true,
       "requires": {
+        "import-fresh": "^2.0.0",
         "is-directory": "^0.3.1",
-        "js-yaml": "^3.9.0",
-        "parse-json": "^4.0.0",
-        "require-from-string": "^2.0.1"
+        "js-yaml": "^3.13.1",
+        "parse-json": "^4.0.0"
+      },
+      "dependencies": {
+        "import-fresh": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
+          "integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
+          "dev": true,
+          "requires": {
+            "caller-path": "^2.0.0",
+            "resolve-from": "^3.0.0"
+          }
+        },
+        "parse-json": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
+          }
+        },
+        "resolve-from": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+          "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+          "dev": true
+        }
       }
     },
     "create-ecdh": {
@@ -6413,14 +11428,24 @@
       }
     },
     "cross-spawn": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
       "dev": true,
       "requires": {
-        "lru-cache": "^4.0.1",
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+          "dev": true
+        }
       }
     },
     "crypt": {
@@ -6448,6 +11473,12 @@
         "randomfill": "^1.0.3"
       }
     },
+    "css-color-names": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.3.tgz",
+      "integrity": "sha1-3gzvFvTYqoIioyDVttfpu62nufY=",
+      "dev": true
+    },
     "css-loader": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-1.0.1.tgz",
@@ -6466,6 +11497,25 @@
         "postcss-modules-values": "^1.3.0",
         "postcss-value-parser": "^3.3.0",
         "source-list-map": "^2.0.0"
+      },
+      "dependencies": {
+        "postcss": {
+          "version": "6.0.23",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.4.1",
+            "source-map": "^0.6.1",
+            "supports-color": "^5.4.0"
+          }
+        },
+        "postcss-value-parser": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+          "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+          "dev": true
+        }
       }
     },
     "css-mediaquery": {
@@ -6572,6 +11622,19 @@
         "cssesc": "^0.1.0",
         "fastparse": "^1.1.1",
         "regexpu-core": "^1.0.0"
+      },
+      "dependencies": {
+        "regexpu-core": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
+          "integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
+          "dev": true,
+          "requires": {
+            "regenerate": "^1.2.1",
+            "regjsgen": "^0.2.0",
+            "regjsparser": "^0.1.4"
+          }
+        }
       }
     },
     "css-tokenize": {
@@ -6611,12 +11674,12 @@
       }
     },
     "css-tree": {
-      "version": "1.0.0-alpha.28",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.28.tgz",
-      "integrity": "sha512-joNNW1gCp3qFFzj4St6zk+Wh/NBv0vM5YbEreZk0SD4S23S+1xBKb6cLDg2uj4P4k/GUMlIm6cKIDqIG+vdt0w==",
+      "version": "1.0.0-alpha.33",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.33.tgz",
+      "integrity": "sha512-SPt57bh5nQnpsTBsx/IXbO14sRc9xXu5MtMAVuo0BaQQmyf0NupNPPSoMaqiAF5tDFafYsTkfeH4Q/HCKXkg4w==",
       "dev": true,
       "requires": {
-        "mdn-data": "~1.1.0",
+        "mdn-data": "2.0.4",
         "source-map": "^0.5.3"
       },
       "dependencies": {
@@ -6627,12 +11690,6 @@
           "dev": true
         }
       }
-    },
-    "css-url-regex": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/css-url-regex/-/css-url-regex-1.1.0.tgz",
-      "integrity": "sha1-g4NCMMyfdMRX3lnuvRVD/uuDt+w=",
-      "dev": true
     },
     "css-what": {
       "version": "2.1.3",
@@ -6665,6 +11722,12 @@
             "source-map": "^0.5.3"
           }
         },
+        "mdn-data": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-1.1.4.tgz",
+          "integrity": "sha512-FSYbp3lyKjyj3E7fMl6rYvUdX0FBXaluGqlFoYESWQlyUTq8R+wp0rkFxoYFqZlHCvsUXGjyJmLQSnXToYhOSA==",
+          "dev": true
+        },
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -6674,9 +11737,9 @@
       }
     },
     "cssom": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.6.tgz",
-      "integrity": "sha512-DtUeseGk9/GBW0hl0vVPpU22iHL6YB5BUX7ml1hB+GMpo0NX5G4voX3kdWiMSEguFtcW3Vh3djqNF4aIe6ne0A==",
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+      "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
       "dev": true
     },
     "cssstyle": {
@@ -6710,86 +11773,19 @@
       "dev": true
     },
     "d": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
-      "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
+      "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
       "dev": true,
       "requires": {
-        "es5-ext": "^0.10.9"
-      }
-    },
-    "d3-array": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
-      "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw==",
-      "dev": true
-    },
-    "d3-collection": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/d3-collection/-/d3-collection-1.0.7.tgz",
-      "integrity": "sha512-ii0/r5f4sjKNTfh84Di+DpztYwqKhEyUlKoPrzUFfeSkWxjW49xU2QzO9qrPrNkpdI0XJkfzvmTu8V2Zylln6A==",
-      "dev": true
-    },
-    "d3-color": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.2.3.tgz",
-      "integrity": "sha512-x37qq3ChOTLd26hnps36lexMRhNXEtVxZ4B25rL0DVdDsGQIJGB18S7y9XDwlDD6MD/ZBzITCf4JjGMM10TZkw==",
-      "dev": true
-    },
-    "d3-format": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.3.2.tgz",
-      "integrity": "sha512-Z18Dprj96ExragQ0DeGi+SYPQ7pPfRMtUXtsg/ChVIKNBCzjO8XYJvRTC1usblx52lqge56V5ect+frYTQc8WQ==",
-      "dev": true
-    },
-    "d3-interpolate": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.3.2.tgz",
-      "integrity": "sha512-NlNKGopqaz9qM1PXh9gBF1KSCVh+jSFErrSlD/4hybwoNX/gt1d8CDbDW+3i+5UOHhjC6s6nMvRxcuoMVNgL2w==",
-      "dev": true,
-      "requires": {
-        "d3-color": "1"
-      }
-    },
-    "d3-path": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.7.tgz",
-      "integrity": "sha512-q0cW1RpvA5c5ma2rch62mX8AYaiLX0+bdaSM2wxSU9tXjU4DNvkx9qiUvjkuWCj3p22UO/hlPivujqMiR9PDzA==",
-      "dev": true
-    },
-    "d3-scale": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-2.2.2.tgz",
-      "integrity": "sha512-LbeEvGgIb8UMcAa0EATLNX0lelKWGYDQiPdHj+gLblGVhGLyNbaCn3EvrJf0A3Y/uOOU5aD6MTh5ZFCdEwGiCw==",
-      "dev": true,
-      "requires": {
-        "d3-array": "^1.2.0",
-        "d3-collection": "1",
-        "d3-format": "1",
-        "d3-interpolate": "1",
-        "d3-time": "1",
-        "d3-time-format": "2"
-      }
-    },
-    "d3-time": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.0.11.tgz",
-      "integrity": "sha512-Z3wpvhPLW4vEScGeIMUckDW7+3hWKOQfAWg/U7PlWBnQmeKQ00gCUsTtWSYulrKNA7ta8hJ+xXc6MHrMuITwEw==",
-      "dev": true
-    },
-    "d3-time-format": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.1.3.tgz",
-      "integrity": "sha512-6k0a2rZryzGm5Ihx+aFMuO1GgelgIz+7HhB4PH4OEndD5q2zGn1mDfRdNrulspOfR6JXkb2sThhDK41CSK85QA==",
-      "dev": true,
-      "requires": {
-        "d3-time": "1"
+        "es5-ext": "^0.10.50",
+        "type": "^1.0.1"
       }
     },
     "damerau-levenshtein": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.4.tgz",
-      "integrity": "sha1-AxkcQyy27qFou3fzpV/9zLiXhRQ=",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.5.tgz",
+      "integrity": "sha512-CBCRqFnpu715iPmw1KrdOrzRqbdFwQTwAWyyyYS42+iAgHCuXZ+/TdMgQkUENPomxEz9z1BEzuQU2Xw0kUuAgA==",
       "dev": true
     },
     "danger": {
@@ -6848,12 +11844,6 @@
             "minimist": "^1.2.0"
           }
         },
-        "lodash.keys": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-4.2.0.tgz",
-          "integrity": "sha1-oIYCrBLk+4P5H8H7ejYKTZujUgU=",
-          "dev": true
-        },
         "minimist": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
@@ -6861,15 +11851,15 @@
           "dev": true
         },
         "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         },
         "node-fetch": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.5.0.tgz",
-          "integrity": "sha512-YuZKluhWGJwCcUu4RlZstdAxr8bFfOVHakc1mplwHkk8J+tqM1Y5yraYvIUpeX8aY7+crCwiELJq7Vl0o0LWXw==",
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+          "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
           "dev": true
         }
       }
@@ -6942,9 +11932,9 @@
       "dev": true
     },
     "deep-equal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
-      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.2.tgz",
+      "integrity": "sha1-hLdFiW80xoTpjyzg5Cq69Du6AX0=",
       "dev": true
     },
     "deep-is": {
@@ -6960,17 +11950,6 @@
       "dev": true,
       "requires": {
         "strip-bom": "^2.0.0"
-      },
-      "dependencies": {
-        "strip-bom": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-          "dev": true,
-          "requires": {
-            "is-utf8": "^0.2.0"
-          }
-        }
       }
     },
     "define-properties": {
@@ -7021,10 +12000,60 @@
             "kind-of": "^6.0.2"
           }
         },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        },
         "kind-of": {
           "version": "6.0.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
           "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
+        }
+      }
+    },
+    "del": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/del/-/del-4.1.1.tgz",
+      "integrity": "sha512-QwGuEUouP2kVwQenAsOof5Fv8K9t3D8Ca8NxcXKrIpEHjTXK5J2nXLdP+ALI1cgv8wj7KuwBhTwBkOZSJKM5XQ==",
+      "dev": true,
+      "requires": {
+        "@types/glob": "^7.1.1",
+        "globby": "^6.1.0",
+        "is-path-cwd": "^2.0.0",
+        "is-path-in-cwd": "^2.0.0",
+        "p-map": "^2.0.0",
+        "pify": "^4.0.1",
+        "rimraf": "^2.6.3"
+      },
+      "dependencies": {
+        "globby": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+          "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
+          "dev": true,
+          "requires": {
+            "array-union": "^1.0.1",
+            "glob": "^7.0.3",
+            "object-assign": "^4.0.1",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          },
+          "dependencies": {
+            "pify": {
+              "version": "2.3.0",
+              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+              "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+              "dev": true
+            }
+          }
+        },
+        "pify": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
           "dev": true
         }
       }
@@ -7153,9 +12182,9 @@
       }
     },
     "doctrine": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
       "dev": true,
       "requires": {
         "esutils": "^2.0.2"
@@ -7250,6 +12279,15 @@
           "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
           "dev": true
         },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
         "isarray": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -7306,6 +12344,17 @@
             "amdefine": ">=0.0.4"
           }
         },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
         "string_decoder": {
           "version": "0.10.31",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
@@ -7345,10 +12394,10 @@
             }
           }
         },
-        "window-size": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
-          "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY=",
+        "y18n": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
           "dev": true
         },
         "yargs": {
@@ -7372,7 +12421,6 @@
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.4.0.tgz",
       "integrity": "sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==",
-      "dev": true,
       "requires": {
         "@babel/runtime": "^7.1.2"
       }
@@ -7486,9 +12534,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.131",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.131.tgz",
-      "integrity": "sha512-NSO4jLeyGLWrT4mzzfYX8vt1MYCoMI5LxSYAjt0H9+LF/14JyiKJSyyjA6AJTxflZlEM5v3QU33F0ohbPMCAPg==",
+      "version": "1.3.200",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.200.tgz",
+      "integrity": "sha512-PUurrpyDA74MuAjJRD+79ss5BqJlU3mdArRbuu4wO/dt6jc3Ic/6BDmFJxkdwbfq39cHf/XKm2vW98XSvut9Dg==",
       "dev": true
     },
     "elegant-spinner": {
@@ -7498,9 +12546,9 @@
       "dev": true
     },
     "elliptic": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.1.tgz",
-      "integrity": "sha512-BsXLz5sqX8OHcsh7CqBMztyXARmGQ3LWPtGjJi6DiJHq5C/qvi9P3OqgswKSDftbu8+IoI/QDTAm2fFnQ9SZSQ==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.0.tgz",
+      "integrity": "sha512-eFOJTMyCYb7xtE/caJ6JJu+bhi67WCYNbkGSknu20pmM8Ke/bqOfdnZWxyoGN26JgfxTbXrsCkEw4KheCT/KGg==",
       "dev": true,
       "requires": {
         "bn.js": "^4.4.0",
@@ -7534,7 +12582,6 @@
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
       "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-      "dev": true,
       "requires": {
         "iconv-lite": "~0.4.13"
       }
@@ -7567,9 +12614,9 @@
       "dev": true
     },
     "enzyme": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/enzyme/-/enzyme-3.9.0.tgz",
-      "integrity": "sha512-JqxI2BRFHbmiP7/UFqvsjxTirWoM1HfeaJrmVSZ9a1EADKkZgdPcAuISPMpoUiHlac9J4dYt81MC5BBIrbJGMg==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/enzyme/-/enzyme-3.10.0.tgz",
+      "integrity": "sha512-p2yy9Y7t/PFbPoTvrWde7JIYB2ZyGC+NgTNbVEGvZ5/EyoYSr9aG/2rSbVvyNvMHEhw9/dmGUJHWtfQIEiX9pg==",
       "dev": true,
       "requires": {
         "array.prototype.flat": "^1.2.1",
@@ -7596,18 +12643,19 @@
       }
     },
     "enzyme-adapter-react-16": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.12.1.tgz",
-      "integrity": "sha512-GB61gvY97XvrA6qljExGY+lgI6BBwz+ASLaRKct9VQ3ozu0EraqcNn3CcrUckSGIqFGa1+CxO5gj5is5t3lwrw==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.14.0.tgz",
+      "integrity": "sha512-7PcOF7pb4hJUvjY7oAuPGpq3BmlCig3kxXGi2kFx0YzJHppqX1K8IIV9skT1IirxXlu8W7bneKi+oQ10QRnhcA==",
       "dev": true,
       "requires": {
-        "enzyme-adapter-utils": "^1.11.0",
+        "enzyme-adapter-utils": "^1.12.0",
+        "has": "^1.0.3",
         "object.assign": "^4.1.0",
         "object.values": "^1.1.0",
         "prop-types": "^15.7.2",
         "react-is": "^16.8.6",
         "react-test-renderer": "^16.0.0-0",
-        "semver": "^5.6.0"
+        "semver": "^5.7.0"
       },
       "dependencies": {
         "semver": {
@@ -7619,12 +12667,12 @@
       }
     },
     "enzyme-adapter-utils": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/enzyme-adapter-utils/-/enzyme-adapter-utils-1.11.0.tgz",
-      "integrity": "sha512-0VZeoE9MNx+QjTfsjmO1Mo+lMfunucYB4wt5ficU85WB/LoetTJrbuujmHP3PJx6pSoaAuLA+Mq877x4LoxdNg==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/enzyme-adapter-utils/-/enzyme-adapter-utils-1.12.0.tgz",
+      "integrity": "sha512-wkZvE0VxcFx/8ZsBw0iAbk3gR1d9hK447ebnSYBf95+r32ezBq+XDSAvRErkc4LZosgH8J7et7H7/7CtUuQfBA==",
       "dev": true,
       "requires": {
-        "airbnb-prop-types": "^2.12.0",
+        "airbnb-prop-types": "^2.13.2",
         "function.prototype.name": "^1.1.0",
         "object.assign": "^4.1.0",
         "object.fromentries": "^2.0.0",
@@ -7729,9 +12777,9 @@
       }
     },
     "es6-promise": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.6.tgz",
-      "integrity": "sha512-aRVgGdnmW2OiySVPUC9e6m+plolMAJKjZnQlCwNSuK5yQ0JN61DZSO1X1Ufd1foqWRAlig0rhduTCHe7sVtK5Q==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
       "dev": true
     },
     "es6-promisify": {
@@ -7767,14 +12815,14 @@
       }
     },
     "es6-weak-map": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
-      "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
+      "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
       "dev": true,
       "requires": {
         "d": "1",
-        "es5-ext": "^0.10.14",
-        "es6-iterator": "^2.0.1",
+        "es5-ext": "^0.10.46",
+        "es6-iterator": "^2.0.3",
         "es6-symbol": "^3.1.1"
       }
     },
@@ -7873,25 +12921,6 @@
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
-        "chardet": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-          "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
-          "dev": true
-        },
-        "cross-spawn": {
-          "version": "6.0.5",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-          "dev": true,
-          "requires": {
-            "nice-try": "^1.0.4",
-            "path-key": "^2.0.1",
-            "semver": "^5.5.0",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
-          }
-        },
         "debug": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -7899,26 +12928,6 @@
           "dev": true,
           "requires": {
             "ms": "^2.1.1"
-          }
-        },
-        "doctrine": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
-          "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
-          "dev": true,
-          "requires": {
-            "esutils": "^2.0.2"
-          }
-        },
-        "external-editor": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.0.3.tgz",
-          "integrity": "sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==",
-          "dev": true,
-          "requires": {
-            "chardet": "^0.7.0",
-            "iconv-lite": "^0.4.24",
-            "tmp": "^0.0.33"
           }
         },
         "globals": {
@@ -7933,70 +12942,10 @@
           "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
           "dev": true
         },
-        "import-fresh": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.0.0.tgz",
-          "integrity": "sha512-pOnA9tfM3Uwics+SaBLCNyZZZbK+4PTu0OPZtLlMIrv17EdBoC15S9Kn8ckJ9TZTyKb3ywNE5y1yeDxxGA7nTQ==",
-          "dev": true,
-          "requires": {
-            "parent-module": "^1.0.0",
-            "resolve-from": "^4.0.0"
-          }
-        },
-        "inquirer": {
-          "version": "6.3.1",
-          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.3.1.tgz",
-          "integrity": "sha512-MmL624rfkFt4TG9y/Jvmt8vdmOo836U7Y0Hxr2aFk3RelZEGX4Igk0KabWrcaaZaTv9uzglOqWh1Vly+FAWAXA==",
-          "dev": true,
-          "requires": {
-            "ansi-escapes": "^3.2.0",
-            "chalk": "^2.4.2",
-            "cli-cursor": "^2.1.0",
-            "cli-width": "^2.0.0",
-            "external-editor": "^3.0.3",
-            "figures": "^2.0.0",
-            "lodash": "^4.17.11",
-            "mute-stream": "0.0.7",
-            "run-async": "^2.2.0",
-            "rxjs": "^6.4.0",
-            "string-width": "^2.1.0",
-            "strip-ansi": "^5.1.0",
-            "through": "^2.3.6"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "4.1.0",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-              "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-              "dev": true
-            },
-            "strip-ansi": {
-              "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-              "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-              "dev": true,
-              "requires": {
-                "ansi-regex": "^4.1.0"
-              }
-            }
-          }
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        },
         "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-          "dev": true
-        },
-        "resolve-from": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         },
         "semver": {
@@ -8004,16 +12953,6 @@
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
           "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
           "dev": true
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
-          }
         },
         "strip-ansi": {
           "version": "4.0.0",
@@ -8027,25 +12966,25 @@
       }
     },
     "eslint-config-airbnb": {
-      "version": "17.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-airbnb/-/eslint-config-airbnb-17.1.0.tgz",
-      "integrity": "sha512-R9jw28hFfEQnpPau01NO5K/JWMGLi6aymiF6RsnMURjTk+MqZKllCqGK/0tOvHkPi/NWSSOU2Ced/GX++YxLnw==",
+      "version": "17.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-airbnb/-/eslint-config-airbnb-17.1.1.tgz",
+      "integrity": "sha512-xCu//8a/aWqagKljt+1/qAM62BYZeNq04HmdevG5yUGWpja0I/xhqd6GdLRch5oetEGFiJAnvtGuTEAese53Qg==",
       "dev": true,
       "requires": {
-        "eslint-config-airbnb-base": "^13.1.0",
+        "eslint-config-airbnb-base": "^13.2.0",
         "object.assign": "^4.1.0",
-        "object.entries": "^1.0.4"
+        "object.entries": "^1.1.0"
       }
     },
     "eslint-config-airbnb-base": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-13.1.0.tgz",
-      "integrity": "sha512-XWwQtf3U3zIoKO1BbHh6aUhJZQweOwSt4c2JrPDg9FP3Ltv3+YfEv7jIDB8275tVnO/qOHbfuYg3kzw6Je7uWw==",
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-13.2.0.tgz",
+      "integrity": "sha512-1mg/7eoB4AUeB0X1c/ho4vb2gYkNH8Trr/EgCT/aGmKhhG+F6vF5s8+iRBlWAzFIAphxIdp3YfEKgEl0f9Xg+w==",
       "dev": true,
       "requires": {
-        "eslint-restricted-globals": "^0.1.1",
+        "confusing-browser-globals": "^1.0.5",
         "object.assign": "^4.1.0",
-        "object.entries": "^1.0.4"
+        "object.entries": "^1.1.0"
       }
     },
     "eslint-config-prettier": {
@@ -8094,9 +13033,9 @@
       }
     },
     "eslint-module-utils": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.4.0.tgz",
-      "integrity": "sha512-14tltLm38Eu3zS+mt0KvILC3q8jyIAH518MlG+HO0p+yK885Lb1UHTY/UgR91eOyGdmxAPb+OLoW4znqIT6Ndw==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.4.1.tgz",
+      "integrity": "sha512-H6DOj+ejw7Tesdgbfs4jeS4YMFrT8uI8xwd1gtQqXssaR0EQ26L+2O/w6wkYFy2MymON0fTwHmXBvvfLNZVZEw==",
       "dev": true,
       "requires": {
         "debug": "^2.6.8",
@@ -8112,52 +13051,21 @@
         "bpk-tokens": "^27.4.7",
         "lodash": "^4.17.11",
         "tinycolor2": "^1.4.1"
-      },
-      "dependencies": {
-        "bpk-tokens": {
-          "version": "27.6.0",
-          "resolved": "https://registry.npmjs.org/bpk-tokens/-/bpk-tokens-27.6.0.tgz",
-          "integrity": "sha512-H2LBrJZPECKehpIzrEYDztcTyH9Kc5zrSVKMmfG1AWu5Z1Hir0ozz/6XNwxhTwIuicWr74N5CWFcsKv/iV5H+g==",
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
-          }
-        },
-        "color": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/color/-/color-3.1.1.tgz",
-          "integrity": "sha512-PvUltIXRjehRKPSy89VnDWFKY58xyhTLyxIg21vwQBI6qLwZNPmC8k3C1uytIgFKEpOIzN4y32iPm8231zFHIg==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^1.9.1",
-            "color-string": "^1.5.2"
-          }
-        },
-        "color-string": {
-          "version": "1.5.3",
-          "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.3.tgz",
-          "integrity": "sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==",
-          "dev": true,
-          "requires": {
-            "color-name": "^1.0.0",
-            "simple-swizzle": "^0.2.2"
-          }
-        }
       }
     },
     "eslint-plugin-flowtype": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-flowtype/-/eslint-plugin-flowtype-3.7.0.tgz",
-      "integrity": "sha512-6PAYrfSAd23C6ZTc9OhEpSn4uz5HnaXSOYzBLPiKNAE+WmNnWkgkfrswOK2Rlvn91ofZoba7SR04gitnmW9sqg==",
+      "version": "3.12.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-flowtype/-/eslint-plugin-flowtype-3.12.1.tgz",
+      "integrity": "sha512-NZqf5iRgsfHOC31HQdtX2pvzCi0n/j9pB+L7Cf9QtuYxpx0i2wObT+R3rPKhQK4KtEDzGuzPYVf75j4eg+s9ZQ==",
       "dev": true,
       "requires": {
         "lodash": "^4.17.11"
       }
     },
     "eslint-plugin-import": {
-      "version": "2.17.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.17.2.tgz",
-      "integrity": "sha512-m+cSVxM7oLsIpmwNn2WXTJoReOF9f/CtLMo7qOVmKd1KntBy0hEcuNZ3erTmWjx+DxRO0Zcrm5KwAvI9wHcV5g==",
+      "version": "2.18.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.18.2.tgz",
+      "integrity": "sha512-5ohpsHAiUBRNaBWAF08izwUGlbrJoJJ+W9/TBwsGoR1MnlgfwMIKrFeSjWbt6moabiXW9xNvtFz+97KHRfI4HQ==",
       "dev": true,
       "requires": {
         "array-includes": "^3.0.3",
@@ -8167,10 +13075,10 @@
         "eslint-import-resolver-node": "^0.3.2",
         "eslint-module-utils": "^2.4.0",
         "has": "^1.0.3",
-        "lodash": "^4.17.11",
         "minimatch": "^3.0.4",
+        "object.values": "^1.1.0",
         "read-pkg-up": "^2.0.0",
-        "resolve": "^1.10.0"
+        "resolve": "^1.11.0"
       },
       "dependencies": {
         "doctrine": {
@@ -8182,15 +13090,64 @@
             "esutils": "^2.0.2",
             "isarray": "^1.0.0"
           }
+        },
+        "load-json-file": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+          "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "strip-bom": "^3.0.0"
+          }
+        },
+        "path-type": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+          "dev": true,
+          "requires": {
+            "pify": "^2.0.0"
+          }
+        },
+        "read-pkg": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+          "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "^2.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^2.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+          "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+          "dev": true,
+          "requires": {
+            "find-up": "^2.0.0",
+            "read-pkg": "^2.0.0"
+          }
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+          "dev": true
         }
       }
     },
     "eslint-plugin-jsx-a11y": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.2.1.tgz",
-      "integrity": "sha512-cjN2ObWrRz0TTw7vEcGQrx+YltMvZoOEx4hWU8eEERDnBIU00OTq7Vr+jA7DFKxiwLNv4tTh5Pq2GUNEa8b6+w==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.2.3.tgz",
+      "integrity": "sha512-CawzfGt9w83tyuVekn0GDPU9ytYtxyxyFZ3aSWROmnRRFQFT2BiPJd7jvRdzNDi6oLWaS2asMeYSNMjWTV4eNg==",
       "dev": true,
       "requires": {
+        "@babel/runtime": "^7.4.5",
         "aria-query": "^3.0.0",
         "array-includes": "^3.0.3",
         "ast-types-flow": "^0.0.7",
@@ -8198,38 +13155,45 @@
         "damerau-levenshtein": "^1.0.4",
         "emoji-regex": "^7.0.2",
         "has": "^1.0.3",
-        "jsx-ast-utils": "^2.0.1"
+        "jsx-ast-utils": "^2.2.1"
       }
     },
     "eslint-plugin-prettier": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.0.1.tgz",
-      "integrity": "sha512-/PMttrarPAY78PLvV3xfWibMOdMDl57hmlQ2XqFeA37wd+CJ7WSxV7txqjVPHi/AAFKd2lX0ZqfsOc/i5yFCSQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.0.tgz",
+      "integrity": "sha512-XWX2yVuwVNLOUhQijAkXz+rMPPoCr7WFiAl8ig6I7Xn+pPVhDhzg4DxHpmbeb0iqjO9UronEA3Tb09ChnFVHHA==",
       "dev": true,
       "requires": {
         "prettier-linter-helpers": "^1.0.0"
       }
     },
     "eslint-plugin-react": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.13.0.tgz",
-      "integrity": "sha512-uA5LrHylu8lW/eAH3bEQe9YdzpPaFd9yAJTwTi/i/BKTD7j6aQMKVAdGM/ML72zD6womuSK7EiGtMKuK06lWjQ==",
+      "version": "7.14.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.14.3.tgz",
+      "integrity": "sha512-EzdyyBWC4Uz2hPYBiEJrKCUi2Fn+BJ9B/pJQcjw5X+x/H2Nm59S4MJIvL4O5NEE0+WbnQwEBxWY03oUk+Bc3FA==",
       "dev": true,
       "requires": {
         "array-includes": "^3.0.3",
         "doctrine": "^2.1.0",
         "has": "^1.0.3",
         "jsx-ast-utils": "^2.1.0",
+        "object.entries": "^1.1.0",
         "object.fromentries": "^2.0.0",
+        "object.values": "^1.1.0",
         "prop-types": "^15.7.2",
         "resolve": "^1.10.1"
+      },
+      "dependencies": {
+        "doctrine": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+          "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2"
+          }
+        }
       }
-    },
-    "eslint-restricted-globals": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-restricted-globals/-/eslint-restricted-globals-0.1.1.tgz",
-      "integrity": "sha1-NfDVy8ZMLj7WLpO0saevBbp+1Nc=",
-      "dev": true
     },
     "eslint-scope": {
       "version": "4.0.3",
@@ -8242,10 +13206,13 @@
       }
     },
     "eslint-utils": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.3.1.tgz",
-      "integrity": "sha512-Z7YjnIldX+2XMcjr7ZkgEsOj/bREONV60qYeB/bjMAqqqZ4zxKyWX+BOUkdmRmA9riiIPVvo5x86m5elviOk0Q==",
-      "dev": true
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.0.tgz",
+      "integrity": "sha512-7ehnzPaP5IIEh1r1tkjuIrxqhNkzUJa9z3R92tLJdZIVdWaczEhr3EbhGtsMrVxi1KeR8qA7Off6SWc5WNQqyQ==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^1.0.0"
+      }
     },
     "eslint-visitor-keys": {
       "version": "1.0.0",
@@ -8276,15 +13243,13 @@
         "acorn": "^6.0.7",
         "acorn-jsx": "^5.0.0",
         "eslint-visitor-keys": "^1.0.0"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "6.1.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
-          "integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==",
-          "dev": true
-        }
       }
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
     },
     "esquery": {
       "version": "1.0.1",
@@ -8323,9 +13288,9 @@
       "dev": true
     },
     "eval": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/eval/-/eval-0.1.3.tgz",
-      "integrity": "sha512-lDBa3hl9YynB+3J7aNPaajAapr+7ZiAylqFeUmx/r9s7I0tkkUJFLw2CQ2oMRYGg/rL7g4IYkZenbKaQGKPnGQ==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/eval/-/eval-0.1.4.tgz",
+      "integrity": "sha512-npGsebJejyjMRnLdFu+T/97dnigqIU0Ov3IGrZ8ygd1v7RL1vGkEKtvyWZobqUH1AQgKlg0Yqqe2BtMA9/QZLw==",
       "dev": true,
       "requires": {
         "require-like": ">= 0.1.1"
@@ -8345,6 +13310,12 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
       "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
+      "dev": true
+    },
+    "events": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.0.0.tgz",
+      "integrity": "sha512-Dc381HFWJzEOhQ+d8pkNon++bk9h6cdAoAj4iE6Q4y6xgTzySWXlKn05/TVNpjnfRqi/X0EpJEJohPjNI3zpVA==",
       "dev": true
     },
     "eventsource": {
@@ -8376,13 +13347,13 @@
       }
     },
     "execa": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-      "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+      "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
       "dev": true,
       "requires": {
-        "cross-spawn": "^5.0.1",
-        "get-stream": "^3.0.0",
+        "cross-spawn": "^6.0.0",
+        "get-stream": "^4.0.0",
         "is-stream": "^1.1.0",
         "npm-run-path": "^2.0.0",
         "p-finally": "^1.0.0",
@@ -8412,38 +13383,12 @@
       "dev": true
     },
     "expand-brackets": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
-      "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+      "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
       "dev": true,
       "requires": {
-        "debug": "^2.3.3",
-        "define-property": "^0.2.5",
-        "extend-shallow": "^2.0.1",
-        "posix-character-classes": "^0.1.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.1"
-      },
-      "dependencies": {
-        "define-property": {
-          "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "dev": true,
-          "requires": {
-            "is-descriptor": "^0.1.0"
-          }
-        },
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "dev": true,
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
-        }
+        "is-posix-bracket": "^0.1.0"
       }
     },
     "expand-range": {
@@ -8453,39 +13398,6 @@
       "dev": true,
       "requires": {
         "fill-range": "^2.1.0"
-      },
-      "dependencies": {
-        "fill-range": {
-          "version": "2.2.4",
-          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
-          "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
-          "dev": true,
-          "requires": {
-            "is-number": "^2.1.0",
-            "isobject": "^2.0.0",
-            "randomatic": "^3.0.0",
-            "repeat-element": "^1.1.2",
-            "repeat-string": "^1.5.2"
-          }
-        },
-        "is-number": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-          "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-          "dev": true,
-          "requires": {
-            "kind-of": "^3.0.2"
-          }
-        },
-        "isobject": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-          "dev": true,
-          "requires": {
-            "isarray": "1.0.0"
-          }
-        }
       }
     },
     "expand-tilde": {
@@ -8512,47 +13424,59 @@
       }
     },
     "express": {
-      "version": "4.16.4",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.16.4.tgz",
-      "integrity": "sha512-j12Uuyb4FMrd/qQAm6uCHAkPtO8FDTRJZBDd5D2KOL2eLaz1yUNdUB/NOIyq0iU4q4cFarsUCrnFDPBcnksuOg==",
+      "version": "4.17.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
+      "integrity": "sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==",
       "dev": true,
       "requires": {
-        "accepts": "~1.3.5",
+        "accepts": "~1.3.7",
         "array-flatten": "1.1.1",
-        "body-parser": "1.18.3",
-        "content-disposition": "0.5.2",
+        "body-parser": "1.19.0",
+        "content-disposition": "0.5.3",
         "content-type": "~1.0.4",
-        "cookie": "0.3.1",
+        "cookie": "0.4.0",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "~1.1.2",
         "encodeurl": "~1.0.2",
         "escape-html": "~1.0.3",
         "etag": "~1.8.1",
-        "finalhandler": "1.1.1",
+        "finalhandler": "~1.1.2",
         "fresh": "0.5.2",
         "merge-descriptors": "1.0.1",
         "methods": "~1.1.2",
         "on-finished": "~2.3.0",
-        "parseurl": "~1.3.2",
+        "parseurl": "~1.3.3",
         "path-to-regexp": "0.1.7",
-        "proxy-addr": "~2.0.4",
-        "qs": "6.5.2",
-        "range-parser": "~1.2.0",
+        "proxy-addr": "~2.0.5",
+        "qs": "6.7.0",
+        "range-parser": "~1.2.1",
         "safe-buffer": "5.1.2",
-        "send": "0.16.2",
-        "serve-static": "1.13.2",
-        "setprototypeof": "1.1.0",
-        "statuses": "~1.4.0",
-        "type-is": "~1.6.16",
+        "send": "0.17.1",
+        "serve-static": "1.14.1",
+        "setprototypeof": "1.1.1",
+        "statuses": "~1.5.0",
+        "type-is": "~1.6.18",
         "utils-merge": "1.0.1",
         "vary": "~1.1.2"
       },
       "dependencies": {
+        "array-flatten": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+          "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
+          "dev": true
+        },
+        "path-to-regexp": {
+          "version": "0.1.7",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+          "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
+          "dev": true
+        },
         "qs": {
-          "version": "6.5.2",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+          "version": "6.7.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+          "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
           "dev": true
         }
       }
@@ -8564,95 +13488,32 @@
       "dev": true
     },
     "extend-shallow": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
-      "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
       "dev": true,
       "requires": {
-        "assign-symbols": "^1.0.0",
-        "is-extendable": "^1.0.1"
-      },
-      "dependencies": {
-        "is-extendable": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-          "dev": true,
-          "requires": {
-            "is-plain-object": "^2.0.4"
-          }
-        }
+        "is-extendable": "^0.1.0"
+      }
+    },
+    "external-editor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+      "dev": true,
+      "requires": {
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
       }
     },
     "extglob": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
-      "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+      "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
       "dev": true,
       "requires": {
-        "array-unique": "^0.3.2",
-        "define-property": "^1.0.0",
-        "expand-brackets": "^2.1.4",
-        "extend-shallow": "^2.0.1",
-        "fragment-cache": "^0.2.1",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.1"
-      },
-      "dependencies": {
-        "define-property": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-          "dev": true,
-          "requires": {
-            "is-descriptor": "^1.0.0"
-          }
-        },
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "dev": true,
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
-        },
-        "is-accessor-descriptor": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-          "dev": true,
-          "requires": {
-            "kind-of": "^6.0.0"
-          }
-        },
-        "is-data-descriptor": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-          "dev": true,
-          "requires": {
-            "kind-of": "^6.0.0"
-          }
-        },
-        "is-descriptor": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-          "dev": true,
-          "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
-          }
-        },
-        "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-          "dev": true
-        }
+        "is-extglob": "^1.0.0"
       }
     },
     "extract-text-webpack-plugin": {
@@ -8665,41 +13526,6 @@
         "loader-utils": "^1.1.0",
         "schema-utils": "^0.3.0",
         "webpack-sources": "^1.0.1"
-      },
-      "dependencies": {
-        "ajv": {
-          "version": "5.5.2",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
-          "dev": true,
-          "requires": {
-            "co": "^4.6.0",
-            "fast-deep-equal": "^1.0.0",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.3.0"
-          }
-        },
-        "fast-deep-equal": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-          "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
-          "dev": true
-        },
-        "json-schema-traverse": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-          "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
-          "dev": true
-        },
-        "schema-utils": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.3.0.tgz",
-          "integrity": "sha1-9YdyIs4+kx7a4DnxfrNxbnE3+M8=",
-          "dev": true,
-          "requires": {
-            "ajv": "^5.0.0"
-          }
-        }
       }
     },
     "extsprintf": {
@@ -8727,9 +13553,9 @@
       "dev": true
     },
     "fast-glob": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.0.3.tgz",
-      "integrity": "sha512-scDJbDhN+6S4ELXzzN96Fqm5y1CMRn+Io3C4Go+n/gUKP+LW26Wma6IxLSsX2eAMBUOFmyHKDBrUSuoHsycQ5A==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.0.4.tgz",
+      "integrity": "sha512-wkIbV6qg37xTJwqSsdnIphL1e+LaGz4AIQqr00mIubMaEhv1/HEmJ0uuCGZRNRUkZZmOB5mJKO0ZUTVq+SxMQg==",
       "dev": true,
       "requires": {
         "@nodelib/fs.stat": "^2.0.1",
@@ -8767,11 +13593,20 @@
             "is-glob": "^4.0.1"
           }
         },
-        "is-number": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+        "is-extglob": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
           "dev": true
+        },
+        "is-glob": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+          "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+          "dev": true,
+          "requires": {
+            "is-extglob": "^2.1.1"
+          }
         },
         "micromatch": {
           "version": "4.0.2",
@@ -8781,15 +13616,6 @@
           "requires": {
             "braces": "^3.0.1",
             "picomatch": "^2.0.5"
-          }
-        },
-        "to-regex-range": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-          "dev": true,
-          "requires": {
-            "is-number": "^7.0.0"
           }
         }
       }
@@ -8822,9 +13648,9 @@
       }
     },
     "faye-websocket": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.1.tgz",
-      "integrity": "sha1-8O/hjE9W5PQK/H4Gxxn9XuYYjzg=",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
+      "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
       "dev": true,
       "requires": {
         "websocket-driver": ">=0.5.1"
@@ -8843,7 +13669,6 @@
       "version": "0.8.17",
       "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
       "integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
-      "dev": true,
       "requires": {
         "core-js": "^1.0.0",
         "isomorphic-fetch": "^2.1.1",
@@ -8857,8 +13682,7 @@
         "core-js": {
           "version": "1.2.7",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
-          "dev": true
+          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
         }
       }
     },
@@ -8920,40 +13744,30 @@
       }
     },
     "fill-range": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-      "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
+      "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
       "dev": true,
       "requires": {
-        "extend-shallow": "^2.0.1",
-        "is-number": "^3.0.0",
-        "repeat-string": "^1.6.1",
-        "to-regex-range": "^2.1.0"
-      },
-      "dependencies": {
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "dev": true,
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
-        }
+        "is-number": "^2.1.0",
+        "isobject": "^2.0.0",
+        "randomatic": "^3.0.0",
+        "repeat-element": "^1.1.2",
+        "repeat-string": "^1.5.2"
       }
     },
     "finalhandler": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
-      "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
+      "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
       "dev": true,
       "requires": {
         "debug": "2.6.9",
         "encodeurl": "~1.0.2",
         "escape-html": "~1.0.3",
         "on-finished": "~2.3.0",
-        "parseurl": "~1.3.2",
-        "statuses": "~1.4.0",
+        "parseurl": "~1.3.3",
+        "statuses": "~1.5.0",
         "unpipe": "~1.0.0"
       }
     },
@@ -8989,9 +13803,9 @@
       }
     },
     "flatted": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.0.tgz",
-      "integrity": "sha512-R+H8IZclI8AAkSBRQJLVOsxwAoHd6WC40b4QTNWIjzAa6BXOBfQcM587MXDTVPeYaopFNWHUFLx7eNmHDSxMWg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz",
+      "integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==",
       "dev": true
     },
     "flatten": {
@@ -9001,181 +13815,133 @@
       "dev": true
     },
     "flow-bin": {
-      "version": "0.101.0",
-      "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.101.0.tgz",
-      "integrity": "sha512-2xriPEOSrGQklAArNw1ixoIUiLTWhIquYV26WqnxEu7IcXWgoZUcfJXufG9kIvrNbdwCNd5RBjTwbB0p6L6XaA==",
+      "version": "0.101.1",
+      "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.101.1.tgz",
+      "integrity": "sha512-+HVuoMgWNK8vIM662Rt6OzlJNTnC+BWChdeYjkPpl70TKiRMt//j6/5x6PH8HVZ/vytOfPZw2b/JrlBHdlGCkQ==",
       "dev": true
     },
     "flow-typed": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/flow-typed/-/flow-typed-2.5.1.tgz",
-      "integrity": "sha1-D/VlzJTSr4xVd0S6NktvFHJqa58=",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/flow-typed/-/flow-typed-2.6.0.tgz",
+      "integrity": "sha512-aTd2ygnb9e0/O4Rskzh/zYMU0NJR3PygoheTfiDEOCbEVdXS6mpX/TfcpcbpPVcJpqqV44+pjhOt36VXlYkLRA==",
       "dev": true,
       "requires": {
-        "@octokit/rest": "^15.2.6",
-        "babel-polyfill": "^6.26.0",
-        "colors": "^1.1.2",
-        "fs-extra": "^5.0.0",
-        "glob": "^7.1.2",
-        "got": "^7.1.0",
-        "md5": "^2.1.0",
+        "@babel/polyfill": "^7.0.0",
+        "@octokit/rest": "^15.12.1",
+        "colors": "^1.3.2",
+        "flowgen": "^1.9.0",
+        "fs-extra": "^7.0.0",
+        "glob": "^7.1.3",
+        "got": "^8.3.2",
+        "md5": "^2.2.1",
         "mkdirp": "^0.5.1",
+        "prettier": "^1.18.2",
         "rimraf": "^2.6.2",
-        "semver": "^5.5.0",
-        "table": "^4.0.2",
+        "semver": "^5.5.1",
+        "table": "^5.0.2",
         "through": "^2.3.8",
-        "unzipper": "^0.8.11",
-        "which": "^1.3.0",
-        "yargs": "^4.2.0"
+        "unzipper": "^0.9.3",
+        "which": "^1.3.1",
+        "yargs": "^12.0.2"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
         "camelcase": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
           "dev": true
-        },
-        "cliui": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-          "dev": true,
-          "requires": {
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wrap-ansi": "^2.0.0"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "2.1.1",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-              "dev": true
-            },
-            "is-fullwidth-code-point": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-              "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-              "dev": true,
-              "requires": {
-                "number-is-nan": "^1.0.0"
-              }
-            },
-            "string-width": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-              "dev": true,
-              "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
-              }
-            },
-            "strip-ansi": {
-              "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-              "dev": true,
-              "requires": {
-                "ansi-regex": "^2.0.0"
-              }
-            }
-          }
         },
         "find-up": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
           "dev": true,
           "requires": {
-            "path-exists": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
+            "locate-path": "^3.0.0"
           }
         },
-        "is-fullwidth-code-point": {
+        "invert-kv": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
+          "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
           "dev": true
         },
-        "load-json-file": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+        "lcid": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
+          "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^2.2.0",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0",
-            "strip-bom": "^2.0.0"
+            "invert-kv": "^2.0.0"
           }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "mem": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
+          "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
+          "dev": true,
+          "requires": {
+            "map-age-cleaner": "^0.1.1",
+            "mimic-fn": "^2.0.0",
+            "p-is-promise": "^2.0.0"
+          }
+        },
+        "mimic-fn": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+          "dev": true
         },
         "os-locale": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-          "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
+          "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
           "dev": true,
           "requires": {
-            "lcid": "^1.0.0"
+            "execa": "^1.0.0",
+            "lcid": "^2.0.0",
+            "mem": "^4.0.0"
           }
         },
-        "parse-json": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-          "dev": true,
-          "requires": {
-            "error-ex": "^1.2.0"
-          }
-        },
-        "path-exists": {
+        "p-is-promise": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+          "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.1.0.tgz",
+          "integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==",
+          "dev": true
+        },
+        "p-limit": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+          "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
           "dev": true,
           "requires": {
-            "pinkie-promise": "^2.0.0"
+            "p-try": "^2.0.0"
           }
         },
-        "path-type": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
+            "p-limit": "^2.0.0"
           }
         },
-        "read-pkg": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-          "dev": true,
-          "requires": {
-            "load-json-file": "^1.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^1.0.0"
-          }
-        },
-        "read-pkg-up": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-          "dev": true,
-          "requires": {
-            "find-up": "^1.0.0",
-            "read-pkg": "^1.0.0"
-          }
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "dev": true
         },
         "semver": {
           "version": "5.7.0",
@@ -9183,138 +13949,53 @@
           "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
           "dev": true
         },
-        "slice-ansi": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
-          "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "^2.0.0"
-          }
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^3.0.0"
-          }
-        },
-        "strip-bom": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-          "dev": true,
-          "requires": {
-            "is-utf8": "^0.2.0"
-          }
-        },
-        "table": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/table/-/table-4.0.3.tgz",
-          "integrity": "sha512-S7rnFITmBH1EnyKcvxBh1LjYeQMmnZtCXSEbHcH6S0NoKit24ZuFO/T1vDcLdYsLQkM188PVVhQmzKIuThNkKg==",
-          "dev": true,
-          "requires": {
-            "ajv": "^6.0.1",
-            "ajv-keywords": "^3.0.0",
-            "chalk": "^2.1.0",
-            "lodash": "^4.17.4",
-            "slice-ansi": "1.0.0",
-            "string-width": "^2.1.1"
-          }
-        },
-        "which-module": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-          "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
-          "dev": true
-        },
-        "window-size": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
-          "integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU=",
-          "dev": true
-        },
         "yargs": {
-          "version": "4.8.1",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
-          "integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
+          "version": "12.0.5",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
+          "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
           "dev": true,
           "requires": {
-            "cliui": "^3.2.0",
-            "decamelize": "^1.1.1",
+            "cliui": "^4.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^3.0.0",
             "get-caller-file": "^1.0.1",
-            "lodash.assign": "^4.0.3",
-            "os-locale": "^1.4.0",
-            "read-pkg-up": "^1.0.1",
+            "os-locale": "^3.0.0",
             "require-directory": "^2.1.1",
             "require-main-filename": "^1.0.1",
             "set-blocking": "^2.0.0",
-            "string-width": "^1.0.1",
-            "which-module": "^1.0.0",
-            "window-size": "^0.2.0",
-            "y18n": "^3.2.1",
-            "yargs-parser": "^2.4.1"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "2.1.1",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-              "dev": true
-            },
-            "is-fullwidth-code-point": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-              "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-              "dev": true,
-              "requires": {
-                "number-is-nan": "^1.0.0"
-              }
-            },
-            "string-width": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-              "dev": true,
-              "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
-              }
-            },
-            "strip-ansi": {
-              "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-              "dev": true,
-              "requires": {
-                "ansi-regex": "^2.0.0"
-              }
-            }
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1 || ^4.0.0",
+            "yargs-parser": "^11.1.1"
           }
         },
         "yargs-parser": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
-          "integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
+          "version": "11.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
+          "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
           "dev": true,
           "requires": {
-            "camelcase": "^3.0.0",
-            "lodash.assign": "^4.0.6"
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
           }
         }
+      }
+    },
+    "flowgen": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/flowgen/-/flowgen-1.9.2.tgz",
+      "integrity": "sha512-YKKNGUqLX/J8nNClaaoaAmICZVVUACRERbyuZPSLN/sDEK5DWRStvV+cUG/QL2ZCLRc1obZgHvkF2LR5CEK2oQ==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@babel/highlight": "^7.0.0",
+        "commander": "^2.11.0",
+        "lodash": "^4.17.4",
+        "paralleljs": "^0.2.1",
+        "prettier": "^1.16.4",
+        "shelljs": "^0.8.3",
+        "typescript": "^3.3.3333",
+        "typescript-compiler": "^1.4.1-2"
       }
     },
     "flush-write-stream": {
@@ -9330,8 +14011,7 @@
     "focusin": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/focusin/-/focusin-2.0.0.tgz",
-      "integrity": "sha1-WMARgN+xlJ8D493u4GNzn8M7b/w=",
-      "dev": true
+      "integrity": "sha1-WMARgN+xlJ8D493u4GNzn8M7b/w="
     },
     "follow-redirects": {
       "version": "1.7.0",
@@ -9352,9 +14032,9 @@
           }
         },
         "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         }
       }
@@ -9429,9 +14109,9 @@
       "dev": true
     },
     "fs-extra": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
-      "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.2",
@@ -9470,29 +14150,24 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "resolved": false,
-          "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": false,
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true,
-          "optional": true
+          "bundled": true,
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
-          "resolved": false,
-          "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.5",
-          "resolved": false,
-          "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -9502,17 +14177,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true,
-          "optional": true
+          "bundled": true,
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "resolved": false,
-          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+          "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -9520,43 +14191,34 @@
         },
         "chownr": {
           "version": "1.1.1",
-          "resolved": false,
-          "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "resolved": false,
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true,
-          "optional": true
+          "bundled": true,
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "resolved": false,
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true,
-          "optional": true
+          "bundled": true,
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "resolved": false,
-          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true,
-          "optional": true
+          "bundled": true,
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "resolved": false,
-          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "debug": {
           "version": "4.1.1",
-          "resolved": false,
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -9565,29 +14227,25 @@
         },
         "deep-extend": {
           "version": "0.6.0",
-          "resolved": false,
-          "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "delegates": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "resolved": false,
-          "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "fs-minipass": {
           "version": "1.2.5",
-          "resolved": false,
-          "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -9596,15 +14254,13 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "gauge": {
           "version": "2.7.4",
-          "resolved": false,
-          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -9620,8 +14276,7 @@
         },
         "glob": {
           "version": "7.1.3",
-          "resolved": false,
-          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -9635,15 +14290,13 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "resolved": false,
-          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "iconv-lite": {
           "version": "0.4.24",
-          "resolved": false,
-          "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -9652,8 +14305,7 @@
         },
         "ignore-walk": {
           "version": "3.0.1",
-          "resolved": false,
-          "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -9662,8 +14314,7 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "resolved": false,
-          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -9673,58 +14324,46 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "resolved": false,
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true,
-          "optional": true
+          "bundled": true,
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
-          "resolved": false,
-          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
         },
         "isarray": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "resolved": false,
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "resolved": false,
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true,
-          "optional": true
+          "bundled": true,
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
-          "resolved": false,
-          "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
+          "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -9732,8 +14371,7 @@
         },
         "minizlib": {
           "version": "1.2.1",
-          "resolved": false,
-          "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -9742,25 +14380,21 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": false,
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
         },
         "ms": {
           "version": "2.1.1",
-          "resolved": false,
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "needle": {
           "version": "2.3.0",
-          "resolved": false,
-          "integrity": "sha512-QBZu7aAFR0522EyaXZM0FZ9GLpq6lvQ3uq8gteiDUp7wKdy0lSd2hPlgFwVuW1CBkfEs9PfDQsQzZghLs/psdg==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -9771,8 +14405,7 @@
         },
         "node-pre-gyp": {
           "version": "0.12.0",
-          "resolved": false,
-          "integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -9790,8 +14423,7 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "resolved": false,
-          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -9801,15 +14433,13 @@
         },
         "npm-bundled": {
           "version": "1.0.6",
-          "resolved": false,
-          "integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "npm-packlist": {
           "version": "1.4.1",
-          "resolved": false,
-          "integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -9819,8 +14449,7 @@
         },
         "npmlog": {
           "version": "4.1.2",
-          "resolved": false,
-          "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -9832,46 +14461,38 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "resolved": false,
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true,
-          "optional": true
+          "bundled": true,
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "resolved": false,
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "resolved": false,
-          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+          "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
         },
         "os-homedir": {
           "version": "1.0.2",
-          "resolved": false,
-          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "resolved": false,
-          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "osenv": {
           "version": "0.1.5",
-          "resolved": false,
-          "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -9881,22 +14502,19 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "resolved": false,
-          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "resolved": false,
-          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "rc": {
           "version": "1.2.8",
-          "resolved": false,
-          "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -9908,8 +14526,7 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "resolved": false,
-              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+              "bundled": true,
               "dev": true,
               "optional": true
             }
@@ -9917,8 +14534,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": false,
-          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -9933,8 +14549,7 @@
         },
         "rimraf": {
           "version": "2.6.3",
-          "resolved": false,
-          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -9943,52 +14558,43 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "resolved": false,
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true,
-          "optional": true
+          "bundled": true,
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "resolved": false,
-          "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "sax": {
           "version": "1.2.4",
-          "resolved": false,
-          "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "semver": {
           "version": "5.7.0",
-          "resolved": false,
-          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "resolved": false,
-          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "resolved": false,
-          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": false,
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -9997,8 +14603,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": false,
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -10007,25 +14612,21 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": false,
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "resolved": false,
-          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "tar": {
           "version": "4.4.8",
-          "resolved": false,
-          "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -10040,15 +14641,13 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "resolved": false,
-          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "wide-align": {
           "version": "1.1.3",
-          "resolved": false,
-          "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -10057,24 +14656,20 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "resolved": false,
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true,
-          "optional": true
+          "bundled": true,
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
-          "resolved": false,
-          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-          "dev": true,
-          "optional": true
+          "bundled": true,
+          "dev": true
         }
       }
     },
     "fstream": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-      "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+      "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.2",
@@ -10126,6 +14721,28 @@
         "string-width": "^1.0.1",
         "strip-ansi": "^3.0.1",
         "wide-align": "^1.1.0"
+      },
+      "dependencies": {
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        }
       }
     },
     "gaze": {
@@ -10156,10 +14773,25 @@
       "dev": true
     },
     "get-stream": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-      "dev": true
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+      "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+      "dev": true,
+      "requires": {
+        "pump": "^3.0.0"
+      },
+      "dependencies": {
+        "pump": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+          "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+          "dev": true,
+          "requires": {
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
+          }
+        }
+      }
     },
     "get-value": {
       "version": "2.0.6",
@@ -10185,23 +14817,12 @@
         "extend-shallow": "^2.0.1",
         "fs-exists-sync": "^0.1.0",
         "homedir-polyfill": "^1.0.0"
-      },
-      "dependencies": {
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "dev": true,
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
-        }
       }
     },
     "glob": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+      "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
       "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
@@ -10220,53 +14841,15 @@
       "requires": {
         "glob-parent": "^2.0.0",
         "is-glob": "^2.0.0"
-      },
-      "dependencies": {
-        "glob-parent": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-          "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-          "dev": true,
-          "requires": {
-            "is-glob": "^2.0.0"
-          }
-        },
-        "is-extglob": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true
-        },
-        "is-glob": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "^1.0.0"
-          }
-        }
       }
     },
     "glob-parent": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
-      "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+      "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
       "dev": true,
       "requires": {
-        "is-glob": "^3.1.0",
-        "path-dirname": "^1.0.0"
-      },
-      "dependencies": {
-        "is-glob": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-          "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "^2.1.0"
-          }
-        }
+        "is-glob": "^2.0.0"
       }
     },
     "glob-to-regexp": {
@@ -10275,6 +14858,34 @@
       "integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=",
       "dev": true
     },
+    "global-modules": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
+      "integrity": "sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==",
+      "dev": true,
+      "requires": {
+        "global-prefix": "^3.0.0"
+      }
+    },
+    "global-prefix": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
+      "integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
+      "dev": true,
+      "requires": {
+        "ini": "^1.3.5",
+        "kind-of": "^6.0.2",
+        "which": "^1.3.1"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
+        }
+      }
+    },
     "globals": {
       "version": "9.18.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
@@ -10282,9 +14893,9 @@
       "dev": true
     },
     "globby": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-10.0.0.tgz",
-      "integrity": "sha512-3LifW9M4joGZasyYPz2A1U74zbC/45fvpXUvO/9KbSa+VV0aGZarWkfdgKyR9sExNP0t0x0ss/UMJpNpcaTspw==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-10.0.1.tgz",
+      "integrity": "sha512-sSs4inE1FB2YQiymcmTv6NWENryABjUNPeWhOvmn4SjtKybglsyPZxFB3U1/+L1bYi0rNZDqCLlHyLYDl1Pq5A==",
       "dev": true,
       "requires": {
         "@types/glob": "^7.1.1",
@@ -10366,38 +14977,49 @@
         }
       }
     },
-    "google-maps-infobox": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/google-maps-infobox/-/google-maps-infobox-2.0.0.tgz",
-      "integrity": "sha512-hTuWmWZZSOxf5D/z7l3/hTF1grgRvLG53BEKMdjiKOG+FcK/kH7vqseUeyIU9Zj2ZIqKTOaro0nknxpAuRq4Vw==",
-      "dev": true
-    },
     "got": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
-      "integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/got/-/got-8.3.2.tgz",
+      "integrity": "sha512-qjUJ5U/hawxosMryILofZCkm3C84PLJS/0grRIpjAwu+Lkxxj5cxeCU25BG0/3mDSpXKTyZr8oh8wIgLaH0QCw==",
       "dev": true,
       "requires": {
-        "decompress-response": "^3.2.0",
+        "@sindresorhus/is": "^0.7.0",
+        "cacheable-request": "^2.1.1",
+        "decompress-response": "^3.3.0",
         "duplexer3": "^0.1.4",
         "get-stream": "^3.0.0",
-        "is-plain-obj": "^1.1.0",
-        "is-retry-allowed": "^1.0.0",
-        "is-stream": "^1.0.0",
+        "into-stream": "^3.1.0",
+        "is-retry-allowed": "^1.1.0",
         "isurl": "^1.0.0-alpha5",
         "lowercase-keys": "^1.0.0",
-        "p-cancelable": "^0.3.0",
-        "p-timeout": "^1.1.1",
-        "safe-buffer": "^5.0.1",
-        "timed-out": "^4.0.0",
-        "url-parse-lax": "^1.0.0",
+        "mimic-response": "^1.0.0",
+        "p-cancelable": "^0.4.0",
+        "p-timeout": "^2.0.1",
+        "pify": "^3.0.0",
+        "safe-buffer": "^5.1.1",
+        "timed-out": "^4.0.1",
+        "url-parse-lax": "^3.0.0",
         "url-to-options": "^1.0.1"
+      },
+      "dependencies": {
+        "get-stream": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+          "dev": true
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        }
       }
     },
     "graceful-fs": {
-      "version": "4.1.15",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
-      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.0.tgz",
+      "integrity": "sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg==",
       "dev": true
     },
     "growly": {
@@ -10422,19 +15044,6 @@
         "optimist": "^0.6.1",
         "source-map": "^0.6.1",
         "uglify-js": "^3.1.4"
-      },
-      "dependencies": {
-        "uglify-js": {
-          "version": "3.5.11",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.11.tgz",
-          "integrity": "sha512-izPJg8RsSyqxbdnqX36ExpbH3K7tDBsAU/VfNv89VkMFy3z39zFjunQGsSHOlGlyIfGLGprGeosgQno3bo2/Kg==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "commander": "~2.20.0",
-            "source-map": "~0.6.1"
-          }
-        }
       }
     },
     "har-schema": {
@@ -10513,6 +15122,14 @@
         "get-value": "^2.0.6",
         "has-values": "^1.0.0",
         "isobject": "^3.0.0"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        }
       }
     },
     "has-values": {
@@ -10525,6 +15142,26 @@
         "kind-of": "^4.0.0"
       },
       "dependencies": {
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
         "kind-of": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
@@ -10581,6 +15218,11 @@
         "minimalistic-crypto-utils": "^1.0.1"
       }
     },
+    "hoist-non-react-statics": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
+      "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
+    },
     "home-or-tmp": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
@@ -10619,20 +15261,12 @@
       }
     },
     "html-element-map": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/html-element-map/-/html-element-map-1.0.1.tgz",
-      "integrity": "sha512-BZSfdEm6n706/lBfXKWa4frZRZcT5k1cOusw95ijZsHlI+GdgY0v95h6IzO3iIDf2ROwq570YTwqNPqHcNMozw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/html-element-map/-/html-element-map-1.1.0.tgz",
+      "integrity": "sha512-iqiG3dTZmy+uUaTmHarTL+3/A2VW9ox/9uasKEZC+R/wAtUrTcRlXPSaPqsnWPfIu8wqn09jQNwMRqzL54jSYA==",
       "dev": true,
       "requires": {
         "array-filter": "^1.0.0"
-      },
-      "dependencies": {
-        "array-filter": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-1.0.0.tgz",
-          "integrity": "sha1-uveeYubvTCpMC4MSMtr/7CUfnYM=",
-          "dev": true
-        }
       }
     },
     "html-encoding-sniffer": {
@@ -10684,9 +15318,9 @@
       },
       "dependencies": {
         "readable-stream": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.3.0.tgz",
-          "integrity": "sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==",
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
           "dev": true,
           "requires": {
             "inherits": "^2.0.3",
@@ -10696,6 +15330,12 @@
         }
       }
     },
+    "http-cache-semantics": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz",
+      "integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w==",
+      "dev": true
+    },
     "http-deceiver": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz",
@@ -10703,21 +15343,30 @@
       "dev": true
     },
     "http-errors": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
-      "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
+      "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
       "dev": true,
       "requires": {
         "depd": "~1.1.2",
         "inherits": "2.0.3",
-        "setprototypeof": "1.1.0",
-        "statuses": ">= 1.4.0 < 2"
+        "setprototypeof": "1.1.1",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.0"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "dev": true
+        }
       }
     },
     "http-parser-js": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.0.tgz",
-      "integrity": "sha512-cZdEF7r4gfRIq7ezX9J0T+kQmJNOub71dWbgAXVHDct80TKP4MCETtZQ31xyv38UwgzkWPYF/Xc0ge55dW9Z9w==",
+      "version": "0.4.10",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.10.tgz",
+      "integrity": "sha1-ksnBN0w1CF912zWexWzCV8u5P6Q=",
       "dev": true
     },
     "http-proxy": {
@@ -10762,6 +15411,328 @@
         "is-glob": "^4.0.0",
         "lodash": "^4.17.11",
         "micromatch": "^3.1.10"
+      },
+      "dependencies": {
+        "arr-diff": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+          "dev": true
+        },
+        "array-unique": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+          "dev": true
+        },
+        "braces": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "expand-brackets": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+          "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+          "dev": true,
+          "requires": {
+            "debug": "^2.3.3",
+            "define-property": "^0.2.5",
+            "extend-shallow": "^2.0.1",
+            "posix-character-classes": "^0.1.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+              "dev": true,
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "0.1.6",
+              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+              "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+              "dev": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "dev": true,
+                  "requires": {
+                    "is-buffer": "^1.1.5"
+                  }
+                }
+              }
+            },
+            "is-data-descriptor": {
+              "version": "0.1.4",
+              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+              "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+              "dev": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "dev": true,
+                  "requires": {
+                    "is-buffer": "^1.1.5"
+                  }
+                }
+              }
+            },
+            "is-descriptor": {
+              "version": "0.1.6",
+              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+              "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+              "dev": true,
+              "requires": {
+                "is-accessor-descriptor": "^0.1.6",
+                "is-data-descriptor": "^0.1.4",
+                "kind-of": "^5.0.0"
+              }
+            },
+            "kind-of": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+              "dev": true
+            }
+          }
+        },
+        "extend-shallow": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+          "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+          "dev": true,
+          "requires": {
+            "assign-symbols": "^1.0.0",
+            "is-extendable": "^1.0.1"
+          },
+          "dependencies": {
+            "is-extendable": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+              "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+              "dev": true,
+              "requires": {
+                "is-plain-object": "^2.0.4"
+              }
+            }
+          }
+        },
+        "extglob": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+          "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+          "dev": true,
+          "requires": {
+            "array-unique": "^0.3.2",
+            "define-property": "^1.0.0",
+            "expand-brackets": "^2.1.4",
+            "extend-shallow": "^2.0.1",
+            "fragment-cache": "^0.2.1",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+              "dev": true,
+              "requires": {
+                "is-descriptor": "^1.0.0"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "dev": true,
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        },
+        "is-extglob": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+          "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+          "dev": true,
+          "requires": {
+            "is-extglob": "^2.1.1"
+          }
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
+        },
+        "micromatch": {
+          "version": "3.1.10",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+          "dev": true,
+          "requires": {
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.3.1",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "extglob": "^2.0.4",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^6.0.2",
+            "nanomatch": "^1.2.9",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.2"
+          }
+        },
+        "to-regex-range": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+          "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+          "dev": true,
+          "requires": {
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1"
+          }
+        }
       }
     },
     "http-signature": {
@@ -10782,12 +15753,12 @@
       "dev": true
     },
     "https-proxy-agent": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
-      "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.2.tgz",
+      "integrity": "sha512-c8Ndjc9Bkpfx/vCJueCPy0jlP4ccCCSNDp8xwCZzPjKJUm+B+u9WX2x98Qx4n1PiMNTWo3D7KK5ifNV/yJyRzg==",
       "dev": true,
       "requires": {
-        "agent-base": "^4.1.0",
+        "agent-base": "^4.3.0",
         "debug": "^3.1.0"
       },
       "dependencies": {
@@ -10801,9 +15772,9 @@
           }
         },
         "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         }
       }
@@ -10815,11 +15786,12 @@
       "dev": true
     },
     "husky": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-3.0.0.tgz",
-      "integrity": "sha512-lKMEn7bRK+7f5eWPNGclDVciYNQt0GIkAQmhKl+uHP1qFzoN0h92kmH9HZ8PCwyVA2EQPD8KHf0FYWqnTxau+Q==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-3.0.1.tgz",
+      "integrity": "sha512-PXBv+iGKw23GHUlgELRlVX9932feFL407/wHFwtsGeArp0dDM4u+/QusSQwPKxmNgjpSL+ustbOdQ2jetgAZbA==",
       "dev": true,
       "requires": {
+        "chalk": "^2.4.2",
         "cosmiconfig": "^5.2.1",
         "execa": "^1.0.0",
         "get-stdin": "^7.0.0",
@@ -10832,46 +15804,6 @@
         "slash": "^3.0.0"
       },
       "dependencies": {
-        "cosmiconfig": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
-          "integrity": "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==",
-          "dev": true,
-          "requires": {
-            "import-fresh": "^2.0.0",
-            "is-directory": "^0.3.1",
-            "js-yaml": "^3.13.1",
-            "parse-json": "^4.0.0"
-          }
-        },
-        "cross-spawn": {
-          "version": "6.0.5",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-          "dev": true,
-          "requires": {
-            "nice-try": "^1.0.4",
-            "path-key": "^2.0.1",
-            "semver": "^5.5.0",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
-          }
-        },
-        "execa": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
-          "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
-          "dev": true,
-          "requires": {
-            "cross-spawn": "^6.0.0",
-            "get-stream": "^4.0.0",
-            "is-stream": "^1.1.0",
-            "npm-run-path": "^2.0.0",
-            "p-finally": "^1.0.0",
-            "signal-exit": "^3.0.0",
-            "strip-eof": "^1.0.0"
-          }
-        },
         "find-up": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -10887,15 +15819,6 @@
           "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-7.0.0.tgz",
           "integrity": "sha512-zRKcywvrXlXsA0v0i9Io4KDRaAw7+a1ZpjRwl9Wox8PFlVCCHra7E9c4kqXCoCM9nR5tBkaTTZRBoCm60bFqTQ==",
           "dev": true
-        },
-        "get-stream": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
-          "dev": true,
-          "requires": {
-            "pump": "^3.0.0"
-          }
         },
         "locate-path": {
           "version": "5.0.0",
@@ -10930,6 +15853,18 @@
           "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
           "dev": true
         },
+        "parse-json": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
+          "integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1",
+            "lines-and-columns": "^1.1.6"
+          }
+        },
         "path-exists": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -10945,33 +15880,17 @@
             "find-up": "^4.0.0"
           }
         },
-        "pump": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-          "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-          "dev": true,
-          "requires": {
-            "end-of-stream": "^1.1.0",
-            "once": "^1.3.1"
-          }
-        },
         "read-pkg": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.1.1.tgz",
-          "integrity": "sha512-dFcTLQi6BZ+aFUaICg7er+/usEoqFdQxiEBsEMNGoipenihtxxtdrQuBXvyANCEI8VuUIVYFgeHGx9sLLvim4w==",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+          "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
           "dev": true,
           "requires": {
             "@types/normalize-package-data": "^2.4.0",
             "normalize-package-data": "^2.5.0",
-            "parse-json": "^4.0.0",
-            "type-fest": "^0.4.1"
+            "parse-json": "^5.0.0",
+            "type-fest": "^0.6.0"
           }
-        },
-        "semver": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
-          "dev": true
         },
         "slash": {
           "version": "3.0.0",
@@ -11003,7 +15922,6 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "dev": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
@@ -11021,6 +15939,19 @@
       "dev": true,
       "requires": {
         "postcss": "^6.0.1"
+      },
+      "dependencies": {
+        "postcss": {
+          "version": "6.0.23",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.4.1",
+            "source-map": "^0.6.1",
+            "supports-color": "^5.4.0"
+          }
+        }
       }
     },
     "ieee754": {
@@ -11051,13 +15982,13 @@
       }
     },
     "import-fresh": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
-      "integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.1.0.tgz",
+      "integrity": "sha512-PpuksHKGt8rXfWEr9m9EHIpgyyaltBy8+eF6GJM0QCAxMgxCfucMF3mjecK2QsJr0amJW7gTqh5/wht0z2UhEQ==",
       "dev": true,
       "requires": {
-        "caller-path": "^2.0.0",
-        "resolve-from": "^3.0.0"
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
       }
     },
     "import-from": {
@@ -11067,7 +15998,21 @@
       "dev": true,
       "requires": {
         "resolve-from": "^3.0.0"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+          "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+          "dev": true
+        }
       }
+    },
+    "import-lazy": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-3.1.0.tgz",
+      "integrity": "sha512-8/gvXvX2JMn0F+CDlSC4l6kOmVaLOO3XLkksI7CI3Ud95KDYJuYur2b9P/PUt/i/pDAMd/DulQsNbbbmRRsDIQ==",
+      "dev": true
     },
     "import-local": {
       "version": "1.0.0",
@@ -11103,12 +16048,6 @@
       "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc=",
       "dev": true
     },
-    "indexof": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
-      "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=",
-      "dev": true
-    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -11120,9 +16059,9 @@
       }
     },
     "inherits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
     "ini": {
@@ -11130,6 +16069,44 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
       "dev": true
+    },
+    "inquirer": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.0.tgz",
+      "integrity": "sha512-scfHejeG/lVZSpvCXpsB4j/wQNPM5JC8kiElOI0OUTwmc1RTpXr4H32/HOlQHcZiYl2z2VElwuCVDRG8vFmbnA==",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "^3.2.0",
+        "chalk": "^2.4.2",
+        "cli-cursor": "^2.1.0",
+        "cli-width": "^2.0.0",
+        "external-editor": "^3.0.3",
+        "figures": "^2.0.0",
+        "lodash": "^4.17.12",
+        "mute-stream": "0.0.7",
+        "run-async": "^2.2.0",
+        "rxjs": "^6.4.0",
+        "string-width": "^2.1.0",
+        "strip-ansi": "^5.1.0",
+        "through": "^2.3.6"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
+      }
     },
     "internal-ip": {
       "version": "1.2.0",
@@ -11145,6 +16122,16 @@
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
       "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==",
       "dev": true
+    },
+    "into-stream": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
+      "integrity": "sha1-lvsKk2wSur1v8XUqF9BWFqvQlMY=",
+      "dev": true,
+      "requires": {
+        "from2": "^2.1.1",
+        "p-is-promise": "^1.1.0"
+      }
     },
     "invariant": {
       "version": "2.2.4",
@@ -11189,9 +16176,9 @@
       }
     },
     "is-alphabetical": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.2.tgz",
-      "integrity": "sha512-V0xN4BYezDHcBSKb1QHUFMlR4as/XEuCZBzMJUU4n7+Cbt33SmUnSol+pnXFvLxSHNq2CemUXNdaXV6Flg7+xg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.3.tgz",
+      "integrity": "sha512-eEMa6MKpHFzw38eKm56iNNi6GJ7lf6aLLio7Kr23sJPAECscgRtZvOBYybejWDQ2bM949Y++61PY+udzj5QMLA==",
       "dev": true
     },
     "is-alphanumeric": {
@@ -11201,9 +16188,9 @@
       "dev": true
     },
     "is-alphanumerical": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.2.tgz",
-      "integrity": "sha512-pyfU/0kHdISIgslFfZN9nfY1Gk3MquQgUm1mJTjdkEPpkAKNWuBTSqFwewOpR7N351VkErCiyV71zX7mlQQqsg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.3.tgz",
+      "integrity": "sha512-A1IGAPO5AW9vSh7omxIlOGwIqEvpW/TA+DksVOPM5ODuxKlZS09+TEM1E3275lJqO2oJ38vDpeAL3DCIiHE6eA==",
       "dev": true,
       "requires": {
         "is-alphabetical": "^1.0.0",
@@ -11277,9 +16264,9 @@
       "dev": true
     },
     "is-decimal": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.2.tgz",
-      "integrity": "sha512-TRzl7mOCchnhchN+f3ICUCzYvL9ul7R+TYOsZ8xia++knyZAJfv/uA1FvQXsAnYIl1T3B2X5E/J7Wb1QXiIBXg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.3.tgz",
+      "integrity": "sha512-bvLSwoDg2q6Gf+E2LEPiklHZxxiSi3XAh4Mav65mKqTfCO1HM3uBs24TjEH8iJX3bbDdLXKJXBTmGzuTUuAEjQ==",
       "dev": true
     },
     "is-descriptor": {
@@ -11329,9 +16316,9 @@
       "dev": true
     },
     "is-extglob": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
       "dev": true
     },
     "is-finite": {
@@ -11344,33 +16331,30 @@
       }
     },
     "is-fullwidth-code-point": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-      "dev": true,
-      "requires": {
-        "number-is-nan": "^1.0.0"
-      }
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true
     },
     "is-glob": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
-      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+      "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
       "dev": true,
       "requires": {
-        "is-extglob": "^2.1.1"
+        "is-extglob": "^1.0.0"
       }
     },
     "is-hexadecimal": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.2.tgz",
-      "integrity": "sha512-but/G3sapV3MNyqiDBLrOi4x8uCIw0RY3o/Vb5GT0sMFHrVV7731wFSVy41T5FO1og7G0gXLJh0MkgPRouko/A==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.3.tgz",
+      "integrity": "sha512-zxQ9//Q3D/34poZf8fiy3m3XVpbQc7ren15iKqrTtLPwkPD/t3Scy9Imp63FujULGxuK0ZlCwoo5xNpktFgbOA==",
       "dev": true
     },
     "is-number": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-      "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+      "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
       "dev": true,
       "requires": {
         "kind-of": "^3.0.2"
@@ -11440,6 +16424,14 @@
       "dev": true,
       "requires": {
         "isobject": "^3.0.1"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        }
       }
     },
     "is-posix-bracket": {
@@ -11484,8 +16476,7 @@
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-      "dev": true
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
     },
     "is-string": {
       "version": "1.0.4",
@@ -11527,9 +16518,9 @@
       "dev": true
     },
     "is-whitespace-character": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-whitespace-character/-/is-whitespace-character-1.0.2.tgz",
-      "integrity": "sha512-SzM+T5GKUCtLhlHFKt2SDAX2RFzfS6joT91F2/WSi9LxgFdsnhfPK/UIA+JhRR2xuyLdrCys2PiFDrtn1fU5hQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-whitespace-character/-/is-whitespace-character-1.0.3.tgz",
+      "integrity": "sha512-SNPgMLz9JzPccD3nPctcj8sZlX9DAMJSKH8bP7Z6bohCwuNgX8xbWr1eTAYXX9Vpi/aSn8Y1akL9WgM3t43YNQ==",
       "dev": true
     },
     "is-windows": {
@@ -11539,9 +16530,9 @@
       "dev": true
     },
     "is-word-character": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-word-character/-/is-word-character-1.0.2.tgz",
-      "integrity": "sha512-T3FlsX8rCHAH8e7RE7PfOPZVFQlcV3XRF9eOOBQ1uf70OxO7CjjSOjeImMPCADBdYWcStAbVbYvJ1m2D3tb+EA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-word-character/-/is-word-character-1.0.3.tgz",
+      "integrity": "sha512-0wfcrFgOOOBdgRNT9H33xe6Zi6yhX/uoc4U8NBZGeQQB0ctU1dnlNTyL9JM2646bHDTpsDm1Brb3VPoCIMrd/A==",
       "dev": true
     },
     "is-wsl": {
@@ -11563,16 +16554,18 @@
       "dev": true
     },
     "isobject": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-      "dev": true
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+      "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+      "dev": true,
+      "requires": {
+        "isarray": "1.0.0"
+      }
     },
     "isomorphic-fetch": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
       "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
-      "dev": true,
       "requires": {
         "node-fetch": "^1.0.1",
         "whatwg-fetch": ">=0.10.0"
@@ -11693,9 +16686,9 @@
           }
         },
         "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         },
         "source-map": {
@@ -11738,38 +16731,6 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "arr-diff": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-          "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-          "dev": true,
-          "requires": {
-            "arr-flatten": "^1.0.1"
-          }
-        },
-        "array-unique": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-          "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
-          "dev": true
-        },
-        "braces": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-          "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-          "dev": true,
-          "requires": {
-            "expand-range": "^1.8.1",
-            "preserve": "^0.2.0",
-            "repeat-element": "^1.1.2"
-          }
-        },
-        "camelcase": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
           "dev": true
         },
         "ci-info": {
@@ -11817,24 +16778,6 @@
             }
           }
         },
-        "expand-brackets": {
-          "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-          "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-          "dev": true,
-          "requires": {
-            "is-posix-bracket": "^0.1.0"
-          }
-        },
-        "extglob": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-          "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "^1.0.0"
-          }
-        },
         "is-ci": {
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
@@ -11844,19 +16787,13 @@
             "ci-info": "^1.5.0"
           }
         },
-        "is-extglob": {
+        "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true
-        },
-        "is-glob": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
-            "is-extglob": "^1.0.0"
+            "number-is-nan": "^1.0.0"
           }
         },
         "jest-cli": {
@@ -11896,34 +16833,41 @@
             "yargs": "^9.0.0"
           }
         },
-        "micromatch": {
-          "version": "2.3.11",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-          "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+        "load-json-file": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+          "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
           "dev": true,
           "requires": {
-            "arr-diff": "^2.0.0",
-            "array-unique": "^0.2.1",
-            "braces": "^1.8.2",
-            "expand-brackets": "^0.1.4",
-            "extglob": "^0.3.1",
-            "filename-regex": "^2.0.0",
-            "is-extglob": "^1.0.0",
-            "is-glob": "^2.0.1",
-            "kind-of": "^3.0.2",
-            "normalize-path": "^2.0.1",
-            "object.omit": "^2.0.0",
-            "parse-glob": "^3.0.4",
-            "regex-cache": "^0.4.2"
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "strip-bom": "^3.0.0"
+          },
+          "dependencies": {
+            "pify": {
+              "version": "2.3.0",
+              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+              "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+              "dev": true
+            }
           }
         },
-        "normalize-path": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-          "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+        "path-type": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
           "dev": true,
           "requires": {
-            "remove-trailing-separator": "^1.0.1"
+            "pify": "^2.0.0"
+          },
+          "dependencies": {
+            "pify": {
+              "version": "2.3.0",
+              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+              "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+              "dev": true
+            }
           }
         },
         "pify": {
@@ -11932,22 +16876,25 @@
           "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
           "dev": true
         },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+        "read-pkg": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+          "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
-          },
-          "dependencies": {
-            "is-fullwidth-code-point": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-              "dev": true
-            }
+            "load-json-file": "^2.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^2.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+          "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+          "dev": true,
+          "requires": {
+            "find-up": "^2.0.0",
+            "read-pkg": "^2.0.0"
           }
         },
         "strip-ansi": {
@@ -11958,6 +16905,18 @@
           "requires": {
             "ansi-regex": "^3.0.0"
           }
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+          "dev": true
+        },
+        "y18n": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+          "dev": true
         },
         "yargs": {
           "version": "9.0.1",
@@ -11978,6 +16937,15 @@
             "which-module": "^2.0.0",
             "y18n": "^3.2.1",
             "yargs-parser": "^7.0.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
+          "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
+          "dev": true,
+          "requires": {
+            "camelcase": "^4.1.0"
           }
         }
       }
@@ -12067,97 +17035,6 @@
         "micromatch": "^2.3.11",
         "sane": "^2.0.0",
         "worker-farm": "^1.3.1"
-      },
-      "dependencies": {
-        "arr-diff": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-          "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-          "dev": true,
-          "requires": {
-            "arr-flatten": "^1.0.1"
-          }
-        },
-        "array-unique": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-          "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
-          "dev": true
-        },
-        "braces": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-          "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-          "dev": true,
-          "requires": {
-            "expand-range": "^1.8.1",
-            "preserve": "^0.2.0",
-            "repeat-element": "^1.1.2"
-          }
-        },
-        "expand-brackets": {
-          "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-          "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-          "dev": true,
-          "requires": {
-            "is-posix-bracket": "^0.1.0"
-          }
-        },
-        "extglob": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-          "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "^1.0.0"
-          }
-        },
-        "is-extglob": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true
-        },
-        "is-glob": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "^1.0.0"
-          }
-        },
-        "micromatch": {
-          "version": "2.3.11",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-          "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-          "dev": true,
-          "requires": {
-            "arr-diff": "^2.0.0",
-            "array-unique": "^0.2.1",
-            "braces": "^1.8.2",
-            "expand-brackets": "^0.1.4",
-            "extglob": "^0.3.1",
-            "filename-regex": "^2.0.0",
-            "is-extglob": "^1.0.0",
-            "is-glob": "^2.0.1",
-            "kind-of": "^3.0.2",
-            "normalize-path": "^2.0.1",
-            "object.omit": "^2.0.0",
-            "parse-glob": "^3.0.4",
-            "regex-cache": "^0.4.2"
-          }
-        },
-        "normalize-path": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-          "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-          "dev": true,
-          "requires": {
-            "remove-trailing-separator": "^1.0.1"
-          }
-        }
       }
     },
     "jest-jasmine2": {
@@ -12174,6 +17051,14 @@
         "jest-message-util": "^21.2.1",
         "jest-snapshot": "^21.2.1",
         "p-cancelable": "^0.3.0"
+      },
+      "dependencies": {
+        "p-cancelable": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
+          "integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw==",
+          "dev": true
+        }
       }
     },
     "jest-matcher-utils": {
@@ -12196,97 +17081,6 @@
         "chalk": "^2.0.1",
         "micromatch": "^2.3.11",
         "slash": "^1.0.0"
-      },
-      "dependencies": {
-        "arr-diff": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-          "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-          "dev": true,
-          "requires": {
-            "arr-flatten": "^1.0.1"
-          }
-        },
-        "array-unique": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-          "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
-          "dev": true
-        },
-        "braces": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-          "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-          "dev": true,
-          "requires": {
-            "expand-range": "^1.8.1",
-            "preserve": "^0.2.0",
-            "repeat-element": "^1.1.2"
-          }
-        },
-        "expand-brackets": {
-          "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-          "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-          "dev": true,
-          "requires": {
-            "is-posix-bracket": "^0.1.0"
-          }
-        },
-        "extglob": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-          "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "^1.0.0"
-          }
-        },
-        "is-extglob": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true
-        },
-        "is-glob": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "^1.0.0"
-          }
-        },
-        "micromatch": {
-          "version": "2.3.11",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-          "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-          "dev": true,
-          "requires": {
-            "arr-diff": "^2.0.0",
-            "array-unique": "^0.2.1",
-            "braces": "^1.8.2",
-            "expand-brackets": "^0.1.4",
-            "extglob": "^0.3.1",
-            "filename-regex": "^2.0.0",
-            "is-extglob": "^1.0.0",
-            "is-glob": "^2.0.1",
-            "kind-of": "^3.0.2",
-            "normalize-path": "^2.0.1",
-            "object.omit": "^2.0.0",
-            "parse-glob": "^3.0.4",
-            "regex-cache": "^0.4.2"
-          }
-        },
-        "normalize-path": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-          "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-          "dev": true,
-          "requires": {
-            "remove-trailing-separator": "^1.0.1"
-          }
-        }
       }
     },
     "jest-mock": {
@@ -12372,27 +17166,6 @@
         "yargs": "^9.0.0"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "arr-diff": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-          "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-          "dev": true,
-          "requires": {
-            "arr-flatten": "^1.0.1"
-          }
-        },
-        "array-unique": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-          "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
-          "dev": true
-        },
         "babel-jest": {
           "version": "21.2.0",
           "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-21.2.0.tgz",
@@ -12419,23 +17192,6 @@
             "babel-plugin-syntax-object-rest-spread": "^6.13.0"
           }
         },
-        "braces": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-          "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-          "dev": true,
-          "requires": {
-            "expand-range": "^1.8.1",
-            "preserve": "^0.2.0",
-            "repeat-element": "^1.1.2"
-          }
-        },
-        "camelcase": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-          "dev": true
-        },
         "cliui": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
@@ -12460,95 +17216,68 @@
             }
           }
         },
-        "expand-brackets": {
-          "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-          "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-          "dev": true,
-          "requires": {
-            "is-posix-bracket": "^0.1.0"
-          }
-        },
-        "extglob": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-          "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "^1.0.0"
-          }
-        },
-        "is-extglob": {
+        "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "load-json-file": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+          "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "strip-bom": "^3.0.0"
+          }
+        },
+        "path-type": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+          "dev": true,
+          "requires": {
+            "pify": "^2.0.0"
+          }
+        },
+        "read-pkg": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+          "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "^2.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^2.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+          "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+          "dev": true,
+          "requires": {
+            "find-up": "^2.0.0",
+            "read-pkg": "^2.0.0"
+          }
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
           "dev": true
         },
-        "is-glob": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "^1.0.0"
-          }
-        },
-        "micromatch": {
-          "version": "2.3.11",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-          "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-          "dev": true,
-          "requires": {
-            "arr-diff": "^2.0.0",
-            "array-unique": "^0.2.1",
-            "braces": "^1.8.2",
-            "expand-brackets": "^0.1.4",
-            "extglob": "^0.3.1",
-            "filename-regex": "^2.0.0",
-            "is-extglob": "^1.0.0",
-            "is-glob": "^2.0.1",
-            "kind-of": "^3.0.2",
-            "normalize-path": "^2.0.1",
-            "object.omit": "^2.0.0",
-            "parse-glob": "^3.0.4",
-            "regex-cache": "^0.4.2"
-          }
-        },
-        "normalize-path": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-          "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-          "dev": true,
-          "requires": {
-            "remove-trailing-separator": "^1.0.1"
-          }
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
-          },
-          "dependencies": {
-            "is-fullwidth-code-point": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-              "dev": true
-            },
-            "strip-ansi": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-              "dev": true,
-              "requires": {
-                "ansi-regex": "^3.0.0"
-              }
-            }
-          }
+        "y18n": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+          "dev": true
         },
         "yargs": {
           "version": "9.0.1",
@@ -12569,6 +17298,15 @@
             "which-module": "^2.0.0",
             "y18n": "^3.2.1",
             "yargs-parser": "^7.0.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
+          "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
+          "dev": true,
+          "requires": {
+            "camelcase": "^4.1.0"
           }
         }
       }
@@ -12600,6 +17338,14 @@
         "jest-mock": "^21.2.0",
         "jest-validate": "^21.2.1",
         "mkdirp": "^0.5.1"
+      },
+      "dependencies": {
+        "callsites": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+          "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
+          "dev": true
+        }
       }
     },
     "jest-validate": {
@@ -12621,10 +17367,9 @@
       "dev": true
     },
     "js-tokens": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
     },
     "js-yaml": {
       "version": "3.13.1",
@@ -12634,14 +17379,6 @@
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
-      },
-      "dependencies": {
-        "esprima": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-          "dev": true
-        }
       }
     },
     "jsbn": {
@@ -12692,9 +17429,9 @@
       }
     },
     "jsesc": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-      "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+      "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
       "dev": true
     },
     "jsome": {
@@ -12706,86 +17443,13 @@
         "chalk": "^2.3.0",
         "json-stringify-safe": "^5.0.1",
         "yargs": "^11.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "camelcase": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-          "dev": true
-        },
-        "cliui": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
-          "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
-          "dev": true,
-          "requires": {
-            "string-width": "^2.1.1",
-            "strip-ansi": "^4.0.0",
-            "wrap-ansi": "^2.0.0"
-          }
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^3.0.0"
-          }
-        },
-        "yargs": {
-          "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
-          "integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
-          "dev": true,
-          "requires": {
-            "cliui": "^4.0.0",
-            "decamelize": "^1.1.1",
-            "find-up": "^2.1.0",
-            "get-caller-file": "^1.0.1",
-            "os-locale": "^2.0.0",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
-            "set-blocking": "^2.0.0",
-            "string-width": "^2.0.0",
-            "which-module": "^2.0.0",
-            "y18n": "^3.2.1",
-            "yargs-parser": "^9.0.2"
-          }
-        },
-        "yargs-parser": {
-          "version": "9.0.2",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
-          "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
-          "dev": true,
-          "requires": {
-            "camelcase": "^4.1.0"
-          }
-        }
       }
+    },
+    "json-buffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
+      "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=",
+      "dev": true
     },
     "json-loader": {
       "version": "0.5.7",
@@ -12833,9 +17497,9 @@
       "dev": true
     },
     "json3": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
-      "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.3.tgz",
+      "integrity": "sha512-c7/8mbUsKigAbLkD5B010BK4D9LZm7A1pNItkEwiUZRpIN66exu/e7YQWysGun+TRKaJp8MhemM+VkfWv42aCA==",
       "dev": true
     },
     "json5": {
@@ -12944,9 +17608,9 @@
       },
       "dependencies": {
         "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         },
         "semver": {
@@ -12970,12 +17634,13 @@
       }
     },
     "jsx-ast-utils": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.1.0.tgz",
-      "integrity": "sha512-yDGDG2DS4JcqhA6blsuYbtsT09xL8AoLuUR2Gb5exrw7UEM19sBcOTq+YBBhrNbl0PUC4R4LnFu+dHg2HKeVvA==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.2.1.tgz",
+      "integrity": "sha512-v3FxCcAf20DayI+uxnCuw795+oOIkVu6EnJ1+kSzhqqTZHNkTZ7B66ZgLp4oLJ/gbA64cI0B7WRoHZMSRdyVRQ==",
       "dev": true,
       "requires": {
-        "array-includes": "^3.0.3"
+        "array-includes": "^3.0.3",
+        "object.assign": "^4.1.0"
       }
     },
     "jszip": {
@@ -13006,6 +17671,15 @@
       "requires": {
         "jwa": "^1.4.1",
         "safe-buffer": "^5.0.1"
+      }
+    },
+    "keyv": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.0.0.tgz",
+      "integrity": "sha512-eguHnq22OE3uVoSYG0LVWNP+4ppamWr9+zWBe1bsNcovIMy6huUJFPgy4mGwCd/rnl3vOLGW1MTlu4c57CT1xA==",
+      "dev": true,
+      "requires": {
+        "json-buffer": "3.0.0"
       }
     },
     "killable": {
@@ -13106,10 +17780,16 @@
         "type-check": "~0.3.2"
       }
     },
+    "lines-and-columns": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
+      "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
+      "dev": true
+    },
     "lint-staged": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-9.0.0.tgz",
-      "integrity": "sha512-32TJoaeyAaj3rvabaXWe0eOhAhnsYRixEmXuSxKbs0uczFbwVjoDhJ/s2g6r1v8jMTw7t5OzXlHR8iaKtz8nLQ==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-9.2.0.tgz",
+      "integrity": "sha512-K/CQWcxYunc8lGMNTFvtI4+ybJcHW3K4Ghudz2OrJhIWdW/i1WWu9rGiVj4yJ0+D/xh8a08kp5slt89VZC9Eqg==",
       "dev": true,
       "requires": {
         "chalk": "^2.4.2",
@@ -13136,31 +17816,6 @@
             "fill-range": "^7.0.1"
           }
         },
-        "cosmiconfig": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
-          "integrity": "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==",
-          "dev": true,
-          "requires": {
-            "import-fresh": "^2.0.0",
-            "is-directory": "^0.3.1",
-            "js-yaml": "^3.13.1",
-            "parse-json": "^4.0.0"
-          }
-        },
-        "cross-spawn": {
-          "version": "6.0.5",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-          "dev": true,
-          "requires": {
-            "nice-try": "^1.0.4",
-            "path-key": "^2.0.1",
-            "semver": "^5.5.0",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
-          }
-        },
         "debug": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -13170,25 +17825,10 @@
             "ms": "^2.1.1"
           }
         },
-        "del": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/del/-/del-4.1.1.tgz",
-          "integrity": "sha512-QwGuEUouP2kVwQenAsOof5Fv8K9t3D8Ca8NxcXKrIpEHjTXK5J2nXLdP+ALI1cgv8wj7KuwBhTwBkOZSJKM5XQ==",
-          "dev": true,
-          "requires": {
-            "@types/glob": "^7.1.1",
-            "globby": "^6.1.0",
-            "is-path-cwd": "^2.0.0",
-            "is-path-in-cwd": "^2.0.0",
-            "p-map": "^2.0.0",
-            "pify": "^4.0.1",
-            "rimraf": "^2.6.3"
-          }
-        },
         "execa": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-2.0.2.tgz",
-          "integrity": "sha512-CkFnhVuWj5stQUvRSeI+zAw0ME+Iprkew4HKSc491vOXLM+hKrDVn+QQoL2CIYy0CpvT0mY+MXlzPreNbuj/8A==",
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-2.0.3.tgz",
+          "integrity": "sha512-iM124nlyGSrXmuyZF1EMe83ESY2chIYVyDRZKgmcDynid2Q2v/+GuE7gNMl6Sy9Niwf4MC0DDxagOxeMPjuLsw==",
           "dev": true,
           "requires": {
             "cross-spawn": "^6.0.5",
@@ -13220,47 +17860,11 @@
             "pump": "^3.0.0"
           }
         },
-        "globby": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
-          "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
-          "dev": true,
-          "requires": {
-            "array-union": "^1.0.1",
-            "glob": "^7.0.3",
-            "object-assign": "^4.0.1",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
-          },
-          "dependencies": {
-            "pify": {
-              "version": "2.3.0",
-              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-              "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-              "dev": true
-            }
-          }
-        },
-        "is-number": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-          "dev": true
-        },
         "is-stream": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
           "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
           "dev": true
-        },
-        "log-symbols": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
-          "integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.4.2"
-          }
         },
         "micromatch": {
           "version": "4.0.2",
@@ -13291,14 +17895,6 @@
           "dev": true,
           "requires": {
             "path-key": "^3.0.0"
-          },
-          "dependencies": {
-            "path-key": {
-              "version": "3.1.0",
-              "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.0.tgz",
-              "integrity": "sha512-8cChqz0RP6SHJkMt48FW0A7+qUOn+OsnOsVtzI59tZ8m+5bCSk7hzwET0pulwOM2YMn9J1efb07KB9l9f30SGg==",
-              "dev": true
-            }
           }
         },
         "onetime": {
@@ -13316,10 +17912,10 @@
           "integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==",
           "dev": true
         },
-        "pify": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+        "path-key": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.0.tgz",
+          "integrity": "sha512-8cChqz0RP6SHJkMt48FW0A7+qUOn+OsnOsVtzI59tZ8m+5bCSk7hzwET0pulwOM2YMn9J1efb07KB9l9f30SGg==",
           "dev": true
         },
         "pump": {
@@ -13330,21 +17926,6 @@
           "requires": {
             "end-of-stream": "^1.1.0",
             "once": "^1.3.1"
-          }
-        },
-        "semver": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
-          "dev": true
-        },
-        "to-regex-range": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-          "dev": true,
-          "requires": {
-            "is-number": "^7.0.0"
           }
         }
       }
@@ -13453,26 +18034,16 @@
       }
     },
     "load-json-file": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-      "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.2",
         "parse-json": "^2.2.0",
         "pify": "^2.0.0",
-        "strip-bom": "^3.0.0"
-      },
-      "dependencies": {
-        "parse-json": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-          "dev": true,
-          "requires": {
-            "error-ex": "^1.2.0"
-          }
-        }
+        "pinkie-promise": "^2.0.0",
+        "strip-bom": "^2.0.0"
       }
     },
     "loader-runner": {
@@ -13520,15 +18091,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
-    },
-    "lodash.assign": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
       "dev": true
     },
     "lodash.assignin": {
@@ -13537,16 +18102,16 @@
       "integrity": "sha1-uo31+4QesKPoBEIysOJjqNxqKKI=",
       "dev": true
     },
+    "lodash.bind": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-4.2.1.tgz",
+      "integrity": "sha1-euMBfpOWIqwxt9fX3LGzTbFpDTU=",
+      "dev": true
+    },
     "lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
-      "dev": true
-    },
-    "lodash.clamp": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/lodash.clamp/-/lodash.clamp-4.0.3.tgz",
-      "integrity": "sha1-XCS+3u7vB1NWDcK0y0Zx+Qpt36o=",
       "dev": true
     },
     "lodash.clonedeep": {
@@ -13651,6 +18216,12 @@
       "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=",
       "dev": true
     },
+    "lodash.keys": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-4.2.0.tgz",
+      "integrity": "sha1-oIYCrBLk+4P5H8H7ejYKTZujUgU=",
+      "dev": true
+    },
     "lodash.map": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
@@ -13658,9 +18229,9 @@
       "dev": true
     },
     "lodash.merge": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
-      "integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
     },
     "lodash.once": {
@@ -13700,12 +18271,12 @@
       "dev": true
     },
     "log-symbols": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
-      "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
+      "integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
       "dev": true,
       "requires": {
-        "chalk": "^2.0.1"
+        "chalk": "^2.4.2"
       }
     },
     "log-update": {
@@ -13724,22 +18295,6 @@
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
-          }
         },
         "strip-ansi": {
           "version": "4.0.0",
@@ -13763,9 +18318,9 @@
       }
     },
     "loglevel": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.1.tgz",
-      "integrity": "sha1-4PyVEztu8nbNyIh82vJKpvFW+Po=",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.3.tgz",
+      "integrity": "sha512-LoEDv5pgpvWgPF4kNYuIp0qqSJVWak/dML0RY74xlzMZiT9w77teNAwKYKWBTYjlokMirg+o3jBwp+vlLrcfAA==",
       "dev": true
     },
     "longest": {
@@ -13775,16 +18330,15 @@
       "dev": true
     },
     "longest-streak": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-2.0.2.tgz",
-      "integrity": "sha512-TmYTeEYxiAmSVdpbnQDXGtvYOIRsCMg89CVZzwzc2o7GFL1CjoiRPjH5ec0NFAVlAx3fVof9dX/t6KKRAo2OWA==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-2.0.3.tgz",
+      "integrity": "sha512-9lz5IVdpwsKLMzQi0MQ+oD9EA0mIGcWYP7jXMTZVXP8D42PwuAk+M/HBFYQoxt1G5OR8m7aSIgb1UymfWGBWEw==",
       "dev": true
     },
     "loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
@@ -13816,9 +18370,9 @@
       }
     },
     "macos-release": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.2.0.tgz",
-      "integrity": "sha512-iV2IDxZaX8dIcM7fG6cI46uNmHUxHE4yN+Z8tKHAW1TBPMZDIKHf/3L+YnOuj/FK9il14UaVdHmiQ1tsi90ltA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.3.0.tgz",
+      "integrity": "sha512-OHhSbtcviqMPt7yfw5ef5aghS2jzFVKEFyCJndQt2YpSQ9qRVSEv2axSJI1paVThEu+FFGs584h/1YhxjVqajA==",
       "dev": true
     },
     "make-dir": {
@@ -13847,6 +18401,15 @@
         "tmpl": "1.0.x"
       }
     },
+    "map-age-cleaner": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+      "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
+      "dev": true,
+      "requires": {
+        "p-defer": "^1.0.0"
+      }
+    },
     "map-cache": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
@@ -13869,9 +18432,9 @@
       }
     },
     "markdown-escapes": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/markdown-escapes/-/markdown-escapes-1.0.2.tgz",
-      "integrity": "sha512-lbRZ2mE3Q9RtLjxZBZ9+IMl68DKIXaVAhwvwn9pmjnPLS0h/6kyBMgNhqi1xFJ/2yv6cSyv0jbiZavZv93JkkA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/markdown-escapes/-/markdown-escapes-1.0.3.tgz",
+      "integrity": "sha512-XUi5HJhhV5R74k8/0H2oCbCiYf/u4cO/rX8tnGkRvrqhsr5BRNU6Mg0yt/8UIx1iIS8220BNJsDb7XnILhLepw==",
       "dev": true
     },
     "markdown-spellcheck": {
@@ -13983,6 +18546,15 @@
             }
           }
         },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
         "mute-stream": {
           "version": "0.0.6",
           "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.6.tgz",
@@ -14005,6 +18577,17 @@
             "onetime": "^1.0.0"
           }
         },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
         "supports-color": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
@@ -14023,27 +18606,15 @@
       }
     },
     "markdown-table": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-1.1.2.tgz",
-      "integrity": "sha512-NcWuJFHDA8V3wkDgR/j4+gZx+YQwstPgfQDV8ndUeWWzta3dnDTBxpVzqS9lkmJAuV5YX35lmyojl6HO5JXAgw==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-1.1.3.tgz",
+      "integrity": "sha512-1RUZVgQlpJSPWYbFSpmudq5nHY1doEIv89gBtF0s4gW1GF2XorxcA/70M5vq7rLv0a6mhOUccRsqkwhwLCIQ2Q==",
       "dev": true
     },
     "marked": {
       "version": "0.3.19",
       "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
       "integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg==",
-      "dev": true
-    },
-    "marker-clusterer-plus": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/marker-clusterer-plus/-/marker-clusterer-plus-2.1.4.tgz",
-      "integrity": "sha1-+O/3TVmdqzt9Dj/tUmTqDnBPXWc=",
-      "dev": true
-    },
-    "markerwithlabel": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/markerwithlabel/-/markerwithlabel-2.0.2.tgz",
-      "integrity": "sha512-C/cbm1A0h/u54gwHk5ZJNdUU3V3+1BbCpRPMsMyFA7vF4yL+aB4rWpxACz29TpQ+cTg6/iQroExh0PMSRGtQFg==",
       "dev": true
     },
     "matchmediaquery": {
@@ -14062,9 +18633,9 @@
       "dev": true
     },
     "mathml-tag-names": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.0.tgz",
-      "integrity": "sha512-3Zs9P/0zzwTob2pdgT0CHZuMbnSUSp8MB1bddfm+HDmnFWHGT4jvEZRf+2RuPoa+cjdn/z25SEt5gFTqdhvJAg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.1.tgz",
+      "integrity": "sha512-pWB896KPGSGkp1XtyzRBftpTzwSOL0Gfk0wLvxt4f2mgzjY19o0LxJ3U25vNWTzsh7da+KTbuXQoQ3lOJZ8WHw==",
       "dev": true
     },
     "md5": {
@@ -14099,18 +18670,18 @@
       }
     },
     "mdast-util-compact": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/mdast-util-compact/-/mdast-util-compact-1.0.2.tgz",
-      "integrity": "sha512-d2WS98JSDVbpSsBfVvD9TaDMlqPRz7ohM/11G0rp5jOBb5q96RJ6YLszQ/09AAixyzh23FeIpCGqfaamEADtWg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-compact/-/mdast-util-compact-1.0.3.tgz",
+      "integrity": "sha512-nRiU5GpNy62rZppDKbLwhhtw5DXoFMqw9UNZFmlPsNaQCZ//WLjGKUwWMdJrUH+Se7UvtO2gXtAMe0g/N+eI5w==",
       "dev": true,
       "requires": {
         "unist-util-visit": "^1.1.0"
       }
     },
     "mdn-data": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-1.1.4.tgz",
-      "integrity": "sha512-FSYbp3lyKjyj3E7fMl6rYvUdX0FBXaluGqlFoYESWQlyUTq8R+wp0rkFxoYFqZlHCvsUXGjyJmLQSnXToYhOSA==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.4.tgz",
+      "integrity": "sha512-iV3XNKw06j5Q7mi6h+9vbx23Tv7JkjEVgKHW4pimwyDGWm0OIQntJJ+u1C6mg6mK1EaTv42XQ7w76yuzH7M2cA==",
       "dev": true
     },
     "media-typer": {
@@ -14127,12 +18698,6 @@
       "requires": {
         "mimic-fn": "^1.0.0"
       }
-    },
-    "memoize-one": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.0.4.tgz",
-      "integrity": "sha512-P0z5IeAH6qHHGkJIXWw0xC2HNEgkx/9uWWBQw64FJj3/ol14VYdfVGWWr0fXfjhhv3TKVIqUq65os6O4GUNksA==",
-      "dev": true
     },
     "memory-fs": {
       "version": "0.4.1",
@@ -14162,93 +18727,11 @@
         "trim-newlines": "^1.0.0"
       },
       "dependencies": {
-        "find-up": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-          "dev": true,
-          "requires": {
-            "path-exists": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
-          }
-        },
-        "load-json-file": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^2.2.0",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0",
-            "strip-bom": "^2.0.0"
-          }
-        },
         "minimist": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
-        },
-        "parse-json": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-          "dev": true,
-          "requires": {
-            "error-ex": "^1.2.0"
-          }
-        },
-        "path-exists": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-          "dev": true,
-          "requires": {
-            "pinkie-promise": "^2.0.0"
-          }
-        },
-        "path-type": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
-          }
-        },
-        "read-pkg": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-          "dev": true,
-          "requires": {
-            "load-json-file": "^1.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^1.0.0"
-          }
-        },
-        "read-pkg-up": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-          "dev": true,
-          "requires": {
-            "find-up": "^1.0.0",
-            "read-pkg": "^1.0.0"
-          }
-        },
-        "strip-bom": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-          "dev": true,
-          "requires": {
-            "is-utf8": "^0.2.0"
-          }
         }
       }
     },
@@ -14283,32 +18766,24 @@
       "dev": true
     },
     "micromatch": {
-      "version": "3.1.10",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-      "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+      "version": "2.3.11",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+      "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
       "dev": true,
       "requires": {
-        "arr-diff": "^4.0.0",
-        "array-unique": "^0.3.2",
-        "braces": "^2.3.1",
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "extglob": "^2.0.4",
-        "fragment-cache": "^0.2.1",
-        "kind-of": "^6.0.2",
-        "nanomatch": "^1.2.9",
-        "object.pick": "^1.3.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.2"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-          "dev": true
-        }
+        "arr-diff": "^2.0.0",
+        "array-unique": "^0.2.1",
+        "braces": "^1.8.2",
+        "expand-brackets": "^0.1.4",
+        "extglob": "^0.3.1",
+        "filename-regex": "^2.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.1",
+        "kind-of": "^3.0.2",
+        "normalize-path": "^2.0.1",
+        "object.omit": "^2.0.0",
+        "parse-glob": "^3.0.4",
+        "regex-cache": "^0.4.2"
       }
     },
     "miller-rabin": {
@@ -14322,9 +18797,9 @@
       }
     },
     "mime": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
-      "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
       "dev": true
     },
     "mime-db": {
@@ -14410,9 +18885,9 @@
       }
     },
     "mixin-deep": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
-      "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
+      "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
       "dev": true,
       "requires": {
         "for-in": "^1.0.2",
@@ -14518,9 +18993,9 @@
       "dev": true
     },
     "nan": {
-      "version": "2.13.2",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
-      "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
       "dev": true
     },
     "nanolru": {
@@ -14548,6 +19023,37 @@
         "to-regex": "^3.0.1"
       },
       "dependencies": {
+        "arr-diff": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+          "dev": true
+        },
+        "array-unique": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+          "dev": true
+        },
+        "extend-shallow": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+          "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+          "dev": true,
+          "requires": {
+            "assign-symbols": "^1.0.0",
+            "is-extendable": "^1.0.1"
+          }
+        },
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "^2.0.4"
+          }
+        },
         "kind-of": {
           "version": "6.0.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
@@ -14602,9 +19108,9 @@
       "dev": true
     },
     "neo-async": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.0.tgz",
-      "integrity": "sha512-MFh0d/Wa7vkKO3Y3LlacqAEeHK0mckVqzDieUKTT+KGxi+zIpeVsFxymkIiRpbpDziHc290Xr9A1O4Om7otoRA==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
+      "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
       "dev": true
     },
     "next-tick": {
@@ -14629,7 +19135,6 @@
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
       "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-      "dev": true,
       "requires": {
         "encoding": "^0.1.11",
         "is-stream": "^1.0.1"
@@ -14676,9 +19181,9 @@
       "dev": true
     },
     "node-libs-browser": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.2.0.tgz",
-      "integrity": "sha512-5MQunG/oyOaBdttrL40dA7bUfPORLRWMUJLQtMg7nluxUvk5XwnLdL9twQHFAjRx/y7mIMkLKT9++qPbbk6BZA==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.2.1.tgz",
+      "integrity": "sha512-h/zcD8H9kaDZ9ALUWwlBUDo6TKF8a7qBSCSEGfjTVIYeqsioSKaAX+BN7NgiMGp6iSIXZ3PxgCu8KS3b71YK5Q==",
       "dev": true,
       "requires": {
         "assert": "^1.1.1",
@@ -14691,7 +19196,7 @@
         "events": "^3.0.0",
         "https-browserify": "^1.0.0",
         "os-browserify": "^0.3.0",
-        "path-browserify": "0.0.0",
+        "path-browserify": "0.0.1",
         "process": "^0.11.10",
         "punycode": "^1.2.4",
         "querystring-es3": "^0.2.0",
@@ -14703,21 +19208,9 @@
         "tty-browserify": "0.0.0",
         "url": "^0.11.0",
         "util": "^0.11.0",
-        "vm-browserify": "0.0.4"
+        "vm-browserify": "^1.0.1"
       },
       "dependencies": {
-        "events": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/events/-/events-3.0.0.tgz",
-          "integrity": "sha512-Dc381HFWJzEOhQ+d8pkNon++bk9h6cdAoAj4iE6Q4y6xgTzySWXlKn05/TVNpjnfRqi/X0EpJEJohPjNI3zpVA==",
-          "dev": true
-        },
-        "process": {
-          "version": "0.11.10",
-          "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-          "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
-          "dev": true
-        },
         "punycode": {
           "version": "1.4.1",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
@@ -14748,9 +19241,9 @@
       }
     },
     "node-releases": {
-      "version": "1.1.17",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.17.tgz",
-      "integrity": "sha512-/SCjetyta1m7YXLgtACZGDYJdCSIBAWorDWkGCGZlydP2Ll7J48l7j/JxNYZ+xsgSPbWfdulVS/aY+GdjUsQ7Q==",
+      "version": "1.1.26",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.26.tgz",
+      "integrity": "sha512-fZPsuhhUHMTlfkhDLGtfY80DSJTjOcx+qD1j5pqPkuhUHVS7xHZIg9EE4DHK8O3f0zTxXHX5VIkDG8pu98/wfQ==",
       "dev": true,
       "requires": {
         "semver": "^5.3.0"
@@ -14862,10 +19355,13 @@
       }
     },
     "normalize-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+      "dev": true,
+      "requires": {
+        "remove-trailing-separator": "^1.0.1"
+      }
     },
     "normalize-range": {
       "version": "0.1.2",
@@ -14879,11 +19375,16 @@
       "integrity": "sha1-0LFF62kRicY6eNIB3E/bEpPvDAM=",
       "dev": true
     },
-    "normalize.css": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/normalize.css/-/normalize.css-4.2.0.tgz",
-      "integrity": "sha1-IdZsxVcVTUN5/R4HnsfeWKN5sJk=",
-      "dev": true
+    "normalize-url": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-2.0.1.tgz",
+      "integrity": "sha512-D6MUW4K/VzoJ4rJ01JFKxDrtY1v9wrgzCX5f2qj/lzH1m/lW6MhUZFKerVsnyjOhOsYzI9Kqqak+10l4LvLpMw==",
+      "dev": true,
+      "requires": {
+        "prepend-http": "^2.0.0",
+        "query-string": "^5.0.1",
+        "sort-keys": "^2.0.0"
+      }
     },
     "npm-run-path": {
       "version": "2.0.2",
@@ -14942,8 +19443,7 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-copy": {
       "version": "0.1.0",
@@ -14992,6 +19492,14 @@
       "dev": true,
       "requires": {
         "isobject": "^3.0.0"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        }
       }
     },
     "object.assign": {
@@ -15057,6 +19565,14 @@
       "dev": true,
       "requires": {
         "isobject": "^3.0.1"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        }
       }
     },
     "object.values": {
@@ -15123,9 +19639,9 @@
       "dev": true
     },
     "opn": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/opn/-/opn-5.2.0.tgz",
-      "integrity": "sha512-Jd/GpzPyHF4P2/aNOVmS3lfMSWV9J7cOhCG1s08XCEAsPkB7lp6ddiU0J7XzyQRDUh8BqJ7PchfINjR8jyofRQ==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/opn/-/opn-5.5.0.tgz",
+      "integrity": "sha512-PqHpggC9bLV0VeWcdKhkpxY+3JTzetLSqTCWL/z/tFIbI6G8JCjondXklT1JinczLz2Xib62sSp0T/gKT4KksA==",
       "dev": true,
       "requires": {
         "is-wsl": "^1.1.0"
@@ -15139,6 +19655,14 @@
       "requires": {
         "minimist": "~0.0.1",
         "wordwrap": "~0.0.2"
+      },
+      "dependencies": {
+        "wordwrap": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+          "dev": true
+        }
       }
     },
     "optionator": {
@@ -15153,14 +19677,6 @@
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2",
         "wordwrap": "~1.0.0"
-      },
-      "dependencies": {
-        "wordwrap": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-          "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
-          "dev": true
-        }
       }
     },
     "original": {
@@ -15193,6 +19709,40 @@
         "execa": "^0.7.0",
         "lcid": "^1.0.0",
         "mem": "^1.1.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^4.0.1",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "execa": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+          "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^5.0.1",
+            "get-stream": "^3.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          }
+        },
+        "get-stream": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+          "dev": true
+        }
       }
     },
     "os-name": {
@@ -15228,15 +19778,27 @@
       }
     },
     "p-cancelable": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
-      "integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
+      "integrity": "sha512-HNa1A8LvB1kie7cERyy21VNeHb2CWJJYqyyC2o3klWFfMGlFmWv2Z7sFgZH8ZiaYL95ydToKTFVXgMV/Os0bBQ==",
+      "dev": true
+    },
+    "p-defer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
+      "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
       "dev": true
     },
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
       "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+      "dev": true
+    },
+    "p-is-promise": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
+      "integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4=",
       "dev": true
     },
     "p-limit": {
@@ -15264,9 +19826,9 @@
       "dev": true
     },
     "p-timeout": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-1.2.1.tgz",
-      "integrity": "sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
+      "integrity": "sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==",
       "dev": true,
       "requires": {
         "p-finally": "^1.0.0"
@@ -15295,6 +19857,12 @@
         "readable-stream": "^2.1.5"
       }
     },
+    "paralleljs": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/paralleljs/-/paralleljs-0.2.1.tgz",
+      "integrity": "sha1-68p0XT4JwB4r68wUhYiR/0UQ6SY=",
+      "dev": true
+    },
     "parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -15302,14 +19870,6 @@
       "dev": true,
       "requires": {
         "callsites": "^3.0.0"
-      },
-      "dependencies": {
-        "callsites": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-          "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-          "dev": true
-        }
       }
     },
     "parse-asn1": {
@@ -15333,9 +19893,9 @@
       "dev": true
     },
     "parse-entities": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.2.1.tgz",
-      "integrity": "sha512-NBWYLQm1KSoDKk7GAHyioLTvCZ5QjdH/ASBBQTD3iLiAWJXS5bg1jEWI8nIJ+vgVvsceBVBcDGRWSo0KVQBvvg==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.2.2.tgz",
+      "integrity": "sha512-NzfpbxW/NPrzZ/yYSoQxyqUZMZXIdCfE0OIN4ESsnptHJECoUk3FZktxNuzQf4tjt5UEopnxpYJbvYuxIFDdsg==",
       "dev": true,
       "requires": {
         "character-entities": "^1.0.0",
@@ -15373,33 +19933,15 @@
         "is-dotfile": "^1.0.0",
         "is-extglob": "^1.0.0",
         "is-glob": "^2.0.0"
-      },
-      "dependencies": {
-        "is-extglob": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true
-        },
-        "is-glob": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "^1.0.0"
-          }
-        }
       }
     },
     "parse-json": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-      "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "dev": true,
       "requires": {
-        "error-ex": "^1.3.1",
-        "json-parse-better-errors": "^1.0.1"
+        "error-ex": "^1.2.0"
       }
     },
     "parse-link-header": {
@@ -15439,9 +19981,9 @@
       "dev": true
     },
     "path-browserify": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
-      "integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo=",
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.1.tgz",
+      "integrity": "sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ==",
       "dev": true
     },
     "path-dirname": {
@@ -15481,18 +20023,31 @@
       "dev": true
     },
     "path-to-regexp": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
-      "dev": true
-    },
-    "path-type": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-      "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+      "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
       "dev": true,
       "requires": {
-        "pify": "^2.0.0"
+        "isarray": "0.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        }
+      }
+    },
+    "path-type": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       }
     },
     "pbkdf2": {
@@ -15591,9 +20146,9 @@
       }
     },
     "portfinder": {
-      "version": "1.0.20",
-      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.20.tgz",
-      "integrity": "sha512-Yxe4mTyDzTd59PZJY4ojZR8F+E5e97iq2ZOHPz3HDgSvYC5siNad2tLooQ5y5QHyQhc3xVqvyk/eNA3wuoa7Sw==",
+      "version": "1.0.21",
+      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.21.tgz",
+      "integrity": "sha512-ESabpDCzmBS3ekHbmpAIiESq3udRsCBGiBZLsC+HgBKv2ezb0R4oG+7RnYEVZ/ZCfhel5Tx3UzdNWA0Lox2QCA==",
       "dev": true,
       "requires": {
         "async": "^1.5.2",
@@ -15616,36 +20171,16 @@
       "dev": true
     },
     "postcss": {
-      "version": "6.0.23",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-      "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+      "version": "7.0.17",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.17.tgz",
+      "integrity": "sha512-546ZowA+KZ3OasvQZHsbuEpysvwTZNGJv9EfyCQdsIDltPSWHAeTQ5fQy/Npi2ZDtLI3zs7Ps/p6wThErhm9fQ==",
       "dev": true,
       "requires": {
-        "chalk": "^2.4.1",
+        "chalk": "^2.4.2",
         "source-map": "^0.6.1",
-        "supports-color": "^5.4.0"
-      }
-    },
-    "postcss-flexbugs-fixes": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-flexbugs-fixes/-/postcss-flexbugs-fixes-4.1.0.tgz",
-      "integrity": "sha512-jr1LHxQvStNNAHlgco6PzY308zvLklh7SJVYuWUwyUQncofaAlD2l+P/gxKHOdqWKe7xJSkVLFF/2Tp+JqMSZA==",
-      "dev": true,
-      "requires": {
-        "postcss": "^7.0.0"
+        "supports-color": "^6.1.0"
       },
       "dependencies": {
-        "postcss": {
-          "version": "7.0.16",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
-          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
-          }
-        },
         "supports-color": {
           "version": "6.1.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
@@ -15655,6 +20190,15 @@
             "has-flag": "^3.0.0"
           }
         }
+      }
+    },
+    "postcss-flexbugs-fixes": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-flexbugs-fixes/-/postcss-flexbugs-fixes-4.1.0.tgz",
+      "integrity": "sha512-jr1LHxQvStNNAHlgco6PzY308zvLklh7SJVYuWUwyUQncofaAlD2l+P/gxKHOdqWKe7xJSkVLFF/2Tp+JqMSZA==",
+      "dev": true,
+      "requires": {
+        "postcss": "^7.0.0"
       }
     },
     "postcss-html": {
@@ -15667,12 +20211,12 @@
       }
     },
     "postcss-jsx": {
-      "version": "0.36.0",
-      "resolved": "https://registry.npmjs.org/postcss-jsx/-/postcss-jsx-0.36.0.tgz",
-      "integrity": "sha512-/lWOSXSX5jlITCKFkuYU2WLFdrncZmjSVyNpHAunEgirZXLwI8RjU556e3Uz4mv0WVHnJA9d3JWb36lK9Yx99g==",
+      "version": "0.36.2",
+      "resolved": "https://registry.npmjs.org/postcss-jsx/-/postcss-jsx-0.36.2.tgz",
+      "integrity": "sha512-7B8a8a6YDOQFqMQ9UmOo+IPPb2i14Z57Fvc9cOI11B3bWMSY2O6r2XJ3tlcQhUhv93TeN0ntxehTaSWJDQavlg==",
       "dev": true,
       "requires": {
-        "@babel/core": ">=7.1.0"
+        "@babel/core": ">=7.2.2"
       }
     },
     "postcss-less": {
@@ -15682,37 +20226,15 @@
       "dev": true,
       "requires": {
         "postcss": "^7.0.14"
-      },
-      "dependencies": {
-        "postcss": {
-          "version": "7.0.16",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
-          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
-          }
-        },
-        "supports-color": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
       }
     },
     "postcss-load-config": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-2.0.0.tgz",
-      "integrity": "sha512-V5JBLzw406BB8UIfsAWSK2KSwIJ5yoEIVFb4gVkXci0QdKgA24jLmHZ/ghe/GgX0lJ0/D1uUK1ejhzEY94MChQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-2.1.0.tgz",
+      "integrity": "sha512-4pV3JJVPLd5+RueiVVB+gFOAa7GWc25XQcMp86Zexzke69mKf6Nx9LRcQywdz7yZI9n1udOxmLuAwTBypypF8Q==",
       "dev": true,
       "requires": {
-        "cosmiconfig": "^4.0.0",
+        "cosmiconfig": "^5.0.0",
         "import-cwd": "^2.0.0"
       }
     },
@@ -15728,17 +20250,6 @@
         "schema-utils": "^1.0.0"
       },
       "dependencies": {
-        "postcss": {
-          "version": "7.0.16",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
-          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
-          }
-        },
         "schema-utils": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
@@ -15748,15 +20259,6 @@
             "ajv": "^6.1.0",
             "ajv-errors": "^1.0.0",
             "ajv-keywords": "^3.1.0"
-          }
-        },
-        "supports-color": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
           }
         }
       }
@@ -15784,6 +20286,19 @@
       "dev": true,
       "requires": {
         "postcss": "^6.0.1"
+      },
+      "dependencies": {
+        "postcss": {
+          "version": "6.0.23",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.4.1",
+            "source-map": "^0.6.1",
+            "supports-color": "^5.4.0"
+          }
+        }
       }
     },
     "postcss-modules-local-by-default": {
@@ -15794,6 +20309,19 @@
       "requires": {
         "css-selector-tokenizer": "^0.7.0",
         "postcss": "^6.0.1"
+      },
+      "dependencies": {
+        "postcss": {
+          "version": "6.0.23",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.4.1",
+            "source-map": "^0.6.1",
+            "supports-color": "^5.4.0"
+          }
+        }
       }
     },
     "postcss-modules-scope": {
@@ -15804,6 +20332,19 @@
       "requires": {
         "css-selector-tokenizer": "^0.7.0",
         "postcss": "^6.0.1"
+      },
+      "dependencies": {
+        "postcss": {
+          "version": "6.0.23",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.4.1",
+            "source-map": "^0.6.1",
+            "supports-color": "^5.4.0"
+          }
+        }
       }
     },
     "postcss-modules-values": {
@@ -15814,6 +20355,19 @@
       "requires": {
         "icss-replace-symbols": "^1.1.0",
         "postcss": "^6.0.1"
+      },
+      "dependencies": {
+        "postcss": {
+          "version": "6.0.23",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.4.1",
+            "source-map": "^0.6.1",
+            "supports-color": "^5.4.0"
+          }
+        }
       }
     },
     "postcss-reporter": {
@@ -15828,24 +20382,13 @@
         "postcss": "^7.0.7"
       },
       "dependencies": {
-        "postcss": {
-          "version": "7.0.16",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
-          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
+        "log-symbols": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
+          "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
           "dev": true,
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
-          }
-        },
-        "supports-color": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
+            "chalk": "^2.0.1"
           }
         }
       }
@@ -15863,28 +20406,6 @@
       "dev": true,
       "requires": {
         "postcss": "^7.0.0"
-      },
-      "dependencies": {
-        "postcss": {
-          "version": "7.0.16",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
-          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
-          }
-        },
-        "supports-color": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
       }
     },
     "postcss-sass": {
@@ -15895,28 +20416,6 @@
       "requires": {
         "gonzales-pe": "^4.2.3",
         "postcss": "^7.0.1"
-      },
-      "dependencies": {
-        "postcss": {
-          "version": "7.0.16",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
-          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
-          }
-        },
-        "supports-color": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
       }
     },
     "postcss-scss": {
@@ -15926,37 +20425,15 @@
       "dev": true,
       "requires": {
         "postcss": "^7.0.0"
-      },
-      "dependencies": {
-        "postcss": {
-          "version": "7.0.16",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
-          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
-          }
-        },
-        "supports-color": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
       }
     },
     "postcss-selector-parser": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz",
-      "integrity": "sha1-+UN3iGBsPJrO4W/+jYsWKX8nu5A=",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
+      "integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
       "dev": true,
       "requires": {
-        "flatten": "^1.0.2",
+        "dot-prop": "^4.1.1",
         "indexes-of": "^1.0.1",
         "uniq": "^1.0.1"
       }
@@ -15969,6 +20446,19 @@
       "requires": {
         "lodash": "^4.17.4",
         "postcss": "^6.0.13"
+      },
+      "dependencies": {
+        "postcss": {
+          "version": "6.0.23",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.4.1",
+            "source-map": "^0.6.1",
+            "supports-color": "^5.4.0"
+          }
+        }
       }
     },
     "postcss-syntax": {
@@ -15978,9 +20468,9 @@
       "dev": true
     },
     "postcss-value-parser": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-      "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.0.0.tgz",
+      "integrity": "sha512-ESPktioptiSUchCKgggAkzdmkgzKfmp0EU8jXH+5kbIUB+unr0Y4CY9SRMvibuvYUBjNh1ACLbxqYNpdTQOteQ==",
       "dev": true
     },
     "prelude-ls": {
@@ -15990,9 +20480,9 @@
       "dev": true
     },
     "prepend-http": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-      "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
+      "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
       "dev": true
     },
     "preserve": {
@@ -16002,9 +20492,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.17.0.tgz",
-      "integrity": "sha512-sXe5lSt2WQlCbydGETgfm1YBShgOX4HxQkFPvbxkcwgDvGDeqVau8h+12+lmSVlP3rHPz0oavfddSZg/q+Szjw==",
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.18.2.tgz",
+      "integrity": "sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==",
       "dev": true
     },
     "prettier-linter-helpers": {
@@ -16040,10 +20530,16 @@
       "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
       "dev": true
     },
+    "process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
+      "dev": true
+    },
     "process-nextick-args": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true
     },
     "progress": {
@@ -16056,7 +20552,6 @@
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
       "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-      "dev": true,
       "requires": {
         "asap": "~2.0.3"
       }
@@ -16126,9 +20621,9 @@
       "dev": true
     },
     "psl": {
-      "version": "1.1.31",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
-      "integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.2.0.tgz",
+      "integrity": "sha512-GEn74ZffufCmkDDLNcl3uuyF/aSD6exEyh1v/ZSdAomB82t6G9hzJVRx0jBmLDW+VfZqks3aScmMw9DszwUalA==",
       "dev": true
     },
     "public-encrypt": {
@@ -16164,18 +20659,6 @@
         "duplexify": "^3.6.0",
         "inherits": "^2.0.3",
         "pump": "^2.0.0"
-      },
-      "dependencies": {
-        "pump": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
-          "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
-          "dev": true,
-          "requires": {
-            "end-of-stream": "^1.1.0",
-            "once": "^1.3.1"
-          }
-        }
       }
     },
     "punycode": {
@@ -16189,6 +20672,23 @@
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
       "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
       "dev": true
+    },
+    "qs": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+      "dev": true
+    },
+    "query-string": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
+      "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
+      "dev": true,
+      "requires": {
+        "decode-uri-component": "^0.2.0",
+        "object-assign": "^4.1.0",
+        "strict-uri-encode": "^1.0.0"
+      }
     },
     "querystring": {
       "version": "0.2.0",
@@ -16290,31 +20790,28 @@
       }
     },
     "range-parser": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
-      "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
       "dev": true
     },
     "raw-body": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.3.tgz",
-      "integrity": "sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
+      "integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
       "dev": true,
       "requires": {
-        "bytes": "3.0.0",
-        "http-errors": "1.6.3",
-        "iconv-lite": "0.4.23",
+        "bytes": "3.1.0",
+        "http-errors": "1.7.2",
+        "iconv-lite": "0.4.24",
         "unpipe": "1.0.0"
       },
       "dependencies": {
-        "iconv-lite": {
-          "version": "0.4.23",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
-          "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
-          "dev": true,
-          "requires": {
-            "safer-buffer": ">= 2.1.2 < 3"
-          }
+        "bytes": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
+          "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
+          "dev": true
         }
       }
     },
@@ -16353,28 +20850,6 @@
         "prop-types": "^15.6.0"
       }
     },
-    "react-autosuggest": {
-      "version": "9.4.3",
-      "resolved": "https://registry.npmjs.org/react-autosuggest/-/react-autosuggest-9.4.3.tgz",
-      "integrity": "sha512-wFbp5QpgFQRfw9cwKvcgLR8theikOUkv8PFsuLYqI2PUgVlx186Cz8MYt5bLxculi+jxGGUUVt+h0esaBZZouw==",
-      "dev": true,
-      "requires": {
-        "prop-types": "^15.5.10",
-        "react-autowhatever": "^10.1.2",
-        "shallow-equal": "^1.0.0"
-      }
-    },
-    "react-autowhatever": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/react-autowhatever/-/react-autowhatever-10.2.0.tgz",
-      "integrity": "sha512-dqHH4uqiJldPMbL8hl/i2HV4E8FMTDEdVlOIbRqYnJi0kTpWseF9fJslk/KS9pGDnm80JkYzVI+nzFjnOG/u+g==",
-      "dev": true,
-      "requires": {
-        "prop-types": "^15.5.8",
-        "react-themeable": "^1.1.0",
-        "section-iterator": "^2.0.0"
-      }
-    },
     "react-dom": {
       "version": "16.4.2",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.4.2.tgz",
@@ -16392,45 +20867,6 @@
       "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
       "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==",
       "dev": true
-    },
-    "react-google-maps": {
-      "version": "9.4.5",
-      "resolved": "https://registry.npmjs.org/react-google-maps/-/react-google-maps-9.4.5.tgz",
-      "integrity": "sha512-8z5nX9DxIcBCXuEiurmRT1VXVwnzx0C6+3Es6lxB2/OyY2SLax2/LcDu6Aldxnl3HegefTL7NJzGeaKAJ61pOA==",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.11.6",
-        "can-use-dom": "^0.1.0",
-        "google-maps-infobox": "^2.0.0",
-        "invariant": "^2.2.1",
-        "lodash": "^4.16.2",
-        "marker-clusterer-plus": "^2.1.4",
-        "markerwithlabel": "^2.0.1",
-        "prop-types": "^15.5.8",
-        "recompose": "^0.26.0",
-        "scriptjs": "^2.5.8",
-        "warning": "^3.0.0"
-      },
-      "dependencies": {
-        "hoist-non-react-statics": {
-          "version": "2.5.5",
-          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
-          "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==",
-          "dev": true
-        },
-        "recompose": {
-          "version": "0.26.0",
-          "resolved": "https://registry.npmjs.org/recompose/-/recompose-0.26.0.tgz",
-          "integrity": "sha512-KwOu6ztO0mN5vy3+zDcc45lgnaUoaQse/a5yLVqtzTK13czSWnFGmXbQVmnoMgDkI5POd1EwIKSbjU1V7xdZog==",
-          "dev": true,
-          "requires": {
-            "change-emitter": "^0.1.2",
-            "fbjs": "^0.8.1",
-            "hoist-non-react-statics": "^2.3.1",
-            "symbol-observable": "^1.0.4"
-          }
-        }
-      }
     },
     "react-helmet": {
       "version": "5.2.1",
@@ -16453,13 +20889,12 @@
     "react-lifecycles-compat": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
-      "dev": true
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
     "react-markdown": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-4.0.8.tgz",
-      "integrity": "sha512-Z6oa648rufvzyO0KwYJ/9p9AsdYGIluqK6OlpJ35ouJ8HPF0Ko1WDNdyymjDSHxNrkb7HDyEcIDJCQs8NlET5A==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-4.1.0.tgz",
+      "integrity": "sha512-EOHsEAN+aoP8UVz7vTHx6Z63GJfhrO9KItKlfsiBtVVS9tmSWtUaBTw73+2SObrWiOiE2Cs9qUBL7ORsvVhOrA==",
       "dev": true,
       "requires": {
         "html-to-react": "^1.3.4",
@@ -16495,38 +20930,6 @@
         "path-to-regexp": "^1.7.0",
         "prop-types": "^15.6.1",
         "warning": "^4.0.1"
-      },
-      "dependencies": {
-        "hoist-non-react-statics": {
-          "version": "2.5.5",
-          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
-          "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==",
-          "dev": true
-        },
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
-        },
-        "path-to-regexp": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
-          "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
-          "dev": true,
-          "requires": {
-            "isarray": "0.0.1"
-          }
-        },
-        "warning": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
-          "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.0.0"
-          }
-        }
       }
     },
     "react-router-dom": {
@@ -16541,17 +20944,6 @@
         "prop-types": "^15.6.1",
         "react-router": "^4.3.1",
         "warning": "^4.0.1"
-      },
-      "dependencies": {
-        "warning": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
-          "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.0.0"
-          }
-        }
       }
     },
     "react-side-effect": {
@@ -16563,12 +20955,6 @@
         "exenv": "^1.2.1",
         "shallowequal": "^1.0.1"
       }
-    },
-    "react-slider": {
-      "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/react-slider/-/react-slider-0.11.2.tgz",
-      "integrity": "sha512-y49ZwJJ7OcPdihgt71xYI8GRdAzpFuSLQR8b+cKotutxqf8MAEPEtqvWKlg+3ZQRe5PMN6oWbIb7wEYDF8XhNQ==",
-      "dev": true
     },
     "react-svg-core": {
       "version": "3.0.3",
@@ -16583,101 +20969,6 @@
         "lodash.clonedeep": "^4.5.0",
         "lodash.isplainobject": "^4.0.6",
         "svgo": "^1.2.2"
-      },
-      "dependencies": {
-        "@babel/core": {
-          "version": "7.4.5",
-          "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.4.5.tgz",
-          "integrity": "sha512-OvjIh6aqXtlsA8ujtGKfC7LYWksYSX8yQcM8Ay3LuvVeQ63lcOKgoZWVqcpFwkd29aYU9rVx7jxhfhiEDV9MZA==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.0.0",
-            "@babel/generator": "^7.4.4",
-            "@babel/helpers": "^7.4.4",
-            "@babel/parser": "^7.4.5",
-            "@babel/template": "^7.4.4",
-            "@babel/traverse": "^7.4.5",
-            "@babel/types": "^7.4.4",
-            "convert-source-map": "^1.1.0",
-            "debug": "^4.1.0",
-            "json5": "^2.1.0",
-            "lodash": "^4.17.11",
-            "resolve": "^1.3.2",
-            "semver": "^5.4.1",
-            "source-map": "^0.5.0"
-          }
-        },
-        "@babel/parser": {
-          "version": "7.4.5",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.5.tgz",
-          "integrity": "sha512-9mUqkL1FF5T7f0WDFfAoDdiMVPWsdD1gZYzSnaXsxUCUqzuch/8of9G3VUSNiZmMBoRxT3neyVsqeiL/ZPcjew==",
-          "dev": true
-        },
-        "@babel/traverse": {
-          "version": "7.4.5",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.5.tgz",
-          "integrity": "sha512-Vc+qjynwkjRmIFGxy0KYoPj4FdVDxLej89kMHFsWScq999uX+pwcX4v9mWRjW0KcAYTPAuVQl2LKP1wEVLsp+A==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.0.0",
-            "@babel/generator": "^7.4.4",
-            "@babel/helper-function-name": "^7.1.0",
-            "@babel/helper-split-export-declaration": "^7.4.4",
-            "@babel/parser": "^7.4.5",
-            "@babel/types": "^7.4.4",
-            "debug": "^4.1.0",
-            "globals": "^11.1.0",
-            "lodash": "^4.17.11"
-          }
-        },
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "globals": {
-          "version": "11.12.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-          "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-          "dev": true
-        },
-        "json5": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
-          "integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
-          "dev": true,
-          "requires": {
-            "minimist": "^1.2.0"
-          }
-        },
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        },
-        "semver": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
-          "dev": true
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
-        }
       }
     },
     "react-svg-loader": {
@@ -16702,45 +20993,6 @@
         "react-is": "^16.4.2"
       }
     },
-    "react-themeable": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/react-themeable/-/react-themeable-1.1.0.tgz",
-      "integrity": "sha1-fURm3ZsrX6dQWHJ4JenxUro3mg4=",
-      "dev": true,
-      "requires": {
-        "object-assign": "^3.0.0"
-      },
-      "dependencies": {
-        "object-assign": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
-          "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=",
-          "dev": true
-        }
-      }
-    },
-    "react-transition-group": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.9.0.tgz",
-      "integrity": "sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==",
-      "dev": true,
-      "requires": {
-        "dom-helpers": "^3.4.0",
-        "loose-envify": "^1.4.0",
-        "prop-types": "^15.6.2",
-        "react-lifecycles-compat": "^3.0.4"
-      }
-    },
-    "react-window": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.1.tgz",
-      "integrity": "sha512-iNzekymggL9zAnil3QbmRG74RDMfIbO+plE/soP3M/zskicA1DwoLthC6/QA6xu9dr+A5UoawCTsEYcva2mfeA==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.0.0",
-        "memoize-one": ">=3.1.1 <6"
-      }
-    },
     "read": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
@@ -16760,24 +21012,45 @@
       }
     },
     "read-pkg": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-      "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
       "dev": true,
       "requires": {
-        "load-json-file": "^2.0.0",
+        "load-json-file": "^1.0.0",
         "normalize-package-data": "^2.3.2",
-        "path-type": "^2.0.0"
+        "path-type": "^1.0.0"
       }
     },
     "read-pkg-up": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-      "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
       "dev": true,
       "requires": {
-        "find-up": "^2.0.0",
-        "read-pkg": "^2.0.0"
+        "find-up": "^1.0.0",
+        "read-pkg": "^1.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+          "dev": true,
+          "requires": {
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "path-exists": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+          "dev": true,
+          "requires": {
+            "pinkie-promise": "^2.0.0"
+          }
+        }
       }
     },
     "readable-stream": {
@@ -16804,6 +21077,313 @@
         "graceful-fs": "^4.1.11",
         "micromatch": "^3.1.10",
         "readable-stream": "^2.0.2"
+      },
+      "dependencies": {
+        "arr-diff": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+          "dev": true
+        },
+        "array-unique": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+          "dev": true
+        },
+        "braces": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "expand-brackets": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+          "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+          "dev": true,
+          "requires": {
+            "debug": "^2.3.3",
+            "define-property": "^0.2.5",
+            "extend-shallow": "^2.0.1",
+            "posix-character-classes": "^0.1.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+              "dev": true,
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "0.1.6",
+              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+              "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+              "dev": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "dev": true,
+                  "requires": {
+                    "is-buffer": "^1.1.5"
+                  }
+                }
+              }
+            },
+            "is-data-descriptor": {
+              "version": "0.1.4",
+              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+              "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+              "dev": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "dev": true,
+                  "requires": {
+                    "is-buffer": "^1.1.5"
+                  }
+                }
+              }
+            },
+            "is-descriptor": {
+              "version": "0.1.6",
+              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+              "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+              "dev": true,
+              "requires": {
+                "is-accessor-descriptor": "^0.1.6",
+                "is-data-descriptor": "^0.1.4",
+                "kind-of": "^5.0.0"
+              }
+            },
+            "kind-of": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+              "dev": true
+            }
+          }
+        },
+        "extend-shallow": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+          "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+          "dev": true,
+          "requires": {
+            "assign-symbols": "^1.0.0",
+            "is-extendable": "^1.0.1"
+          },
+          "dependencies": {
+            "is-extendable": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+              "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+              "dev": true,
+              "requires": {
+                "is-plain-object": "^2.0.4"
+              }
+            }
+          }
+        },
+        "extglob": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+          "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+          "dev": true,
+          "requires": {
+            "array-unique": "^0.3.2",
+            "define-property": "^1.0.0",
+            "expand-brackets": "^2.1.4",
+            "extend-shallow": "^2.0.1",
+            "fragment-cache": "^0.2.1",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+              "dev": true,
+              "requires": {
+                "is-descriptor": "^1.0.0"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "dev": true,
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
+        },
+        "micromatch": {
+          "version": "3.1.10",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+          "dev": true,
+          "requires": {
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.3.1",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "extglob": "^2.0.4",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^6.0.2",
+            "nanomatch": "^1.2.9",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.2"
+          }
+        },
+        "to-regex-range": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+          "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+          "dev": true,
+          "requires": {
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1"
+          }
+        }
       }
     },
     "readline-sync": {
@@ -16812,26 +21392,13 @@
       "integrity": "sha1-PtqOZfI80qF+YTAbHwADOWr17No=",
       "dev": true
     },
-    "recompose": {
-      "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/recompose/-/recompose-0.30.0.tgz",
-      "integrity": "sha512-ZTrzzUDa9AqUIhRk4KmVFihH0rapdCSMFXjhHbNrjAWxBuUD/guYlyysMnuHjlZC/KRiOKRtB4jf96yYSkKE8w==",
+    "rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.0.0",
-        "change-emitter": "^0.1.2",
-        "fbjs": "^0.8.1",
-        "hoist-non-react-statics": "^2.3.1",
-        "react-lifecycles-compat": "^3.0.2",
-        "symbol-observable": "^1.0.4"
-      },
-      "dependencies": {
-        "hoist-non-react-statics": {
-          "version": "2.5.5",
-          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
-          "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==",
-          "dev": true
-        }
+        "resolve": "^1.1.6"
       }
     },
     "redent": {
@@ -16901,6 +21468,27 @@
       "requires": {
         "extend-shallow": "^3.0.2",
         "safe-regex": "^1.1.0"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+          "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+          "dev": true,
+          "requires": {
+            "assign-symbols": "^1.0.0",
+            "is-extendable": "^1.0.1"
+          }
+        },
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "^2.0.4"
+          }
+        }
       }
     },
     "regexpp": {
@@ -16910,9 +21498,9 @@
       "dev": true
     },
     "regexpu-core": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
-      "integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
+      "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
       "dev": true,
       "requires": {
         "regenerate": "^1.2.1",
@@ -16933,6 +21521,14 @@
       "dev": true,
       "requires": {
         "jsesc": "~0.5.0"
+      },
+      "dependencies": {
+        "jsesc": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+          "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+          "dev": true
+        }
       }
     },
     "remark": {
@@ -17111,11 +21707,21 @@
         "uuid": "^3.3.2"
       },
       "dependencies": {
-        "qs": {
-          "version": "6.5.2",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
           "dev": true
+        },
+        "tough-cookie": {
+          "version": "2.4.3",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+          "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+          "dev": true,
+          "requires": {
+            "psl": "^1.1.24",
+            "punycode": "^1.4.1"
+          }
         }
       }
     },
@@ -17150,9 +21756,9 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.1.tgz",
-      "integrity": "sha512-KuIe4mf++td/eFb6wkaPbMDnP6kObCaEtIDuHOUED6MNUo4K670KZUHuuvYPZDxNF0WVLw49n06M2m2dXphEzA==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz",
+      "integrity": "sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==",
       "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
@@ -17165,12 +21771,20 @@
       "dev": true,
       "requires": {
         "resolve-from": "^3.0.0"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+          "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+          "dev": true
+        }
       }
     },
     "resolve-from": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-      "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true
     },
     "resolve-pathname": {
@@ -17184,6 +21798,15 @@
       "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
       "dev": true
+    },
+    "responselike": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
+      "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
+      "dev": true,
+      "requires": {
+        "lowercase-keys": "^1.0.0"
+      }
     },
     "restore-cursor": {
       "version": "2.0.0",
@@ -17300,9 +21923,9 @@
       "dev": true
     },
     "rxjs": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.1.tgz",
-      "integrity": "sha512-y0j31WJc83wPu31vS1VlAFW5JGrnGC+j+TtGAa1fRQphy48+fDYiDmX8tjGloToEsMkxnouOg/1IzXGKkJnZMg==",
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.2.tgz",
+      "integrity": "sha512-HUb7j3kvb7p7eCUHE3FqjoDsC1xfZQ4AHFWfTKSpZ+sAhhz5X1WX0ZuUqWbzB2QhSLp3DoLUG+hMdEDKqWo2Zg==",
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"
@@ -17326,8 +21949,7 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sane": {
       "version": "2.5.2",
@@ -17346,11 +21968,316 @@
         "watch": "~0.18.0"
       },
       "dependencies": {
+        "arr-diff": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+          "dev": true
+        },
+        "array-unique": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+          "dev": true
+        },
+        "braces": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "expand-brackets": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+          "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+          "dev": true,
+          "requires": {
+            "debug": "^2.3.3",
+            "define-property": "^0.2.5",
+            "extend-shallow": "^2.0.1",
+            "posix-character-classes": "^0.1.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+              "dev": true,
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "0.1.6",
+              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+              "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+              "dev": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "dev": true,
+                  "requires": {
+                    "is-buffer": "^1.1.5"
+                  }
+                }
+              }
+            },
+            "is-data-descriptor": {
+              "version": "0.1.4",
+              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+              "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+              "dev": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "dev": true,
+                  "requires": {
+                    "is-buffer": "^1.1.5"
+                  }
+                }
+              }
+            },
+            "is-descriptor": {
+              "version": "0.1.6",
+              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+              "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+              "dev": true,
+              "requires": {
+                "is-accessor-descriptor": "^0.1.6",
+                "is-data-descriptor": "^0.1.4",
+                "kind-of": "^5.0.0"
+              }
+            },
+            "kind-of": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+              "dev": true
+            }
+          }
+        },
+        "extend-shallow": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+          "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+          "dev": true,
+          "requires": {
+            "assign-symbols": "^1.0.0",
+            "is-extendable": "^1.0.1"
+          },
+          "dependencies": {
+            "is-extendable": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+              "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+              "dev": true,
+              "requires": {
+                "is-plain-object": "^2.0.4"
+              }
+            }
+          }
+        },
+        "extglob": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+          "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+          "dev": true,
+          "requires": {
+            "array-unique": "^0.3.2",
+            "define-property": "^1.0.0",
+            "expand-brackets": "^2.1.4",
+            "extend-shallow": "^2.0.1",
+            "fragment-cache": "^0.2.1",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+              "dev": true,
+              "requires": {
+                "is-descriptor": "^1.0.0"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "dev": true,
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
+        },
+        "micromatch": {
+          "version": "3.1.10",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+          "dev": true,
+          "requires": {
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.3.1",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "extglob": "^2.0.4",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^6.0.2",
+            "nanomatch": "^1.2.9",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.2"
+          }
+        },
         "minimist": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
+        },
+        "to-regex-range": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+          "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+          "dev": true,
+          "requires": {
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1"
+          }
         }
       }
     },
@@ -17383,27 +22310,13 @@
             "wrap-ansi": "^2.0.0"
           }
         },
-        "find-up": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
-            "path-exists": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
-          }
-        },
-        "load-json-file": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^2.2.0",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0",
-            "strip-bom": "^2.0.0"
+            "number-is-nan": "^1.0.0"
           }
         },
         "os-locale": {
@@ -17415,69 +22328,27 @@
             "lcid": "^1.0.0"
           }
         },
-        "parse-json": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
-            "error-ex": "^1.2.0"
-          }
-        },
-        "path-exists": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-          "dev": true,
-          "requires": {
-            "pinkie-promise": "^2.0.0"
-          }
-        },
-        "path-type": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
-          }
-        },
-        "read-pkg": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-          "dev": true,
-          "requires": {
-            "load-json-file": "^1.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^1.0.0"
-          }
-        },
-        "read-pkg-up": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-          "dev": true,
-          "requires": {
-            "find-up": "^1.0.0",
-            "read-pkg": "^1.0.0"
-          }
-        },
-        "strip-bom": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-          "dev": true,
-          "requires": {
-            "is-utf8": "^0.2.0"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         },
         "which-module": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
           "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
+          "dev": true
+        },
+        "y18n": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
           "dev": true
         },
         "yargs": {
@@ -17546,11 +22417,40 @@
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
       "dev": true
     },
-    "scriptjs": {
-      "version": "2.5.9",
-      "resolved": "https://registry.npmjs.org/scriptjs/-/scriptjs-2.5.9.tgz",
-      "integrity": "sha512-qGVDoreyYiP1pkQnbnFAUIS5AjenNwwQBdl7zeos9etl+hYKWahjRTfzAZZYBv5xNHx7vNKCmaLDQZ6Fr2AEXg==",
-      "dev": true
+    "schema-utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.3.0.tgz",
+      "integrity": "sha1-9YdyIs4+kx7a4DnxfrNxbnE3+M8=",
+      "dev": true,
+      "requires": {
+        "ajv": "^5.0.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "5.5.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+          "dev": true,
+          "requires": {
+            "co": "^4.6.0",
+            "fast-deep-equal": "^1.0.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.3.0"
+          }
+        },
+        "fast-deep-equal": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+          "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+          "dev": true
+        },
+        "json-schema-traverse": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+          "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+          "dev": true
+        }
+      }
     },
     "scss-tokenizer": {
       "version": "0.2.3",
@@ -17573,12 +22473,6 @@
         }
       }
     },
-    "section-iterator": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/section-iterator/-/section-iterator-2.0.0.tgz",
-      "integrity": "sha1-v0RNev7rlK1Dw5rS+yYVFifMuio=",
-      "dev": true
-    },
     "select-hose": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
@@ -17595,9 +22489,9 @@
       }
     },
     "semver": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.0.0.tgz",
-      "integrity": "sha512-0UewU+9rFapKFnlbirLi3byoOuhrSsli/z/ihNnvM24vgF+8sNBiI1LZPBSH9wJKUwaUbw+s3hToDLCXkrghrQ==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
       "dev": true
     },
     "semver-compare": {
@@ -17607,9 +22501,9 @@
       "dev": true
     },
     "send": {
-      "version": "0.16.2",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
-      "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
+      "integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
       "dev": true,
       "requires": {
         "debug": "2.6.9",
@@ -17619,12 +22513,20 @@
         "escape-html": "~1.0.3",
         "etag": "~1.8.1",
         "fresh": "0.5.2",
-        "http-errors": "~1.6.2",
-        "mime": "1.4.1",
-        "ms": "2.0.0",
+        "http-errors": "~1.7.2",
+        "mime": "1.6.0",
+        "ms": "2.1.1",
         "on-finished": "~2.3.0",
-        "range-parser": "~1.2.0",
-        "statuses": "~1.4.0"
+        "range-parser": "~1.2.1",
+        "statuses": "~1.5.0"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        }
       }
     },
     "serialize-javascript": {
@@ -17646,18 +22548,44 @@
         "http-errors": "~1.6.2",
         "mime-types": "~2.1.17",
         "parseurl": "~1.3.2"
+      },
+      "dependencies": {
+        "http-errors": {
+          "version": "1.6.3",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+          "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+          "dev": true,
+          "requires": {
+            "depd": "~1.1.2",
+            "inherits": "2.0.3",
+            "setprototypeof": "1.1.0",
+            "statuses": ">= 1.4.0 < 2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "dev": true
+        },
+        "setprototypeof": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+          "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
+          "dev": true
+        }
       }
     },
     "serve-static": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
-      "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
+      "integrity": "sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==",
       "dev": true,
       "requires": {
         "encodeurl": "~1.0.2",
         "escape-html": "~1.0.3",
-        "parseurl": "~1.3.2",
-        "send": "0.16.2"
+        "parseurl": "~1.3.3",
+        "send": "0.17.1"
       }
     },
     "set-blocking": {
@@ -17667,38 +22595,26 @@
       "dev": true
     },
     "set-value": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
-      "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+      "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
       "dev": true,
       "requires": {
         "extend-shallow": "^2.0.1",
         "is-extendable": "^0.1.1",
         "is-plain-object": "^2.0.3",
         "split-string": "^3.0.1"
-      },
-      "dependencies": {
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "dev": true,
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
-        }
       }
     },
     "setimmediate": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
-      "dev": true
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
     },
     "setprototypeof": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-      "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+      "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
       "dev": true
     },
     "sha.js": {
@@ -17730,12 +22646,6 @@
         }
       }
     },
-    "shallow-equal": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/shallow-equal/-/shallow-equal-1.1.0.tgz",
-      "integrity": "sha512-0SW1nWo1hnabO62SEeHsl8nmTVVEzguVWZCj5gaQrgWAxz/BaCja4OWdJBWLVPDxdtE/WU7c98uUCCXyPHSCvw==",
-      "dev": true
-    },
     "shallowequal": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
@@ -17757,6 +22667,17 @@
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
     },
+    "shelljs": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.3.tgz",
+      "integrity": "sha512-fc0BKlAWiLpwZljmOvAOTE/gXawtCoNrP5oaY7KIaQbbyHeQVg01pSEuEGvGh3HEdBU4baCD7wQBwADmM/7f7A==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      }
+    },
     "shellwords": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
@@ -17773,7 +22694,6 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
       "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
-      "dev": true,
       "requires": {
         "is-arrayish": "^0.3.1"
       },
@@ -17781,8 +22701,7 @@
         "is-arrayish": {
           "version": "0.3.2",
           "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-          "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
-          "dev": true
+          "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
         }
       }
     },
@@ -17811,14 +22730,6 @@
         "ansi-styles": "^3.2.0",
         "astral-regex": "^1.0.0",
         "is-fullwidth-code-point": "^2.0.0"
-      },
-      "dependencies": {
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        }
       }
     },
     "snapdragon": {
@@ -17844,15 +22755,6 @@
           "dev": true,
           "requires": {
             "is-descriptor": "^0.1.0"
-          }
-        },
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "dev": true,
-          "requires": {
-            "is-extendable": "^0.1.0"
           }
         },
         "source-map": {
@@ -17912,6 +22814,12 @@
             "kind-of": "^6.0.2"
           }
         },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        },
         "kind-of": {
           "version": "6.0.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
@@ -17937,17 +22845,6 @@
       "requires": {
         "faye-websocket": "^0.10.0",
         "uuid": "^3.0.1"
-      },
-      "dependencies": {
-        "faye-websocket": {
-          "version": "0.10.0",
-          "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
-          "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
-          "dev": true,
-          "requires": {
-            "websocket-driver": ">=0.5.1"
-          }
-        }
       }
     },
     "sockjs-client": {
@@ -17962,6 +22859,26 @@
         "inherits": "^2.0.1",
         "json3": "^3.3.2",
         "url-parse": "^1.1.8"
+      },
+      "dependencies": {
+        "faye-websocket": {
+          "version": "0.11.3",
+          "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.3.tgz",
+          "integrity": "sha512-D2y4bovYpzziGgbHYtGCMjlJM36vAl/y+xUyn1C+FVx8szd1E+86KwVw6XvYSzOP8iMpm1X0I4xJD+QtUb36OA==",
+          "dev": true,
+          "requires": {
+            "websocket-driver": ">=0.5.1"
+          }
+        }
+      }
+    },
+    "sort-keys": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
+      "integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
+      "dev": true,
+      "requires": {
+        "is-plain-obj": "^1.0.0"
       }
     },
     "source-list-map": {
@@ -18049,9 +22966,9 @@
       }
     },
     "spdx-license-ids": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.4.tgz",
-      "integrity": "sha512-7j8LYJLeY/Yb6ACbQ7F76qy5jHkp0U6jgBfJsk97bwWlVUnUWsAgpyaCvo17h0/RQGnQ036tVDomiwoI4pDkQA==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
+      "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
       "dev": true
     },
     "spdy": {
@@ -18077,9 +22994,9 @@
           }
         },
         "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         }
       }
@@ -18108,15 +23025,15 @@
           }
         },
         "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         },
         "readable-stream": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.3.0.tgz",
-          "integrity": "sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==",
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
           "dev": true,
           "requires": {
             "inherits": "^2.0.3",
@@ -18139,6 +23056,27 @@
       "dev": true,
       "requires": {
         "extend-shallow": "^3.0.0"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+          "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+          "dev": true,
+          "requires": {
+            "assign-symbols": "^1.0.0",
+            "is-extendable": "^1.0.1"
+          }
+        },
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "^2.0.4"
+          }
+        }
       }
     },
     "split2": {
@@ -18231,9 +23169,9 @@
       "dev": true
     },
     "state-toggle": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/state-toggle/-/state-toggle-1.0.1.tgz",
-      "integrity": "sha512-Qe8QntFrrpWTnHwvwj2FZTgv+PKIsp0B9VxLzLLbSpPXWOgRgc5LVj/aTiSfK1RqIeF9jeC1UeOH8Q8y60A7og==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/state-toggle/-/state-toggle-1.0.2.tgz",
+      "integrity": "sha512-8LpelPGR0qQM4PnfLiplOQNJcIN1/r2Gy0xKB2zKnIW2YzPMt2sR4I/+gtPjhN7Svh9kw+zqEg2SFwpBO9iNiw==",
       "dev": true
     },
     "static-extend": {
@@ -18292,19 +23230,13 @@
             "lodash.reject": "^4.4.0",
             "lodash.some": "^4.4.0"
           }
-        },
-        "lodash.bind": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-4.2.1.tgz",
-          "integrity": "sha1-euMBfpOWIqwxt9fX3LGzTbFpDTU=",
-          "dev": true
         }
       }
     },
     "statuses": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-      "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
       "dev": true
     },
     "stdout-stream": {
@@ -18365,6 +23297,12 @@
       "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
       "dev": true
     },
+    "strict-uri-encode": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
+      "dev": true
+    },
     "string-argv": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.0.tgz",
@@ -18399,14 +23337,30 @@
       }
     },
     "string-width": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "dev": true,
       "requires": {
-        "code-point-at": "^1.0.0",
-        "is-fullwidth-code-point": "^1.0.0",
-        "strip-ansi": "^3.0.0"
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
       }
     },
     "string.prototype.trim": {
@@ -18462,10 +23416,13 @@
       }
     },
     "strip-bom": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-      "dev": true
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+      "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+      "dev": true,
+      "requires": {
+        "is-utf8": "^0.2.0"
+      }
     },
     "strip-eof": {
       "version": "1.0.0",
@@ -18635,6 +23592,17 @@
             "postcss": "^5.0.0"
           }
         },
+        "postcss-selector-parser": {
+          "version": "2.2.3",
+          "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz",
+          "integrity": "sha1-+UN3iGBsPJrO4W/+jYsWKX8nu5A=",
+          "dev": true,
+          "requires": {
+            "flatten": "^1.0.2",
+            "indexes-of": "^1.0.1",
+            "uniq": "^1.0.1"
+          }
+        },
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -18716,17 +23684,46 @@
           "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
           "dev": true
         },
-        "balanced-match": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+        "arr-diff": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
           "dev": true
         },
-        "camelcase": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+        "array-unique": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
           "dev": true
+        },
+        "braces": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
         },
         "camelcase-keys": {
           "version": "4.2.0",
@@ -18739,18 +23736,6 @@
             "quick-lru": "^1.0.0"
           }
         },
-        "cosmiconfig": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.0.tgz",
-          "integrity": "sha512-nxt+Nfc3JAqf4WIWd0jXLjTJZmsPLrA9DDc4nRw2KFJQJK7DNooqSXrNI7tzLG50CF8axczly5UV929tBmh/7g==",
-          "dev": true,
-          "requires": {
-            "import-fresh": "^2.0.0",
-            "is-directory": "^0.3.1",
-            "js-yaml": "^3.13.0",
-            "parse-json": "^4.0.0"
-          }
-        },
         "debug": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -18758,6 +23743,170 @@
           "dev": true,
           "requires": {
             "ms": "^2.1.1"
+          }
+        },
+        "expand-brackets": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+          "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+          "dev": true,
+          "requires": {
+            "debug": "^2.3.3",
+            "define-property": "^0.2.5",
+            "extend-shallow": "^2.0.1",
+            "posix-character-classes": "^0.1.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+              "dev": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "define-property": {
+              "version": "0.2.5",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+              "dev": true,
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "0.1.6",
+              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+              "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+              "dev": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "dev": true,
+                  "requires": {
+                    "is-buffer": "^1.1.5"
+                  }
+                }
+              }
+            },
+            "is-data-descriptor": {
+              "version": "0.1.4",
+              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+              "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+              "dev": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "dev": true,
+                  "requires": {
+                    "is-buffer": "^1.1.5"
+                  }
+                }
+              }
+            },
+            "is-descriptor": {
+              "version": "0.1.6",
+              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+              "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+              "dev": true,
+              "requires": {
+                "is-accessor-descriptor": "^0.1.6",
+                "is-data-descriptor": "^0.1.4",
+                "kind-of": "^5.0.0"
+              }
+            },
+            "kind-of": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+              "dev": true
+            },
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+              "dev": true
+            }
+          }
+        },
+        "extend-shallow": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+          "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+          "dev": true,
+          "requires": {
+            "assign-symbols": "^1.0.0",
+            "is-extendable": "^1.0.1"
+          },
+          "dependencies": {
+            "is-extendable": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+              "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+              "dev": true,
+              "requires": {
+                "is-plain-object": "^2.0.4"
+              }
+            }
+          }
+        },
+        "extglob": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+          "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+          "dev": true,
+          "requires": {
+            "array-unique": "^0.3.2",
+            "define-property": "^1.0.0",
+            "expand-brackets": "^2.1.4",
+            "extend-shallow": "^2.0.1",
+            "fragment-cache": "^0.2.1",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+              "dev": true,
+              "requires": {
+                "is-descriptor": "^1.0.0"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
           }
         },
         "fast-glob": {
@@ -18783,24 +23932,48 @@
             "flat-cache": "^2.0.1"
           }
         },
-        "global-modules": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
-          "integrity": "sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==",
+        "fill-range": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "dev": true,
           "requires": {
-            "global-prefix": "^3.0.0"
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
           }
         },
-        "global-prefix": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
-          "integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
+        "glob-parent": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+          "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
           "dev": true,
           "requires": {
-            "ini": "^1.3.5",
-            "kind-of": "^6.0.2",
-            "which": "^1.3.1"
+            "is-glob": "^3.1.0",
+            "path-dirname": "^1.0.0"
+          },
+          "dependencies": {
+            "is-glob": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+              "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+              "dev": true,
+              "requires": {
+                "is-extglob": "^2.1.0"
+              }
+            }
           }
         },
         "globby": {
@@ -18828,21 +24001,79 @@
           }
         },
         "ignore": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.1.tgz",
-          "integrity": "sha512-DWjnQIFLenVrwyRCKZT+7a7/U4Cqgar4WG8V++K3hw+lrW1hc/SIwdiGmtxKCVACmHULTuGeBbHJmbwW7/sAvA==",
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.2.tgz",
+          "integrity": "sha512-vdqWBp7MyzdmHkkRWV5nY+PfGRbYbahfuvsBCh277tq+w9zyNi7h5CYJCK0kmzti9kU+O/cB7sE8HvKv6aXAKQ==",
           "dev": true
         },
-        "import-lazy": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-3.1.0.tgz",
-          "integrity": "sha512-8/gvXvX2JMn0F+CDlSC4l6kOmVaLOO3XLkksI7CI3Ud95KDYJuYur2b9P/PUt/i/pDAMd/DulQsNbbbmRRsDIQ==",
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        },
+        "is-extglob": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
           "dev": true
         },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+        "is-glob": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+          "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+          "dev": true,
+          "requires": {
+            "is-extglob": "^2.1.1"
+          }
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
           "dev": true
         },
         "kind-of": {
@@ -18871,6 +24102,15 @@
             }
           }
         },
+        "log-symbols": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
+          "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.0.1"
+          }
+        },
         "map-obj": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
@@ -18894,11 +24134,42 @@
             "yargs-parser": "^10.0.0"
           }
         },
+        "micromatch": {
+          "version": "3.1.10",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+          "dev": true,
+          "requires": {
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.3.1",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "extglob": "^2.0.4",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^6.0.2",
+            "nanomatch": "^1.2.9",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.2"
+          }
+        },
         "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
+        },
+        "parse-json": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
+          }
         },
         "path-type": {
           "version": "3.0.0",
@@ -18923,27 +24194,11 @@
           "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
           "dev": true
         },
-        "postcss": {
-          "version": "7.0.16",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
-          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
-          }
-        },
-        "postcss-selector-parser": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
-          "integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
-          "dev": true,
-          "requires": {
-            "dot-prop": "^4.1.1",
-            "indexes-of": "^1.0.1",
-            "uniq": "^1.0.1"
-          }
+        "postcss-value-parser": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+          "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+          "dev": true
         },
         "read-pkg": {
           "version": "3.0.0",
@@ -18976,12 +24231,6 @@
             "strip-indent": "^2.0.0"
           }
         },
-        "resolve-from": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-          "dev": true
-        },
         "slash": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
@@ -19008,19 +24257,26 @@
             "ansi-regex": "^4.1.0"
           }
         },
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+          "dev": true
+        },
         "strip-indent": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
           "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
           "dev": true
         },
-        "supports-color": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+        "to-regex-range": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+          "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1"
           }
         },
         "trim-newlines": {
@@ -19076,31 +24332,10 @@
         "stylelint": "^7.6.0"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
         "ansi-styles": {
           "version": "2.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
           "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "arr-diff": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-          "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-          "dev": true,
-          "requires": {
-            "arr-flatten": "^1.0.1"
-          }
-        },
-        "array-unique": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-          "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
           "dev": true
         },
         "autoprefixer": {
@@ -19117,16 +24352,11 @@
             "postcss-value-parser": "^3.2.3"
           }
         },
-        "braces": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-          "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-          "dev": true,
-          "requires": {
-            "expand-range": "^1.8.1",
-            "preserve": "^0.2.0",
-            "repeat-element": "^1.1.2"
-          }
+        "balanced-match": {
+          "version": "0.4.2",
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+          "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
+          "dev": true
         },
         "browserslist": {
           "version": "1.7.7",
@@ -19151,24 +24381,6 @@
             "os-homedir": "^1.0.1",
             "parse-json": "^2.2.0",
             "require-from-string": "^1.1.0"
-          }
-        },
-        "expand-brackets": {
-          "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-          "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-          "dev": true,
-          "requires": {
-            "is-posix-bracket": "^0.1.0"
-          }
-        },
-        "extglob": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-          "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "^1.0.0"
           }
         },
         "file-entry-cache": {
@@ -19218,27 +24430,6 @@
           "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
           "dev": true
         },
-        "is-extglob": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        },
-        "is-glob": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "^1.0.0"
-          }
-        },
         "known-css-properties": {
           "version": "0.2.0",
           "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.2.0.tgz",
@@ -19275,50 +24466,11 @@
             }
           }
         },
-        "micromatch": {
-          "version": "2.3.11",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-          "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-          "dev": true,
-          "requires": {
-            "arr-diff": "^2.0.0",
-            "array-unique": "^0.2.1",
-            "braces": "^1.8.2",
-            "expand-brackets": "^0.1.4",
-            "extglob": "^0.3.1",
-            "filename-regex": "^2.0.0",
-            "is-extglob": "^1.0.0",
-            "is-glob": "^2.0.1",
-            "kind-of": "^3.0.2",
-            "normalize-path": "^2.0.1",
-            "object.omit": "^2.0.0",
-            "parse-glob": "^3.0.4",
-            "regex-cache": "^0.4.2"
-          }
-        },
         "minimist": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
-        },
-        "normalize-path": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-          "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-          "dev": true,
-          "requires": {
-            "remove-trailing-separator": "^1.0.1"
-          }
-        },
-        "parse-json": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-          "dev": true,
-          "requires": {
-            "error-ex": "^1.2.0"
-          }
         },
         "postcss": {
           "version": "5.2.18",
@@ -19406,10 +24558,33 @@
             "postcss": "^5.2.13"
           }
         },
+        "postcss-selector-parser": {
+          "version": "2.2.3",
+          "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz",
+          "integrity": "sha1-+UN3iGBsPJrO4W/+jYsWKX8nu5A=",
+          "dev": true,
+          "requires": {
+            "flatten": "^1.0.2",
+            "indexes-of": "^1.0.1",
+            "uniq": "^1.0.1"
+          }
+        },
+        "postcss-value-parser": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+          "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+          "dev": true
+        },
         "require-from-string": {
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-1.2.1.tgz",
           "integrity": "sha1-UpyczvJzgK3+yaL5ZbZJu+5jZBg=",
+          "dev": true
+        },
+        "resolve-from": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+          "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
           "dev": true
         },
         "slice-ansi": {
@@ -19432,27 +24607,6 @@
           "resolved": "https://registry.npmjs.org/specificity/-/specificity-0.3.2.tgz",
           "integrity": "sha512-Nc/QN/A425Qog7j9aHmwOrlwX2e7pNI47ciwxwy4jOlvbbMHkNNJchit+FX+UjF3IAdiaaV5BKeWuDUnws6G1A==",
           "dev": true
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
-          },
-          "dependencies": {
-            "strip-ansi": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-              "dev": true,
-              "requires": {
-                "ansi-regex": "^3.0.0"
-              }
-            }
-          }
         },
         "stylelint": {
           "version": "7.13.0",
@@ -19553,6 +24707,19 @@
         "lodash": "^4.17.4",
         "postcss": "^6.0.14",
         "postcss-sorting": "^3.1.0"
+      },
+      "dependencies": {
+        "postcss": {
+          "version": "6.0.23",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.4.1",
+            "source-map": "^0.6.1",
+            "supports-color": "^5.4.0"
+          }
+        }
       }
     },
     "stylelint-scss": {
@@ -19568,16 +24735,11 @@
         "postcss-value-parser": "^3.3.0"
       },
       "dependencies": {
-        "postcss-selector-parser": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
-          "integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
-          "dev": true,
-          "requires": {
-            "dot-prop": "^4.1.1",
-            "indexes-of": "^1.0.1",
-            "uniq": "^1.0.1"
-          }
+        "postcss-value-parser": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+          "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+          "dev": true
         }
       }
     },
@@ -19588,28 +24750,6 @@
       "dev": true,
       "requires": {
         "postcss": "^7.0.2"
-      },
-      "dependencies": {
-        "postcss": {
-          "version": "7.0.16",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
-          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
-          }
-        },
-        "supports-color": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
       }
     },
     "supports-color": {
@@ -19646,17 +24786,16 @@
       "dev": true
     },
     "svgo": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-1.2.2.tgz",
-      "integrity": "sha512-rAfulcwp2D9jjdGu+0CuqlrAUin6bBWrpoqXWwKDZZZJfXcUXQSxLJOFJCQCSA0x0pP2U0TxSlJu2ROq5Bq6qA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-1.3.0.tgz",
+      "integrity": "sha512-MLfUA6O+qauLDbym+mMZgtXCGRfIxyQoeH6IKVcFslyODEe/ElJNwr0FohQ3xG4C6HK6bk3KYPPXwHVJk3V5NQ==",
       "dev": true,
       "requires": {
         "chalk": "^2.4.1",
         "coa": "^2.0.2",
         "css-select": "^2.0.0",
         "css-select-base-adapter": "^0.1.1",
-        "css-tree": "1.0.0-alpha.28",
-        "css-url-regex": "^1.1.0",
+        "css-tree": "1.0.0-alpha.33",
         "csso": "^3.5.1",
         "js-yaml": "^3.13.1",
         "mkdirp": "~0.5.1",
@@ -19694,13 +24833,12 @@
     "symbol-observable": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
-      "dev": true
+      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
     },
     "symbol-tree": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
-      "integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true
     },
     "synesthesia": {
@@ -19710,30 +24848,21 @@
       "dev": true,
       "requires": {
         "css-color-names": "0.0.3"
-      },
-      "dependencies": {
-        "css-color-names": {
-          "version": "0.0.3",
-          "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.3.tgz",
-          "integrity": "sha1-3gzvFvTYqoIioyDVttfpu62nufY=",
-          "dev": true
-        }
       }
     },
     "tabbable": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-1.1.3.tgz",
-      "integrity": "sha512-nOWwx35/JuDI4ONuF0ZTo6lYvI0fY0tZCH1ErzY2EXfu4az50ZyiUX8X073FLiZtmWUVlkRnuXsehjJgCw9tYg==",
-      "dev": true
+      "integrity": "sha512-nOWwx35/JuDI4ONuF0ZTo6lYvI0fY0tZCH1ErzY2EXfu4az50ZyiUX8X073FLiZtmWUVlkRnuXsehjJgCw9tYg=="
     },
     "table": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/table/-/table-5.2.3.tgz",
-      "integrity": "sha512-N2RsDAMvDLvYwFcwbPyF3VmVSSkuF+G1e+8inhBLtHpvwXGw4QRPEZhihQNeEN0i1up6/f6ObCJXNdlRG3YVyQ==",
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/table/-/table-5.4.4.tgz",
+      "integrity": "sha512-IIfEAUx5QlODLblLrGTTLJA7Tk0iLSGBvgY8essPRVNGHAzThujww1YqHLs6h3HfTg55h++RzLHH5Xw/rfv+mg==",
       "dev": true,
       "requires": {
-        "ajv": "^6.9.1",
-        "lodash": "^4.17.11",
+        "ajv": "^6.10.2",
+        "lodash": "^4.17.14",
         "slice-ansi": "^2.1.0",
         "string-width": "^3.0.0"
       },
@@ -19742,12 +24871,6 @@
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
           "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
         "string-width": {
@@ -19779,13 +24902,13 @@
       "dev": true
     },
     "tar": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-      "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
+      "integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
       "dev": true,
       "requires": {
         "block-stream": "*",
-        "fstream": "^1.0.2",
+        "fstream": "^1.0.12",
         "inherits": "2"
       }
     },
@@ -19800,179 +24923,6 @@
         "object-assign": "^4.1.0",
         "read-pkg-up": "^1.0.1",
         "require-main-filename": "^1.0.1"
-      },
-      "dependencies": {
-        "arr-diff": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-          "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-          "dev": true,
-          "requires": {
-            "arr-flatten": "^1.0.1"
-          }
-        },
-        "array-unique": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-          "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
-          "dev": true
-        },
-        "braces": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-          "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-          "dev": true,
-          "requires": {
-            "expand-range": "^1.8.1",
-            "preserve": "^0.2.0",
-            "repeat-element": "^1.1.2"
-          }
-        },
-        "expand-brackets": {
-          "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-          "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-          "dev": true,
-          "requires": {
-            "is-posix-bracket": "^0.1.0"
-          }
-        },
-        "extglob": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-          "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "^1.0.0"
-          }
-        },
-        "find-up": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-          "dev": true,
-          "requires": {
-            "path-exists": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
-          }
-        },
-        "is-extglob": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true
-        },
-        "is-glob": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "^1.0.0"
-          }
-        },
-        "load-json-file": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^2.2.0",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0",
-            "strip-bom": "^2.0.0"
-          }
-        },
-        "micromatch": {
-          "version": "2.3.11",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-          "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-          "dev": true,
-          "requires": {
-            "arr-diff": "^2.0.0",
-            "array-unique": "^0.2.1",
-            "braces": "^1.8.2",
-            "expand-brackets": "^0.1.4",
-            "extglob": "^0.3.1",
-            "filename-regex": "^2.0.0",
-            "is-extglob": "^1.0.0",
-            "is-glob": "^2.0.1",
-            "kind-of": "^3.0.2",
-            "normalize-path": "^2.0.1",
-            "object.omit": "^2.0.0",
-            "parse-glob": "^3.0.4",
-            "regex-cache": "^0.4.2"
-          }
-        },
-        "normalize-path": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-          "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-          "dev": true,
-          "requires": {
-            "remove-trailing-separator": "^1.0.1"
-          }
-        },
-        "parse-json": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-          "dev": true,
-          "requires": {
-            "error-ex": "^1.2.0"
-          }
-        },
-        "path-exists": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-          "dev": true,
-          "requires": {
-            "pinkie-promise": "^2.0.0"
-          }
-        },
-        "path-type": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
-          }
-        },
-        "read-pkg": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-          "dev": true,
-          "requires": {
-            "load-json-file": "^1.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^1.0.0"
-          }
-        },
-        "read-pkg-up": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-          "dev": true,
-          "requires": {
-            "find-up": "^1.0.0",
-            "read-pkg": "^1.0.0"
-          }
-        },
-        "strip-bom": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-          "dev": true,
-          "requires": {
-            "is-utf8": "^0.2.0"
-          }
-        }
       }
     },
     "text-table": {
@@ -20031,15 +24981,15 @@
       }
     },
     "tiny-invariant": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.0.4.tgz",
-      "integrity": "sha512-lMhRd/djQJ3MoaHEBrw8e2/uM4rs9YMNk0iOr8rHQ0QdbM7D4l0gFl3szKdeixrlyfm9Zqi4dxHCM2qVG8ND5g==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.0.6.tgz",
+      "integrity": "sha512-FOyLWWVjG+aC0UqG76V53yAWdXfH8bO6FNmyZOuUrzDzK8DI3/JRY25UD7+g49JWM1LXwymsKERB+DzI0dTEQA==",
       "dev": true
     },
     "tiny-warning": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.2.tgz",
-      "integrity": "sha512-rru86D9CpQRLvsFG5XFdy0KdLAvjdQDyZCsRcuu60WtzFylDM3eAWSxEVz5kzL2Gp544XiUvPbVKtOA/txLi9Q==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
+      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==",
       "dev": true
     },
     "tinycolor2": {
@@ -20094,34 +25044,60 @@
         "extend-shallow": "^3.0.2",
         "regex-not": "^1.0.2",
         "safe-regex": "^1.1.0"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+          "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+          "dev": true,
+          "requires": {
+            "assign-symbols": "^1.0.0",
+            "is-extendable": "^1.0.1"
+          }
+        },
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "^2.0.4"
+          }
+        }
       }
     },
     "to-regex-range": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
-      "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "dev": true,
       "requires": {
-        "is-number": "^3.0.0",
-        "repeat-string": "^1.6.1"
-      }
-    },
-    "tough-cookie": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
-      "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
-      "dev": true,
-      "requires": {
-        "psl": "^1.1.24",
-        "punycode": "^1.4.1"
+        "is-number": "^7.0.0"
       },
       "dependencies": {
-        "punycode": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
           "dev": true
         }
+      }
+    },
+    "toidentifier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
+      "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
+      "dev": true
+    },
+    "tough-cookie": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+      "dev": true,
+      "requires": {
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
       }
     },
     "tr46": {
@@ -20155,15 +25131,15 @@
       "dev": true
     },
     "trim-trailing-lines": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.1.tgz",
-      "integrity": "sha512-bWLv9BbWbbd7mlqqs2oQYnLD/U/ZqeJeJwbO0FG2zA1aTq+HTvxfHNKFa/HGCVyJpDiioUYaBhfiT6rgk+l4mg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.2.tgz",
+      "integrity": "sha512-MUjYItdrqqj2zpcHFTkMa9WAv4JHTI6gnRQGPFLrt5L9a6tRMiDnIqYl8JBvu2d2Tc3lWJKQwlGCp0K8AvCM+Q==",
       "dev": true
     },
     "trough": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.3.tgz",
-      "integrity": "sha512-fwkLWH+DimvA4YCy+/nvJd61nWQQ2liO/nF/RjkTpiOGi+zxZzVkhb1mvbHIIW4b/8nDsYI8uTmAlc0nNkRMOw==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.4.tgz",
+      "integrity": "sha512-tdzBRDGWcI1OpPVmChbdSKhvSVurznZ8X36AYURAcl+0o2ldlCY2XPzyXNNxwJwwyIU+rIglTCG4kxtNKBQH7Q==",
       "dev": true
     },
     "true-case-path": {
@@ -20176,9 +25152,9 @@
       }
     },
     "tslib": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
       "dev": true
     },
     "tty-browserify": {
@@ -20202,6 +25178,12 @@
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "dev": true
     },
+    "type": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/type/-/type-1.0.1.tgz",
+      "integrity": "sha512-MAM5dBMJCJNKs9E7JXo4CXRAansRfG0nlJxW7Wf6GZzSOvH31zClSaHdIMWLehe/EGMBkqeC55rrkaOr5Oo7Nw==",
+      "dev": true
+    },
     "type-check": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
@@ -20212,9 +25194,9 @@
       }
     },
     "type-fest": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.4.1.tgz",
-      "integrity": "sha512-IwzA/LSfD2vC1/YDYMv/zHP4rDF1usCwllsDpbolT3D4fUepIO7f9K70jjmUewU/LmGUKJcwcVtDCpnKk4BPMw==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+      "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
       "dev": true
     },
     "type-is": {
@@ -20233,41 +25215,31 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
-    "ua-parser-js": {
-      "version": "0.7.19",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.19.tgz",
-      "integrity": "sha512-T3PVJ6uz8i0HzPxOF9SWzWAlfN/DavlpQqepn22xgve/5QecC+XMCAtmUNnY7C9StehaV6exjUCI801lOI7QlQ==",
+    "typescript": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
+      "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
       "dev": true
     },
+    "typescript-compiler": {
+      "version": "1.4.1-2",
+      "resolved": "https://registry.npmjs.org/typescript-compiler/-/typescript-compiler-1.4.1-2.tgz",
+      "integrity": "sha1-uk99si2RU0oZKdkACdzhYety/T8=",
+      "dev": true
+    },
+    "ua-parser-js": {
+      "version": "0.7.20",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.20.tgz",
+      "integrity": "sha512-8OaIKfzL5cpx8eCMAhhvTlft8GYF8b2eQr6JkCyVdrgjcytyOmPCXrqXFcUnhonRpLlh5yxEZVohm6mzaowUOw=="
+    },
     "uglify-js": {
-      "version": "2.8.29",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-      "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.0.tgz",
+      "integrity": "sha512-W+jrUHJr3DXKhrsS7NUVxn3zqMOFn0hL/Ei6v0anCIMoKC93TjcflTagwIHLW7SfMFfiQuktQyFVCFHGUE0+yg==",
       "dev": true,
       "requires": {
-        "source-map": "~0.5.1",
-        "uglify-to-browserify": "~1.0.0",
-        "yargs": "~3.10.0"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
-        },
-        "yargs": {
-          "version": "3.10.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-          "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-          "dev": true,
-          "requires": {
-            "camelcase": "^1.0.2",
-            "cliui": "^2.1.0",
-            "decamelize": "^1.0.0",
-            "window-size": "0.1.0"
-          }
-        }
+        "commander": "~2.20.0",
+        "source-map": "~0.6.1"
       }
     },
     "uglify-loader": {
@@ -20286,24 +25258,6 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
           "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
           "dev": true
-        },
-        "uglify-js": {
-          "version": "3.5.10",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.10.tgz",
-          "integrity": "sha512-/GTF0nosyPLbdJBd+AwYiZ+Hu5z8KXWnO0WCGt1BQ/u9Iamhejykqmz5o1OHJ53+VAk6xVxychonnApDjuqGsw==",
-          "dev": true,
-          "requires": {
-            "commander": "~2.20.0",
-            "source-map": "~0.6.1"
-          },
-          "dependencies": {
-            "source-map": {
-              "version": "0.6.1",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-              "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-              "dev": true
-            }
-          }
         }
       }
     },
@@ -20314,10 +25268,81 @@
       "dev": true,
       "optional": true
     },
+    "uglifyjs-webpack-plugin": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-0.4.6.tgz",
+      "integrity": "sha1-uVH0q7a9YX5m9j64kUmOORdj4wk=",
+      "dev": true,
+      "requires": {
+        "source-map": "^0.5.6",
+        "uglify-js": "^2.8.29",
+        "webpack-sources": "^1.0.1"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+          "dev": true
+        },
+        "cliui": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+          "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+          "dev": true,
+          "requires": {
+            "center-align": "^0.1.1",
+            "right-align": "^0.1.1",
+            "wordwrap": "0.0.2"
+          }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        },
+        "uglify-js": {
+          "version": "2.8.29",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+          "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+          "dev": true,
+          "requires": {
+            "source-map": "~0.5.1",
+            "uglify-to-browserify": "~1.0.0",
+            "yargs": "~3.10.0"
+          }
+        },
+        "window-size": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+          "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+          "dev": true
+        },
+        "wordwrap": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+          "dev": true
+        },
+        "yargs": {
+          "version": "3.10.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+          "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+          "dev": true,
+          "requires": {
+            "camelcase": "^1.0.2",
+            "cliui": "^2.1.0",
+            "decamelize": "^1.0.0",
+            "window-size": "0.1.0"
+          }
+        }
+      }
+    },
     "unherit": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.1.tgz",
-      "integrity": "sha512-+XZuV691Cn4zHsK0vkKYwBEwB74T3IZIcxrgn2E4rKwTfFyI1zCh7X7grwh9Re08fdPlarIdyWgI8aVB3F5A5g==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.2.tgz",
+      "integrity": "sha512-W3tMnpaMG7ZY6xe/moK04U9fBhi6wEiCYHUW5Mop/wQHf12+79EQGwxYejNdhEz2mkqkBlGwm7pxmgBKMVUj0w==",
       "dev": true,
       "requires": {
         "inherits": "^2.0.1",
@@ -20339,38 +25364,15 @@
       }
     },
     "union-value": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
-      "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
+      "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
       "dev": true,
       "requires": {
         "arr-union": "^3.1.0",
         "get-value": "^2.0.6",
         "is-extendable": "^0.1.1",
-        "set-value": "^0.4.3"
-      },
-      "dependencies": {
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "dev": true,
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
-        },
-        "set-value": {
-          "version": "0.4.3",
-          "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
-          "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
-          "dev": true,
-          "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-extendable": "^0.1.1",
-            "is-plain-object": "^2.0.1",
-            "to-object-path": "^0.3.0"
-          }
-        }
+        "set-value": "^2.0.1"
       }
     },
     "uniq": {
@@ -20395,33 +25397,33 @@
       }
     },
     "unique-slug": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.1.tgz",
-      "integrity": "sha512-n9cU6+gITaVu7VGj1Z8feKMmfAjEAQGhwD9fE3zvpRRa0wEIx8ODYkVGfSc94M2OX00tUFV8wH3zYbm1I8mxFg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
+      "integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
       "dev": true,
       "requires": {
         "imurmurhash": "^0.1.4"
       }
     },
     "unist-util-find-all-after": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/unist-util-find-all-after/-/unist-util-find-all-after-1.0.2.tgz",
-      "integrity": "sha512-nDl79mKpffXojLpCimVXnxhlH/jjaTnDuScznU9J4jjsaUtBdDbxmlc109XtcqxY4SDO0SwzngsxxW8DIISt1w==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/unist-util-find-all-after/-/unist-util-find-all-after-1.0.4.tgz",
+      "integrity": "sha512-CaxvMjTd+yF93BKLJvZnEfqdM7fgEACsIpQqz8vIj9CJnUb9VpyymFS3tg6TCtgrF7vfCJBF5jbT2Ox9CBRYRQ==",
       "dev": true,
       "requires": {
-        "unist-util-is": "^2.0.0"
+        "unist-util-is": "^3.0.0"
       }
     },
     "unist-util-is": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-2.1.2.tgz",
-      "integrity": "sha512-YkXBK/H9raAmG7KXck+UUpnKiNmUdB+aBGrknfQ4EreE1banuzrKABx3jP6Z5Z3fMSPMQQmeXBlKpCbMwBkxVw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-3.0.0.tgz",
+      "integrity": "sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A==",
       "dev": true
     },
     "unist-util-remove-position": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-1.1.2.tgz",
-      "integrity": "sha512-XxoNOBvq1WXRKXxgnSYbtCF76TJrRoe5++pD4cCBsssSiWSnPEktyFrFLE8LTk3JW5mt9hB0Sk5zn4x/JeWY7Q==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-1.1.3.tgz",
+      "integrity": "sha512-CtszTlOjP2sBGYc2zcKA/CvNdTdEs3ozbiJ63IPBxh8iZg42SCCb8m04f8z2+V1aSk5a7BxbZKEdoDjadmBkWA==",
       "dev": true,
       "requires": {
         "unist-util-visit": "^1.1.0"
@@ -20434,21 +25436,21 @@
       "dev": true
     },
     "unist-util-visit": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.0.tgz",
-      "integrity": "sha512-FiGu34ziNsZA3ZUteZxSFaczIjGmksfSgdKqBfOejrrfzyUy5b7YrlzT1Bcvi+djkYDituJDy2XB7tGTeBieKw==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
+      "integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
       "dev": true,
       "requires": {
         "unist-util-visit-parents": "^2.0.0"
       },
       "dependencies": {
         "unist-util-visit-parents": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.0.1.tgz",
-          "integrity": "sha512-6B0UTiMfdWql4cQ03gDTCSns+64Zkfo2OCbK31Ov0uMizEz+CJeAp0cgZVb5Fhmcd7Bct2iRNywejT0orpbqUA==",
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz",
+          "integrity": "sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==",
           "dev": true,
           "requires": {
-            "unist-util-is": "^2.1.2"
+            "unist-util-is": "^3.0.0"
           }
         }
       }
@@ -20460,9 +25462,9 @@
       "dev": true
     },
     "universal-user-agent": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-2.0.3.tgz",
-      "integrity": "sha512-eRHEHhChCBHrZsA4WEhdgiOKgdvgrMIHwnwnqD0r5C6AO8kwKcG7qSku3iXdhvHL3YvsS9ZkSGN8h/hIpoFC8g==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-2.1.0.tgz",
+      "integrity": "sha512-8itiX7G05Tu3mGDTdNY2fB4KJ8MgZLS54RdG6PkkfwMAavrXu1mV/lls/GABx9O3Rw4PnTtasxrvbMQoBYY92Q==",
       "dev": true,
       "requires": {
         "os-name": "^3.0.0"
@@ -20523,13 +25525,19 @@
           "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
           "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
           "dev": true
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
         }
       }
     },
     "unzipper": {
-      "version": "0.8.14",
-      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.8.14.tgz",
-      "integrity": "sha512-8rFtE7EP5ssOwGpN2dt1Q4njl0N1hUXJ7sSPz0leU2hRdq6+pra57z4YPBlVqm40vcgv6ooKZEAx48fMTv9x4w==",
+      "version": "0.9.15",
+      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.9.15.tgz",
+      "integrity": "sha512-2aaUvO4RAeHDvOCuEtth7jrHFaCKTSXPqUkXwADaLBzGbgZGzUDccoEdJ5lW+3RmfpOZYNx0Rw6F6PUzM6caIA==",
       "dev": true,
       "requires": {
         "big-integer": "^1.6.17",
@@ -20537,9 +25545,9 @@
         "bluebird": "~3.4.1",
         "buffer-indexof-polyfill": "~1.0.0",
         "duplexer2": "~0.1.4",
-        "fstream": "~1.0.10",
+        "fstream": "^1.0.12",
         "listenercount": "~1.0.1",
-        "readable-stream": "~2.1.5",
+        "readable-stream": "~2.3.6",
         "setimmediate": "~1.0.4"
       },
       "dependencies": {
@@ -20547,33 +25555,6 @@
           "version": "3.4.7",
           "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
           "integrity": "sha1-9y12C+Cbf3bQjtj66Ysomo0F+rM=",
-          "dev": true
-        },
-        "process-nextick-args": {
-          "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "2.1.5",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-          "integrity": "sha1-ZvqLcg4UOLNkaB8q0aY8YYRIydA=",
-          "dev": true,
-          "requires": {
-            "buffer-shims": "^1.0.0",
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "string_decoder": "~0.10.x",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "dev": true
         }
       }
@@ -20628,12 +25609,12 @@
       }
     },
     "url-parse-lax": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
-      "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
+      "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
       "dev": true,
       "requires": {
-        "prepend-http": "^1.0.1"
+        "prepend-http": "^2.0.0"
       }
     },
     "url-template": {
@@ -20661,6 +25642,14 @@
       "dev": true,
       "requires": {
         "inherits": "2.0.3"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "dev": true
+        }
       }
     },
     "util-deprecate": {
@@ -20697,12 +25686,6 @@
           "version": "0.9.2",
           "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
           "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
-          "dev": true
-        },
-        "deep-equal": {
-          "version": "0.2.2",
-          "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.2.tgz",
-          "integrity": "sha1-hLdFiW80xoTpjyzg5Cq69Du6AX0=",
           "dev": true
         }
       }
@@ -20765,9 +25748,9 @@
       }
     },
     "vfile-location": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-2.0.4.tgz",
-      "integrity": "sha512-KRL5uXQPoUKu+NGvQVL4XLORw45W62v4U4gxJ3vRlDfI9QsT4ZN1PNXn/zQpKUulqGDpYuT0XDfp5q9O87/y/w==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-2.0.5.tgz",
+      "integrity": "sha512-Pa1ey0OzYBkLPxPZI3d9E+S4BmvfVwNAAXrrqGbwTVXWaX2p9kM1zZ+n35UtVM06shmWKH4RPRN8KI80qE3wNQ==",
       "dev": true
     },
     "vfile-message": {
@@ -20780,18 +25763,15 @@
       }
     },
     "vm-browserify": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
-      "integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
-      "dev": true,
-      "requires": {
-        "indexof": "0.0.1"
-      }
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.0.tgz",
+      "integrity": "sha512-iq+S7vZJE60yejDYM0ek6zg308+UZsdtPExWP9VZoCFCz1zkJoXFnAX7aZfd/ZwrkidzdUZL0C/ryW+JwAiIGw==",
+      "dev": true
     },
     "vm2": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.8.1.tgz",
-      "integrity": "sha512-ecR1+KFuP7KK2hpo8ItamW0F9pq4dJOd4o+r6OWvAsx2eXGPshP6uKE24qepGshT8v+TF0jpnzugFJak42LuZQ==",
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.8.2.tgz",
+      "integrity": "sha512-FE9slf0o4YoD2Jf7VEjytHTac2SMt2J4ahf9Tw9YLLVqJm0DQiMpmN+I0+RsnOZ0kb7PyeR1rLxathXZWJ23kg==",
       "dev": true
     },
     "voca": {
@@ -20810,9 +25790,9 @@
       }
     },
     "warning": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
-      "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
       "dev": true,
       "requires": {
         "loose-envify": "^1.0.0"
@@ -20892,16 +25872,103 @@
         "yargs": "^8.0.2"
       },
       "dependencies": {
+        "acorn": {
+          "version": "5.7.3",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
+          "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+          "dev": true
+        },
+        "cliui": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+          "dev": true,
+          "requires": {
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wrap-ansi": "^2.0.0"
+          },
+          "dependencies": {
+            "string-width": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+              "dev": true,
+              "requires": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+              }
+            }
+          }
+        },
         "has-flag": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
           "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
           "dev": true
         },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "load-json-file": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+          "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "strip-bom": "^3.0.0"
+          }
+        },
+        "path-type": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+          "dev": true,
+          "requires": {
+            "pify": "^2.0.0"
+          }
+        },
+        "read-pkg": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+          "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "^2.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^2.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+          "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+          "dev": true,
+          "requires": {
+            "find-up": "^2.0.0",
+            "read-pkg": "^2.0.0"
+          }
+        },
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
           "dev": true
         },
         "supports-color": {
@@ -20913,15 +25980,40 @@
             "has-flag": "^2.0.0"
           }
         },
-        "uglifyjs-webpack-plugin": {
-          "version": "0.4.6",
-          "resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-0.4.6.tgz",
-          "integrity": "sha1-uVH0q7a9YX5m9j64kUmOORdj4wk=",
+        "y18n": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+          "dev": true
+        },
+        "yargs": {
+          "version": "8.0.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
+          "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
           "dev": true,
           "requires": {
-            "source-map": "^0.5.6",
-            "uglify-js": "^2.8.29",
-            "webpack-sources": "^1.0.1"
+            "camelcase": "^4.1.0",
+            "cliui": "^3.2.0",
+            "decamelize": "^1.1.1",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^2.0.0",
+            "read-pkg-up": "^2.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^7.0.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
+          "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
+          "dev": true,
+          "requires": {
+            "camelcase": "^4.1.0"
           }
         }
       }
@@ -20937,14 +26029,6 @@
         "path-is-absolute": "^1.0.0",
         "range-parser": "^1.0.3",
         "time-stamp": "^2.0.0"
-      },
-      "dependencies": {
-        "mime": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-          "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-          "dev": true
-        }
       }
     },
     "webpack-dev-server": {
@@ -21022,16 +26106,6 @@
             "rimraf": "^2.2.8"
           }
         },
-        "find-up": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-          "dev": true,
-          "requires": {
-            "path-exists": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
-          }
-        },
         "globby": {
           "version": "6.1.0",
           "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
@@ -21051,6 +26125,15 @@
               "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
               "dev": true
             }
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
           }
         },
         "is-path-cwd": {
@@ -21077,31 +26160,10 @@
             "path-is-inside": "^1.0.1"
           }
         },
-        "load-json-file": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^2.2.0",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0",
-            "strip-bom": "^2.0.0"
-          },
-          "dependencies": {
-            "pify": {
-              "version": "2.3.0",
-              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-              "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-              "dev": true
-            }
-          }
-        },
         "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         },
         "os-locale": {
@@ -21119,83 +26181,33 @@
           "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
           "dev": true
         },
-        "parse-json": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-          "dev": true,
-          "requires": {
-            "error-ex": "^1.2.0"
-          }
-        },
-        "path-exists": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-          "dev": true,
-          "requires": {
-            "pinkie-promise": "^2.0.0"
-          }
-        },
-        "path-type": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
-          },
-          "dependencies": {
-            "pify": {
-              "version": "2.3.0",
-              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-              "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-              "dev": true
-            }
-          }
-        },
         "pify": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
           "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
           "dev": true
         },
-        "read-pkg": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
-            "load-json-file": "^1.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^1.0.0"
-          }
-        },
-        "read-pkg-up": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-          "dev": true,
-          "requires": {
-            "find-up": "^1.0.0",
-            "read-pkg": "^1.0.0"
-          }
-        },
-        "strip-bom": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-          "dev": true,
-          "requires": {
-            "is-utf8": "^0.2.0"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         },
         "which-module": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
           "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
+          "dev": true
+        },
+        "y18n": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
           "dev": true
         },
         "yargs": {
@@ -21241,12 +26253,13 @@
       }
     },
     "websocket-driver": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.0.tgz",
-      "integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.3.tgz",
+      "integrity": "sha512-bpxWlvbbB459Mlipc5GBzzZwhoZgGEZLuqPaR0INBGnPAY1vdBX6hPnoFXiw+3yWxDuHyQjO2oXTMyS8A5haFg==",
       "dev": true,
       "requires": {
-        "http-parser-js": ">=0.4.0",
+        "http-parser-js": ">=0.4.0 <0.4.11",
+        "safe-buffer": ">=5.1.0",
         "websocket-extensions": ">=0.1.1"
       }
     },
@@ -21268,8 +26281,7 @@
     "whatwg-fetch": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
-      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==",
-      "dev": true
+      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
     },
     "whatwg-url": {
       "version": "4.8.0",
@@ -21314,9 +26326,9 @@
       }
     },
     "window-size": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-      "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
+      "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY=",
       "dev": true
     },
     "windows-release": {
@@ -21326,61 +26338,6 @@
       "dev": true,
       "requires": {
         "execa": "^1.0.0"
-      },
-      "dependencies": {
-        "cross-spawn": {
-          "version": "6.0.5",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-          "dev": true,
-          "requires": {
-            "nice-try": "^1.0.4",
-            "path-key": "^2.0.1",
-            "semver": "^5.5.0",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
-          }
-        },
-        "execa": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
-          "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
-          "dev": true,
-          "requires": {
-            "cross-spawn": "^6.0.0",
-            "get-stream": "^4.0.0",
-            "is-stream": "^1.1.0",
-            "npm-run-path": "^2.0.0",
-            "p-finally": "^1.0.0",
-            "signal-exit": "^3.0.0",
-            "strip-eof": "^1.0.0"
-          }
-        },
-        "get-stream": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
-          "dev": true,
-          "requires": {
-            "pump": "^3.0.0"
-          }
-        },
-        "pump": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-          "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-          "dev": true,
-          "requires": {
-            "end-of-stream": "^1.1.0",
-            "once": "^1.3.1"
-          }
-        },
-        "semver": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
-          "dev": true
-        }
       }
     },
     "winston": {
@@ -21419,9 +26376,9 @@
       }
     },
     "wordwrap": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-      "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
       "dev": true
     },
     "worker-farm": {
@@ -21441,6 +26398,28 @@
       "requires": {
         "string-width": "^1.0.1",
         "strip-ansi": "^3.0.1"
+      },
+      "dependencies": {
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        }
       }
     },
     "wrapper-webpack-plugin": {
@@ -21468,9 +26447,9 @@
       }
     },
     "write-file-atomic": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.1.tgz",
-      "integrity": "sha512-TGHFeZEZMnv+gBFRfjAcxL5bPHrsGKtnb4qsFAws7/vlh+QfwAaySIw4AXP9ZskTTh5GWu3FLuJhsWVdiJPGvg==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
+      "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.11",
@@ -21497,15 +26476,15 @@
       "dev": true
     },
     "xtend": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
       "dev": true
     },
     "y18n": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
       "dev": true
     },
     "yallist": {
@@ -21515,106 +26494,40 @@
       "dev": true
     },
     "yargs": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
-      "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
+      "integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
       "dev": true,
       "requires": {
-        "camelcase": "^4.1.0",
-        "cliui": "^3.2.0",
+        "cliui": "^4.0.0",
         "decamelize": "^1.1.1",
+        "find-up": "^2.1.0",
         "get-caller-file": "^1.0.1",
         "os-locale": "^2.0.0",
-        "read-pkg-up": "^2.0.0",
         "require-directory": "^2.1.1",
         "require-main-filename": "^1.0.1",
         "set-blocking": "^2.0.0",
         "string-width": "^2.0.0",
         "which-module": "^2.0.0",
         "y18n": "^3.2.1",
-        "yargs-parser": "^7.0.0"
+        "yargs-parser": "^9.0.2"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+        "y18n": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
           "dev": true
-        },
-        "camelcase": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-          "dev": true
-        },
-        "cliui": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-          "dev": true,
-          "requires": {
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wrap-ansi": "^2.0.0"
-          },
-          "dependencies": {
-            "string-width": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-              "dev": true,
-              "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
-              }
-            }
-          }
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
-          },
-          "dependencies": {
-            "is-fullwidth-code-point": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-              "dev": true
-            },
-            "strip-ansi": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-              "dev": true,
-              "requires": {
-                "ansi-regex": "^3.0.0"
-              }
-            }
-          }
         }
       }
     },
     "yargs-parser": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
-      "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
+      "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
       "dev": true,
       "requires": {
         "camelcase": "^4.1.0"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-          "dev": true
-        }
       }
     },
     "zip-it-loader": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,31 +5,31 @@
   "requires": true,
   "dependencies": {
     "@babel/code-frame": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
-      "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
+      "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
       "dev": true,
       "requires": {
         "@babel/highlight": "^7.0.0"
       }
     },
     "@babel/core": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.5.5.tgz",
-      "integrity": "sha512-i4qoSr2KTtce0DmkuuQBV4AuQgGPUcPXMr9L5MyYAtk06z068lQ10a4O009fe5OB/DfNV+h+qqT7ddNV8UnRjg==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.4.4.tgz",
+      "integrity": "sha512-lQgGX3FPRgbz2SKmhMtYgJvVzGZrmjaF4apZ2bLwofAKiSjxU0drPh4S/VasyYXwaTs+A1gvQ45BN8SQJzHsQQ==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.5.5",
-        "@babel/generator": "^7.5.5",
-        "@babel/helpers": "^7.5.5",
-        "@babel/parser": "^7.5.5",
+        "@babel/code-frame": "^7.0.0",
+        "@babel/generator": "^7.4.4",
+        "@babel/helpers": "^7.4.4",
+        "@babel/parser": "^7.4.4",
         "@babel/template": "^7.4.4",
-        "@babel/traverse": "^7.5.5",
-        "@babel/types": "^7.5.5",
+        "@babel/traverse": "^7.4.4",
+        "@babel/types": "^7.4.4",
         "convert-source-map": "^1.1.0",
         "debug": "^4.1.0",
         "json5": "^2.1.0",
-        "lodash": "^4.17.13",
+        "lodash": "^4.17.11",
         "resolve": "^1.3.2",
         "semver": "^5.4.1",
         "source-map": "^0.5.0"
@@ -60,9 +60,9 @@
           "dev": true
         },
         "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
           "dev": true
         },
         "semver": {
@@ -80,14 +80,14 @@
       }
     },
     "@babel/generator": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.5.5.tgz",
-      "integrity": "sha512-ETI/4vyTSxTzGnU2c49XHv2zhExkv9JHLTwDAFz85kmcwuShvYG2H08FwgIguQf4JC75CBnXAUM5PqeF4fj0nQ==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.4.tgz",
+      "integrity": "sha512-53UOLK6TVNqKxf7RUh8NE851EHRxOOeVXKbK2bivdb+iziMyk03Sr4eaE9OELCbyZAAafAKPDwF2TPUES5QbxQ==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.5.5",
+        "@babel/types": "^7.4.4",
         "jsesc": "^2.5.1",
-        "lodash": "^4.17.13",
+        "lodash": "^4.17.11",
         "source-map": "^0.5.0",
         "trim-right": "^1.0.1"
       },
@@ -152,39 +152,31 @@
       }
     },
     "@babel/helpers": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.5.5.tgz",
-      "integrity": "sha512-nRq2BUhxZFnfEn/ciJuhklHvFOqjJUD5wpx+1bxUF2axL9C+v4DE/dmp5sT2dKnpOs4orZWzpAZqlCy8QqE/7g==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.4.4.tgz",
+      "integrity": "sha512-igczbR/0SeuPR8RFfC7tGrbdTbFL3QTvH6D+Z6zNxnTe//GyqmtHmDkzrqDmyZ3eSwPqB/LhyKoU5DXsp+Vp2A==",
       "dev": true,
       "requires": {
         "@babel/template": "^7.4.4",
-        "@babel/traverse": "^7.5.5",
-        "@babel/types": "^7.5.5"
+        "@babel/traverse": "^7.4.4",
+        "@babel/types": "^7.4.4"
       }
     },
     "@babel/highlight": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.5.0.tgz",
-      "integrity": "sha512-7dV4eu9gBxoM0dAnj/BCFDW9LFU0zvTrkq0ugM7pnHEgguOEeOz1so2ZghEdzviYzQEED0r4EAgpsBChKy1TRQ==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
+      "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
       "dev": true,
       "requires": {
         "chalk": "^2.0.0",
         "esutils": "^2.0.2",
         "js-tokens": "^4.0.0"
-      },
-      "dependencies": {
-        "js-tokens": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-          "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-          "dev": true
-        }
       }
     },
     "@babel/parser": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.5.5.tgz",
-      "integrity": "sha512-E5BN68cqR7dhKan1SfqgPGhQ178bkVKpXTPEXnFJBrEt8/DKRZlybmy+IgYLTeN7tp1R5Ccmbm2rBk17sHYU3g==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.4.tgz",
+      "integrity": "sha512-5pCS4mOsL+ANsFZGdvNLybx4wtqAZJ0MJjMHxvzI3bvIsz6sQvzW8XX92EYIkiPtIvcfG3Aj+Ir5VNyjnZhP7w==",
       "dev": true
     },
     "@babel/plugin-syntax-jsx": {
@@ -227,37 +219,13 @@
       }
     },
     "@babel/plugin-transform-react-jsx-source": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.5.0.tgz",
-      "integrity": "sha512-58Q+Jsy4IDCZx7kqEZuSDdam/1oW8OdDX8f+Loo6xyxdfg1yF0GE2XNJQSTZCaMol93+FBzpWiPEwtbMloAcPg==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.2.0.tgz",
+      "integrity": "sha512-A32OkKTp4i5U6aE88GwwcuV4HAprUgHcTq0sSafLxjr6AW0QahrCRCjxogkbbcdtpbXkuTOlgpjophCxb6sh5g==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/plugin-syntax-jsx": "^7.2.0"
-      }
-    },
-    "@babel/polyfill": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.4.4.tgz",
-      "integrity": "sha512-WlthFLfhQQhh+A2Gn5NSFl0Huxz36x86Jn+E9OW7ibK8edKPq+KLy4apM1yDpQ8kJOVi1OVjpP4vSDLdrI04dg==",
-      "dev": true,
-      "requires": {
-        "core-js": "^2.6.5",
-        "regenerator-runtime": "^0.13.2"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
-          "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==",
-          "dev": true
-        },
-        "regenerator-runtime": {
-          "version": "0.13.3",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
-          "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
-          "dev": true
-        }
       }
     },
     "@babel/preset-react": {
@@ -274,18 +242,18 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.5.tgz",
-      "integrity": "sha512-28QvEGyQyNkB0/m2B4FU7IEZGK2NUrcMtT6BZEFALTguLk+AUT6ofsHtPk5QyjAdUkpMJ+/Em+quwz4HOt30AQ==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.4.tgz",
+      "integrity": "sha512-w0+uT71b6Yi7i5SE0co4NioIpSYS6lLiXvCzWzGSKvpK5vdQtCbICHMj+gbAKAOtxiV6HsVh/MBdaF9EQ6faSg==",
       "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.2"
       },
       "dependencies": {
         "regenerator-runtime": {
-          "version": "0.13.3",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
-          "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
+          "version": "0.13.2",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
+          "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA==",
           "dev": true
         }
       }
@@ -302,20 +270,20 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.5.5.tgz",
-      "integrity": "sha512-MqB0782whsfffYfSjH4TM+LMjrJnhCNEDMDIjeTpl+ASaUvxcjoiVCo/sM1GhS1pHOXYfWVCYneLjMckuUxDaQ==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.4.tgz",
+      "integrity": "sha512-Gw6qqkw/e6AGzlyj9KnkabJX7VcubqPtkUQVAwkc0wUMldr3A/hezNB3Rc5eIvId95iSGkGIOe5hh1kMKf951A==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.5.5",
-        "@babel/generator": "^7.5.5",
+        "@babel/code-frame": "^7.0.0",
+        "@babel/generator": "^7.4.4",
         "@babel/helper-function-name": "^7.1.0",
         "@babel/helper-split-export-declaration": "^7.4.4",
-        "@babel/parser": "^7.5.5",
-        "@babel/types": "^7.5.5",
+        "@babel/parser": "^7.4.4",
+        "@babel/types": "^7.4.4",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
-        "lodash": "^4.17.13"
+        "lodash": "^4.17.11"
       },
       "dependencies": {
         "debug": {
@@ -334,21 +302,21 @@
           "dev": true
         },
         "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
           "dev": true
         }
       }
     },
     "@babel/types": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.5.5.tgz",
-      "integrity": "sha512-s63F9nJioLqOlW3UkyMd+BYhXt44YuaFm/VV0VwuteqjYwRrObkU7ra9pY4wAJR3oXi8hJrMcrcJdO/HH33vtw==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
+      "integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
       "dev": true,
       "requires": {
         "esutils": "^2.0.2",
-        "lodash": "^4.17.13",
+        "lodash": "^4.17.11",
         "to-fast-properties": "^2.0.0"
       },
       "dependencies": {
@@ -423,15 +391,15 @@
           }
         },
         "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
           "dev": true
         },
         "node-fetch": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-          "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.5.0.tgz",
+          "integrity": "sha512-YuZKluhWGJwCcUu4RlZstdAxr8bFfOVHakc1mplwHkk8J+tqM1Y5yraYvIUpeX8aY7+crCwiELJq7Vl0o0LWXw==",
           "dev": true
         }
       }
@@ -444,12 +412,6 @@
       "requires": {
         "any-observable": "^0.3.0"
       }
-    },
-    "@sindresorhus/is": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
-      "integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==",
-      "dev": true
     },
     "@skyscanner/popper.js": {
       "version": "1.12.9-beta.1",
@@ -481,9 +443,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.6.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.6.8.tgz",
-      "integrity": "sha512-aX+gFgA5GHcDi89KG5keey2zf0WfZk/HAQotEamsK2kbey+8yGKcson0hbK8E+v0NArlCJQCqMP161YhV6ZXLg==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.0.tgz",
+      "integrity": "sha512-Jrb/x3HT4PTJp6a4avhmJCDEVrPdqLfl3e8GGMbpkGGdwAV5UGlIs4vVEfsHHfylZVOKZWpOqmqFH8CbfOZ6kg==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -574,9 +536,9 @@
       }
     },
     "acorn": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.2.1.tgz",
-      "integrity": "sha512-JD0xT5FCRDNyjDda3Lrg/IxFscp9q4tiYtxE1/nOzlKCk7hIRuYjhq1kCNkbPjMRMZuFq20HNQn1I9k8Oj0E+Q==",
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
+      "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
       "dev": true
     },
     "acorn-dynamic-import": {
@@ -620,9 +582,9 @@
       "dev": true
     },
     "agent-base": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
-      "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
+      "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
       "dev": true,
       "requires": {
         "es6-promisify": "^5.0.0"
@@ -647,9 +609,9 @@
       }
     },
     "ajv": {
-      "version": "6.10.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
-      "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
+      "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
       "dev": true,
       "requires": {
         "fast-deep-equal": "^2.0.1",
@@ -665,9 +627,9 @@
       "dev": true
     },
     "ajv-keywords": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.1.tgz",
-      "integrity": "sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.0.tgz",
+      "integrity": "sha512-aUjdRFISbuFOl0EIZc+9e4FfZp0bDZgAdOOf30bJmw8VM9v84SHyVyxDfbWxpGYbdZD/9XoKxfHVNmxPkhwyGw==",
       "dev": true
     },
     "align-text": {
@@ -730,309 +692,13 @@
         "normalize-path": "^2.1.1"
       },
       "dependencies": {
-        "arr-diff": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
-          "dev": true
-        },
-        "array-unique": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-          "dev": true
-        },
-        "braces": {
-          "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-          "dev": true,
-          "requires": {
-            "arr-flatten": "^1.1.0",
-            "array-unique": "^0.3.2",
-            "extend-shallow": "^2.0.1",
-            "fill-range": "^4.0.0",
-            "isobject": "^3.0.1",
-            "repeat-element": "^1.1.2",
-            "snapdragon": "^0.8.1",
-            "snapdragon-node": "^2.0.1",
-            "split-string": "^3.0.2",
-            "to-regex": "^3.0.1"
-          },
-          "dependencies": {
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            }
-          }
-        },
-        "expand-brackets": {
-          "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
-          "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
-          "dev": true,
-          "requires": {
-            "debug": "^2.3.3",
-            "define-property": "^0.2.5",
-            "extend-shallow": "^2.0.1",
-            "posix-character-classes": "^0.1.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
-          },
-          "dependencies": {
-            "define-property": {
-              "version": "0.2.5",
-              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-              "dev": true,
-              "requires": {
-                "is-descriptor": "^0.1.0"
-              }
-            },
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            },
-            "is-accessor-descriptor": {
-              "version": "0.1.6",
-              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-              "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-              "dev": true,
-              "requires": {
-                "kind-of": "^3.0.2"
-              },
-              "dependencies": {
-                "kind-of": {
-                  "version": "3.2.2",
-                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                  "dev": true,
-                  "requires": {
-                    "is-buffer": "^1.1.5"
-                  }
-                }
-              }
-            },
-            "is-data-descriptor": {
-              "version": "0.1.4",
-              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-              "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-              "dev": true,
-              "requires": {
-                "kind-of": "^3.0.2"
-              },
-              "dependencies": {
-                "kind-of": {
-                  "version": "3.2.2",
-                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                  "dev": true,
-                  "requires": {
-                    "is-buffer": "^1.1.5"
-                  }
-                }
-              }
-            },
-            "is-descriptor": {
-              "version": "0.1.6",
-              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-              "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-              "dev": true,
-              "requires": {
-                "is-accessor-descriptor": "^0.1.6",
-                "is-data-descriptor": "^0.1.4",
-                "kind-of": "^5.0.0"
-              }
-            },
-            "kind-of": {
-              "version": "5.1.0",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-              "dev": true
-            }
-          }
-        },
-        "extend-shallow": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
-          "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
-          "dev": true,
-          "requires": {
-            "assign-symbols": "^1.0.0",
-            "is-extendable": "^1.0.1"
-          },
-          "dependencies": {
-            "is-extendable": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-              "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-              "dev": true,
-              "requires": {
-                "is-plain-object": "^2.0.4"
-              }
-            }
-          }
-        },
-        "extglob": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
-          "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
-          "dev": true,
-          "requires": {
-            "array-unique": "^0.3.2",
-            "define-property": "^1.0.0",
-            "expand-brackets": "^2.1.4",
-            "extend-shallow": "^2.0.1",
-            "fragment-cache": "^0.2.1",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
-          },
-          "dependencies": {
-            "define-property": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-              "dev": true,
-              "requires": {
-                "is-descriptor": "^1.0.0"
-              }
-            },
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            }
-          }
-        },
-        "fill-range": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-          "dev": true,
-          "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1",
-            "to-regex-range": "^2.1.0"
-          },
-          "dependencies": {
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            }
-          }
-        },
-        "is-accessor-descriptor": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-          "dev": true,
-          "requires": {
-            "kind-of": "^6.0.0"
-          }
-        },
-        "is-data-descriptor": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-          "dev": true,
-          "requires": {
-            "kind-of": "^6.0.0"
-          }
-        },
-        "is-descriptor": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-          "dev": true,
-          "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
-          }
-        },
-        "is-number": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "dev": true,
-          "requires": {
-            "kind-of": "^3.0.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "^1.1.5"
-              }
-            }
-          }
-        },
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
-        },
-        "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-          "dev": true
-        },
-        "micromatch": {
-          "version": "3.1.10",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-          "dev": true,
-          "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "braces": "^2.3.1",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "extglob": "^2.0.4",
-            "fragment-cache": "^0.2.1",
-            "kind-of": "^6.0.2",
-            "nanomatch": "^1.2.9",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.2"
-          }
-        },
-        "to-regex-range": {
+        "normalize-path": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
-          "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+          "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
           "dev": true,
           "requires": {
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1"
+            "remove-trailing-separator": "^1.0.1"
           }
         }
       }
@@ -1082,13 +748,10 @@
       }
     },
     "arr-diff": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-      "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-      "dev": true,
-      "requires": {
-        "arr-flatten": "^1.0.1"
-      }
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+      "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+      "dev": true
     },
     "arr-flatten": {
       "version": "1.1.0",
@@ -1114,12 +777,6 @@
       "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
       "dev": true
     },
-    "array-filter": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-1.0.0.tgz",
-      "integrity": "sha1-uveeYubvTCpMC4MSMtr/7CUfnYM=",
-      "dev": true
-    },
     "array-find-index": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
@@ -1127,9 +784,9 @@
       "dev": true
     },
     "array-flatten": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.2.tgz",
-      "integrity": "sha512-hNfzcOV8W4NdualtqBFPyVO+54DSJuZGY9qT4pRroB6S9e3iiido2ISIC5h9R2sPJ8H3FHCIiEnsv1lPXO3KtQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
       "dev": true
     },
     "array-includes": {
@@ -1158,19 +815,19 @@
       "dev": true
     },
     "array-unique": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-      "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+      "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
       "dev": true
     },
     "array.prototype.find": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.1.0.tgz",
-      "integrity": "sha512-Wn41+K1yuO5p7wRZDl7890c3xvv5UBrfVXTVIe28rSQb6LS0fZMDrQB6PAcxQFRFy6vJTLDc3A2+3CjQdzVKRg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.0.4.tgz",
+      "integrity": "sha1-VWpcU2LAhkgyPdrrnenRS8GGTJA=",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.13.0"
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.7.0"
       }
     },
     "array.prototype.flat": {
@@ -1217,12 +874,11 @@
       }
     },
     "assert": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/assert/-/assert-1.5.0.tgz",
-      "integrity": "sha512-EDsgawzwoun2CZkCgtxJbv392v4nbk9XDD06zI+kQYoBM/3RBWLlEyJARDOmhAAosBjWACEkKL6S+lIZtcAubA==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
+      "integrity": "sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=",
       "dev": true,
       "requires": {
-        "object-assign": "^4.1.1",
         "util": "0.10.3"
       },
       "dependencies": {
@@ -1268,12 +924,12 @@
       "dev": true
     },
     "async": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
+      "integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.14"
+        "lodash": "^4.17.11"
       }
     },
     "async-each": {
@@ -1301,18 +957,50 @@
       "dev": true
     },
     "autoprefixer": {
-      "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.6.1.tgz",
-      "integrity": "sha512-aVo5WxR3VyvyJxcJC3h4FKfwCQvQWb1tSI5VHNibddCVWrcD1NvlxEweg3TSgiPztMnWfjpy2FURKA2kvDE+Tw==",
+      "version": "9.5.1",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.5.1.tgz",
+      "integrity": "sha512-KJSzkStUl3wP0D5sdMlP82Q52JLy5+atf2MHAre48+ckWkXgixmfHyWmA77wFDy6jTHU6mIgXv6hAQ2mf1PjJQ==",
       "dev": true,
       "requires": {
-        "browserslist": "^4.6.3",
-        "caniuse-lite": "^1.0.30000980",
-        "chalk": "^2.4.2",
+        "browserslist": "^4.5.4",
+        "caniuse-lite": "^1.0.30000957",
         "normalize-range": "^0.1.2",
         "num2fraction": "^1.2.2",
-        "postcss": "^7.0.17",
-        "postcss-value-parser": "^4.0.0"
+        "postcss": "^7.0.14",
+        "postcss-value-parser": "^3.3.1"
+      },
+      "dependencies": {
+        "browserslist": {
+          "version": "4.5.6",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.5.6.tgz",
+          "integrity": "sha512-o/hPOtbU9oX507lIqon+UvPYqpx3mHc8cV3QemSBTXwkG8gSQSK6UKvXcE/DcleU3+A59XTUHyCvZ5qGy8xVAg==",
+          "dev": true,
+          "requires": {
+            "caniuse-lite": "^1.0.30000963",
+            "electron-to-chromium": "^1.3.127",
+            "node-releases": "^1.1.17"
+          }
+        },
+        "postcss": {
+          "version": "7.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.4.2",
+            "source-map": "^0.6.1",
+            "supports-color": "^6.1.0"
+          }
+        },
+        "supports-color": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
       }
     },
     "aws-sign2": {
@@ -1366,6 +1054,12 @@
             "supports-color": "^2.0.0"
           }
         },
+        "js-tokens": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+          "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+          "dev": true
+        },
         "supports-color": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
@@ -1410,9 +1104,9 @@
       }
     },
     "babel-eslint": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.0.2.tgz",
-      "integrity": "sha512-UdsurWPtgiPgpJ06ryUnuaSXC2s0WoSZnQmEpbAH65XZSdwowgN5MvyP7e88nW07FYXv72erVtpBkxyDVKhH1Q==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.0.1.tgz",
+      "integrity": "sha512-z7OT1iNV+TjOwHNLLyJk+HN+YVWX+CLE6fPD2SymJZOZQBs+QIexFjhm4keGTm8MW9xr4EC9Q0PbaLB24V5GoQ==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -1451,6 +1145,12 @@
         "trim-right": "^1.0.1"
       },
       "dependencies": {
+        "jsesc": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+          "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
+          "dev": true
+        },
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -1967,6 +1667,19 @@
         "babel-helper-regex": "^6.24.1",
         "babel-runtime": "^6.22.0",
         "regexpu-core": "^2.0.0"
+      },
+      "dependencies": {
+        "regexpu-core": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
+          "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
+          "dev": true,
+          "requires": {
+            "regenerate": "^1.2.1",
+            "regjsgen": "^0.2.0",
+            "regjsparser": "^0.1.4"
+          }
+        }
       }
     },
     "babel-plugin-transform-exponentiation-operator": {
@@ -2071,9 +1784,9 @@
       },
       "dependencies": {
         "core-js": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
-          "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==",
+          "version": "2.6.5",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
+          "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==",
           "dev": true
         },
         "regenerator-runtime": {
@@ -2189,9 +1902,9 @@
       },
       "dependencies": {
         "core-js": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
-          "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==",
+          "version": "2.6.5",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
+          "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==",
           "dev": true
         }
       }
@@ -2207,9 +1920,9 @@
       },
       "dependencies": {
         "core-js": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
-          "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==",
+          "version": "2.6.5",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
+          "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==",
           "dev": true
         }
       }
@@ -2263,15 +1976,15 @@
       "dev": true
     },
     "bail": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.4.tgz",
-      "integrity": "sha512-S8vuDB4w6YpRhICUDET3guPlQpaJl7od94tpZ0Fvnyp+MKW/HyDTcRDck+29C9g+d/qQHnddRH3+94kZdrW0Ww==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.3.tgz",
+      "integrity": "sha512-1X8CnjFVQ+a+KW36uBNMTU5s8+v5FzeqrP7hTG5aTb4aPreSbZJlhwPon9VKMuEVgV++JM+SQrALY3kr7eswdg==",
       "dev": true
     },
     "balanced-match": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+      "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
       "dev": true
     },
     "base": {
@@ -2327,12 +2040,6 @@
             "kind-of": "^6.0.2"
           }
         },
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
-        },
         "kind-of": {
           "version": "6.0.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
@@ -2369,9 +2076,9 @@
       "dev": true
     },
     "big-integer": {
-      "version": "1.6.44",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.44.tgz",
-      "integrity": "sha512-7MzElZPTyJ2fNvBkPxtFQ2fWIkVmuzw41+BZHSzpEq3ymB2MfeKp1+yXl/tS75xCx+WnyV+yb0kp+K1C3UNwmQ==",
+      "version": "1.6.43",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.43.tgz",
+      "integrity": "sha512-9dULc9jsKmXl0Aeunug8wbF+58n+hQoFjqClN7WeZwGLh0XJUWyJJ9Ee+Ep+Ql/J9fRsTVaeThp8MhiCCrY0Jg==",
       "dev": true
     },
     "big.js": {
@@ -2406,9 +2113,9 @@
       }
     },
     "bluebird": {
-      "version": "3.5.5",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
-      "integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==",
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.4.tgz",
+      "integrity": "sha512-FG+nFEZChJrbQ9tIccIfZJBz3J7mLrAhxakAbnrJWn8d7aKOC+LWifa0G+p4ZqKp4y13T7juYvdhq9NzKdsrjw==",
       "dev": true
     },
     "bn.js": {
@@ -2418,33 +2125,36 @@
       "dev": true
     },
     "body-parser": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
-      "integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==",
+      "version": "1.18.3",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.3.tgz",
+      "integrity": "sha1-WykhmP/dVTs6DyDe0FkrlWlVyLQ=",
       "dev": true,
       "requires": {
-        "bytes": "3.1.0",
+        "bytes": "3.0.0",
         "content-type": "~1.0.4",
         "debug": "2.6.9",
         "depd": "~1.1.2",
-        "http-errors": "1.7.2",
-        "iconv-lite": "0.4.24",
+        "http-errors": "~1.6.3",
+        "iconv-lite": "0.4.23",
         "on-finished": "~2.3.0",
-        "qs": "6.7.0",
-        "raw-body": "2.4.0",
-        "type-is": "~1.6.17"
+        "qs": "6.5.2",
+        "raw-body": "2.3.3",
+        "type-is": "~1.6.16"
       },
       "dependencies": {
-        "bytes": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
-          "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
-          "dev": true
+        "iconv-lite": {
+          "version": "0.4.23",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
+          "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+          "dev": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
         },
         "qs": {
-          "version": "6.7.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
-          "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
           "dev": true
         }
       }
@@ -2463,10 +2173,10 @@
         "multicast-dns-service-types": "^1.1.0"
       },
       "dependencies": {
-        "deep-equal": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
-          "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
+        "array-flatten": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.2.tgz",
+          "integrity": "sha512-hNfzcOV8W4NdualtqBFPyVO+54DSJuZGY9qT4pRroB6S9e3iiido2ISIC5h9R2sPJ8H3FHCIiEnsv1lPXO3KtQ==",
           "dev": true
         }
       }
@@ -2496,56 +2206,47 @@
       },
       "dependencies": {
         "bpk-animate-height": {
-          "version": "1.1.113",
-          "bundled": true,
+          "version": "1.1.112",
+          "resolved": "https://registry.npmjs.org/bpk-animate-height/-/bpk-animate-height-1.1.112.tgz",
+          "integrity": "sha512-xX5wT7YKYgFbwRlOZVQXhqNKm7d1tlnp8Pk5sCf1CKVzgZO+be9W7GgZ9HF6wTUoWuMIAt/31f3fP80mDwlvFg==",
           "dev": true,
           "requires": {
             "prop-types": "^15.6.2"
           }
         },
         "bpk-component-icon": {
-          "version": "3.31.5",
-          "bundled": true,
+          "version": "3.31.4",
+          "resolved": "https://registry.npmjs.org/bpk-component-icon/-/bpk-component-icon-3.31.4.tgz",
+          "integrity": "sha512-DAiwhBYyyFmy2jonUFxEtxLpj2RlN17EDgd1zwZGpjfIhryyA+vL4XlSr8EkfPjZ6z+I6NWwbfmEUqDZgrn7Ag==",
           "dev": true,
           "requires": {
-            "bpk-mixins": "^17.24.5",
+            "bpk-mixins": "^17.24.4",
             "bpk-react-utils": "^2.7.9",
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5",
+            "bpk-svgs": "^6.9.2",
+            "bpk-tokens": "^27.6.4",
             "prop-types": "^15.6.2"
           }
         },
         "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
+          "version": "17.24.4",
+          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
+          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
+            "bpk-svgs": "^6.9.2",
+            "bpk-tokens": "^27.6.4"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
+          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
             "prop-types": "^15.6.2",
             "react-transition-group": "^2.5.3",
             "recompose": "^0.30.0"
-          }
-        },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
           }
         }
       }
@@ -2561,60 +2262,38 @@
         "react-autosuggest": "^9.4.2"
       },
       "dependencies": {
-        "bpk-component-icon": {
-          "version": "3.31.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.5",
-            "bpk-react-utils": "^2.7.9",
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5",
-            "prop-types": "^15.6.2"
-          }
-        },
         "bpk-component-input": {
-          "version": "4.1.27",
-          "bundled": true,
+          "version": "4.1.26",
+          "resolved": "https://registry.npmjs.org/bpk-component-input/-/bpk-component-input-4.1.26.tgz",
+          "integrity": "sha512-+5P8u4+tmf+pABR9fhqDvMcVDaThFZgiEk9yPOcv0m9rgPZMzWXxOcEpN7Wzr2fdW6P/kCAtFA0jwUKtuzEyWQ==",
           "dev": true,
           "requires": {
-            "bpk-component-icon": "^3.31.5",
-            "bpk-mixins": "^17.24.5",
+            "bpk-component-icon": "^3.31.4",
+            "bpk-mixins": "^17.24.4",
             "bpk-react-utils": "^2.7.9",
             "prop-types": "^15.6.2"
           }
         },
         "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
+          "version": "17.24.4",
+          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
+          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
+            "bpk-svgs": "^6.9.2",
+            "bpk-tokens": "^27.6.4"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
+          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
             "prop-types": "^15.6.2",
             "react-transition-group": "^2.5.3",
             "recompose": "^0.30.0"
-          }
-        },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
           }
         }
       }
@@ -2629,36 +2308,25 @@
       },
       "dependencies": {
         "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
+          "version": "17.24.4",
+          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
+          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
+            "bpk-svgs": "^6.9.2",
+            "bpk-tokens": "^27.6.4"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
+          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
             "prop-types": "^15.6.2",
             "react-transition-group": "^2.5.3",
             "recompose": "^0.30.0"
-          }
-        },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
           }
         }
       }
@@ -2678,48 +2346,53 @@
       },
       "dependencies": {
         "bpk-animate-height": {
-          "version": "1.1.113",
-          "bundled": true,
+          "version": "1.1.112",
+          "resolved": "https://registry.npmjs.org/bpk-animate-height/-/bpk-animate-height-1.1.112.tgz",
+          "integrity": "sha512-xX5wT7YKYgFbwRlOZVQXhqNKm7d1tlnp8Pk5sCf1CKVzgZO+be9W7GgZ9HF6wTUoWuMIAt/31f3fP80mDwlvFg==",
           "dev": true,
           "requires": {
             "prop-types": "^15.6.2"
           }
         },
         "bpk-component-close-button": {
-          "version": "1.0.142",
-          "bundled": true,
+          "version": "1.0.141",
+          "resolved": "https://registry.npmjs.org/bpk-component-close-button/-/bpk-component-close-button-1.0.141.tgz",
+          "integrity": "sha512-Yd2kQnwuEQ3Myoqk2z/NDVIxB3YebCZrtgFJlQ/C6otp3sH3lbWLg4INREQqAyK1ZU5GK96qhvneubMA1tPLqQ==",
           "dev": true,
           "requires": {
-            "bpk-component-icon": "^3.31.5",
-            "bpk-mixins": "^17.24.5",
+            "bpk-component-icon": "^3.31.4",
+            "bpk-mixins": "^17.24.4",
             "bpk-react-utils": "^2.7.9",
             "prop-types": "^15.6.2"
           }
         },
         "bpk-component-icon": {
-          "version": "3.31.5",
-          "bundled": true,
+          "version": "3.31.4",
+          "resolved": "https://registry.npmjs.org/bpk-component-icon/-/bpk-component-icon-3.31.4.tgz",
+          "integrity": "sha512-DAiwhBYyyFmy2jonUFxEtxLpj2RlN17EDgd1zwZGpjfIhryyA+vL4XlSr8EkfPjZ6z+I6NWwbfmEUqDZgrn7Ag==",
           "dev": true,
           "requires": {
-            "bpk-mixins": "^17.24.5",
+            "bpk-mixins": "^17.24.4",
             "bpk-react-utils": "^2.7.9",
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5",
+            "bpk-svgs": "^6.9.2",
+            "bpk-tokens": "^27.6.4",
             "prop-types": "^15.6.2"
           }
         },
         "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
+          "version": "17.24.4",
+          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
+          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
+            "bpk-svgs": "^6.9.2",
+            "bpk-tokens": "^27.6.4"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
+          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
@@ -2728,17 +2401,25 @@
             "recompose": "^0.30.0"
           }
         },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
         "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
+          "version": "27.6.4",
+          "resolved": "https://registry.npmjs.org/bpk-tokens/-/bpk-tokens-27.6.4.tgz",
+          "integrity": "sha512-/7BXdfw5Ft2UxkpLlme4x2TXoTEtITeJX1IzxqdgKZF0+fb+WT4SywoO0g9iM/nfQ1893ZEdNkG25u49v43dsQ==",
           "dev": true,
           "requires": {
             "color": "^3.0.0"
+          },
+          "dependencies": {
+            "color": {
+              "version": "3.1.2",
+              "resolved": "https://registry.npmjs.org/color/-/color-3.1.2.tgz",
+              "integrity": "sha512-vXTJhHebByxZn3lDvDJYw4lR5+uB3vuoHsuYA5AKuxRVn5wzzIfQKGLBmgdVRHKTJYeK5rvJcHnrd0Li49CFpg==",
+              "dev": true,
+              "requires": {
+                "color-convert": "^1.9.1",
+                "color-string": "^1.5.2"
+              }
+            }
           }
         }
       }
@@ -2758,28 +2439,31 @@
       },
       "dependencies": {
         "bpk-component-mobile-scroll-container": {
-          "version": "1.1.82",
-          "bundled": true,
+          "version": "1.1.81",
+          "resolved": "https://registry.npmjs.org/bpk-component-mobile-scroll-container/-/bpk-component-mobile-scroll-container-1.1.81.tgz",
+          "integrity": "sha512-j+UYBa/vMZjqcCaz2cwoQWdcg3Tvt33iNdLNzrI/MWb92wqxW+BQ6PDazAX9L4VklzzEIAkOGS/76/DyIu57mg==",
           "dev": true,
           "requires": {
-            "bpk-mixins": "^17.24.5",
+            "bpk-mixins": "^17.24.4",
             "bpk-react-utils": "^2.7.9",
             "lodash.debounce": "^4.0.8",
             "prop-types": "^15.6.2"
           }
         },
         "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
+          "version": "17.24.4",
+          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
+          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
+            "bpk-svgs": "^6.9.2",
+            "bpk-tokens": "^27.6.4"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
+          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
@@ -2788,17 +2472,25 @@
             "recompose": "^0.30.0"
           }
         },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
         "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
+          "version": "27.6.4",
+          "resolved": "https://registry.npmjs.org/bpk-tokens/-/bpk-tokens-27.6.4.tgz",
+          "integrity": "sha512-/7BXdfw5Ft2UxkpLlme4x2TXoTEtITeJX1IzxqdgKZF0+fb+WT4SywoO0g9iM/nfQ1893ZEdNkG25u49v43dsQ==",
           "dev": true,
           "requires": {
             "color": "^3.0.0"
+          },
+          "dependencies": {
+            "color": {
+              "version": "3.1.2",
+              "resolved": "https://registry.npmjs.org/color/-/color-3.1.2.tgz",
+              "integrity": "sha512-vXTJhHebByxZn3lDvDJYw4lR5+uB3vuoHsuYA5AKuxRVn5wzzIfQKGLBmgdVRHKTJYeK5rvJcHnrd0Li49CFpg==",
+              "dev": true,
+              "requires": {
+                "color-convert": "^1.9.1",
+                "color-string": "^1.5.2"
+              }
+            }
           }
         }
       }
@@ -2813,36 +2505,25 @@
       },
       "dependencies": {
         "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
+          "version": "17.24.4",
+          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
+          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
+            "bpk-svgs": "^6.9.2",
+            "bpk-tokens": "^27.6.4"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
+          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
             "prop-types": "^15.6.2",
             "react-transition-group": "^2.5.3",
             "recompose": "^0.30.0"
-          }
-        },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
           }
         }
       }
@@ -2860,68 +2541,60 @@
       },
       "dependencies": {
         "bpk-component-icon": {
-          "version": "3.31.5",
-          "bundled": true,
+          "version": "3.31.4",
+          "resolved": "https://registry.npmjs.org/bpk-component-icon/-/bpk-component-icon-3.31.4.tgz",
+          "integrity": "sha512-DAiwhBYyyFmy2jonUFxEtxLpj2RlN17EDgd1zwZGpjfIhryyA+vL4XlSr8EkfPjZ6z+I6NWwbfmEUqDZgrn7Ag==",
           "dev": true,
           "requires": {
-            "bpk-mixins": "^17.24.5",
+            "bpk-mixins": "^17.24.4",
             "bpk-react-utils": "^2.7.9",
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5",
+            "bpk-svgs": "^6.9.2",
+            "bpk-tokens": "^27.6.4",
             "prop-types": "^15.6.2"
           }
         },
         "bpk-component-link": {
-          "version": "1.2.76",
-          "bundled": true,
+          "version": "1.2.75",
+          "resolved": "https://registry.npmjs.org/bpk-component-link/-/bpk-component-link-1.2.75.tgz",
+          "integrity": "sha512-qoosptvwz8ZjxRt2WvoERb2E71zrBhs5+USNjy6FtDl+cXndmMOsINB1JiAmMB9TO6PgUZJkj7FBN7Vm7rZ+bQ==",
           "dev": true,
           "requires": {
-            "bpk-mixins": "^17.24.5",
+            "bpk-mixins": "^17.24.4",
             "bpk-react-utils": "^2.7.9",
             "prop-types": "^15.6.2"
           }
         },
         "bpk-component-text": {
-          "version": "1.1.7",
-          "bundled": true,
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/bpk-component-text/-/bpk-component-text-1.1.6.tgz",
+          "integrity": "sha512-U4wp5+Fz1Rd9LeJphQRKwKx2ekIbzGj0SFdvjDkVOkG120YVtVb4YQN/3xEl/zb7Csku5HLvkJIJK4C+wR22nQ==",
           "dev": true,
           "requires": {
-            "bpk-mixins": "^17.24.5",
+            "bpk-mixins": "^17.24.4",
             "bpk-react-utils": "^2.7.9",
             "prop-types": "^15.6.2"
           }
         },
         "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
+          "version": "17.24.4",
+          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
+          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
+            "bpk-svgs": "^6.9.2",
+            "bpk-tokens": "^27.6.4"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
+          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
             "prop-types": "^15.6.2",
             "react-transition-group": "^2.5.3",
             "recompose": "^0.30.0"
-          }
-        },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
           }
         }
       }
@@ -2936,25 +2609,13 @@
       },
       "dependencies": {
         "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
+          "version": "17.24.4",
+          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
+          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
-          }
-        },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
+            "bpk-svgs": "^6.9.2",
+            "bpk-tokens": "^27.6.4"
           }
         }
       }
@@ -2968,25 +2629,13 @@
       },
       "dependencies": {
         "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
+          "version": "17.24.4",
+          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
+          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
-          }
-        },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
+            "bpk-svgs": "^6.9.2",
+            "bpk-tokens": "^27.6.4"
           }
         }
       }
@@ -3005,39 +2654,43 @@
       },
       "dependencies": {
         "bpk-component-icon": {
-          "version": "3.31.5",
-          "bundled": true,
+          "version": "3.31.4",
+          "resolved": "https://registry.npmjs.org/bpk-component-icon/-/bpk-component-icon-3.31.4.tgz",
+          "integrity": "sha512-DAiwhBYyyFmy2jonUFxEtxLpj2RlN17EDgd1zwZGpjfIhryyA+vL4XlSr8EkfPjZ6z+I6NWwbfmEUqDZgrn7Ag==",
           "dev": true,
           "requires": {
-            "bpk-mixins": "^17.24.5",
+            "bpk-mixins": "^17.24.4",
             "bpk-react-utils": "^2.7.9",
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5",
+            "bpk-svgs": "^6.9.2",
+            "bpk-tokens": "^27.6.4",
             "prop-types": "^15.6.2"
           }
         },
         "bpk-component-select": {
-          "version": "2.3.8",
-          "bundled": true,
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/bpk-component-select/-/bpk-component-select-2.3.7.tgz",
+          "integrity": "sha512-5A3duQQ58GmdgHfI8GCvbMA8b8IzyUh+b+7mRQVR0NBCqY2HUL1rrjly95ejfZx1OhUWfEwwYU3fAOFgpj6o3A==",
           "dev": true,
           "requires": {
-            "bpk-mixins": "^17.24.5",
+            "bpk-mixins": "^17.24.4",
             "bpk-react-utils": "^2.7.9",
             "prop-types": "^15.6.2"
           }
         },
         "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
+          "version": "17.24.4",
+          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
+          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
+            "bpk-svgs": "^6.9.2",
+            "bpk-tokens": "^27.6.4"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
+          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
@@ -3046,17 +2699,25 @@
             "recompose": "^0.30.0"
           }
         },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
         "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
+          "version": "27.6.4",
+          "resolved": "https://registry.npmjs.org/bpk-tokens/-/bpk-tokens-27.6.4.tgz",
+          "integrity": "sha512-/7BXdfw5Ft2UxkpLlme4x2TXoTEtITeJX1IzxqdgKZF0+fb+WT4SywoO0g9iM/nfQ1893ZEdNkG25u49v43dsQ==",
           "dev": true,
           "requires": {
             "color": "^3.0.0"
+          },
+          "dependencies": {
+            "color": {
+              "version": "3.1.2",
+              "resolved": "https://registry.npmjs.org/color/-/color-3.1.2.tgz",
+              "integrity": "sha512-vXTJhHebByxZn3lDvDJYw4lR5+uB3vuoHsuYA5AKuxRVn5wzzIfQKGLBmgdVRHKTJYeK5rvJcHnrd0Li49CFpg==",
+              "dev": true,
+              "requires": {
+                "color-convert": "^1.9.1",
+                "color-string": "^1.5.2"
+              }
+            }
           }
         }
       }
@@ -3071,36 +2732,25 @@
       },
       "dependencies": {
         "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
+          "version": "17.24.4",
+          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
+          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
+            "bpk-svgs": "^6.9.2",
+            "bpk-tokens": "^27.6.4"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
+          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
             "prop-types": "^15.6.2",
             "react-transition-group": "^2.5.3",
             "recompose": "^0.30.0"
-          }
-        },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
           }
         }
       }
@@ -3116,48 +2766,38 @@
       },
       "dependencies": {
         "bpk-component-icon": {
-          "version": "3.31.5",
-          "bundled": true,
+          "version": "3.31.4",
+          "resolved": "https://registry.npmjs.org/bpk-component-icon/-/bpk-component-icon-3.31.4.tgz",
+          "integrity": "sha512-DAiwhBYyyFmy2jonUFxEtxLpj2RlN17EDgd1zwZGpjfIhryyA+vL4XlSr8EkfPjZ6z+I6NWwbfmEUqDZgrn7Ag==",
           "dev": true,
           "requires": {
-            "bpk-mixins": "^17.24.5",
+            "bpk-mixins": "^17.24.4",
             "bpk-react-utils": "^2.7.9",
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5",
+            "bpk-svgs": "^6.9.2",
+            "bpk-tokens": "^27.6.4",
             "prop-types": "^15.6.2"
           }
         },
         "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
+          "version": "17.24.4",
+          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
+          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
+            "bpk-svgs": "^6.9.2",
+            "bpk-tokens": "^27.6.4"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
+          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
             "prop-types": "^15.6.2",
             "react-transition-group": "^2.5.3",
             "recompose": "^0.30.0"
-          }
-        },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
           }
         }
       }
@@ -3173,59 +2813,37 @@
       },
       "dependencies": {
         "bpk-component-close-button": {
-          "version": "1.0.142",
-          "bundled": true,
+          "version": "1.0.141",
+          "resolved": "https://registry.npmjs.org/bpk-component-close-button/-/bpk-component-close-button-1.0.141.tgz",
+          "integrity": "sha512-Yd2kQnwuEQ3Myoqk2z/NDVIxB3YebCZrtgFJlQ/C6otp3sH3lbWLg4INREQqAyK1ZU5GK96qhvneubMA1tPLqQ==",
           "dev": true,
           "requires": {
-            "bpk-component-icon": "^3.31.5",
-            "bpk-mixins": "^17.24.5",
+            "bpk-component-icon": "^3.31.4",
+            "bpk-mixins": "^17.24.4",
             "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-component-icon": {
-          "version": "3.31.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.5",
-            "bpk-react-utils": "^2.7.9",
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5",
             "prop-types": "^15.6.2"
           }
         },
         "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
+          "version": "17.24.4",
+          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
+          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
+            "bpk-svgs": "^6.9.2",
+            "bpk-tokens": "^27.6.4"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
+          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
             "prop-types": "^15.6.2",
             "react-transition-group": "^2.5.3",
             "recompose": "^0.30.0"
-          }
-        },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
           }
         }
       }
@@ -3241,48 +2859,38 @@
       },
       "dependencies": {
         "bpk-component-icon": {
-          "version": "3.31.5",
-          "bundled": true,
+          "version": "3.31.4",
+          "resolved": "https://registry.npmjs.org/bpk-component-icon/-/bpk-component-icon-3.31.4.tgz",
+          "integrity": "sha512-DAiwhBYyyFmy2jonUFxEtxLpj2RlN17EDgd1zwZGpjfIhryyA+vL4XlSr8EkfPjZ6z+I6NWwbfmEUqDZgrn7Ag==",
           "dev": true,
           "requires": {
-            "bpk-mixins": "^17.24.5",
+            "bpk-mixins": "^17.24.4",
             "bpk-react-utils": "^2.7.9",
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5",
+            "bpk-svgs": "^6.9.2",
+            "bpk-tokens": "^27.6.4",
             "prop-types": "^15.6.2"
           }
         },
         "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
+          "version": "17.24.4",
+          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
+          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
+            "bpk-svgs": "^6.9.2",
+            "bpk-tokens": "^27.6.4"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
+          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
             "prop-types": "^15.6.2",
             "react-transition-group": "^2.5.3",
             "recompose": "^0.30.0"
-          }
-        },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
           }
         }
       }
@@ -3297,36 +2905,25 @@
       },
       "dependencies": {
         "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
+          "version": "17.24.4",
+          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
+          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
+            "bpk-svgs": "^6.9.2",
+            "bpk-tokens": "^27.6.4"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
+          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
             "prop-types": "^15.6.2",
             "react-transition-group": "^2.5.3",
             "recompose": "^0.30.0"
-          }
-        },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
           }
         }
       }
@@ -3341,36 +2938,25 @@
       },
       "dependencies": {
         "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
+          "version": "17.24.4",
+          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
+          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
+            "bpk-svgs": "^6.9.2",
+            "bpk-tokens": "^27.6.4"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
+          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
             "prop-types": "^15.6.2",
             "react-transition-group": "^2.5.3",
             "recompose": "^0.30.0"
-          }
-        },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
           }
         }
       }
@@ -3390,135 +2976,89 @@
       },
       "dependencies": {
         "bpk-component-breakpoint": {
-          "version": "1.1.75",
-          "bundled": true,
+          "version": "1.1.74",
+          "resolved": "https://registry.npmjs.org/bpk-component-breakpoint/-/bpk-component-breakpoint-1.1.74.tgz",
+          "integrity": "sha512-4C5vPMoBnKKXXC/C2KZg3Csz+c+nxmrJqGaTmEA5XlTG6GyomX4ltOmEtsG4x+mDK+qJYSg/HsxbZHIIxGHx/w==",
           "dev": true,
           "requires": {
-            "bpk-mixins": "^17.24.5",
+            "bpk-mixins": "^17.24.4",
             "prop-types": "^15.6.2",
             "react-responsive": "^5.0.0"
           }
         },
         "bpk-component-calendar": {
-          "version": "5.0.27",
-          "bundled": true,
+          "version": "5.0.26",
+          "resolved": "https://registry.npmjs.org/bpk-component-calendar/-/bpk-component-calendar-5.0.26.tgz",
+          "integrity": "sha512-eBo5tfZyTczqZn0EH5Xv1Weahf1S/hR92PpZlJV3GPs7yMrYsf0C+Bxn1edkvCKZu4lX83bl2Er6zfPAgfkUdg==",
           "dev": true,
           "requires": {
-            "bpk-component-icon": "^3.31.5",
-            "bpk-component-select": "^2.3.8",
-            "bpk-mixins": "^17.24.5",
+            "bpk-component-icon": "^3.31.4",
+            "bpk-component-select": "^2.3.7",
+            "bpk-mixins": "^17.24.4",
             "bpk-react-utils": "^2.7.9",
-            "bpk-tokens": "^27.6.5",
+            "bpk-tokens": "^27.6.4",
             "date-fns": "^1.29.0",
             "prop-types": "^15.6.2"
           }
         },
-        "bpk-component-close-button": {
-          "version": "1.0.142",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-component-icon": "^3.31.5",
-            "bpk-mixins": "^17.24.5",
-            "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-component-icon": {
-          "version": "3.31.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.5",
-            "bpk-react-utils": "^2.7.9",
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5",
-            "prop-types": "^15.6.2"
-          }
-        },
         "bpk-component-input": {
-          "version": "4.1.27",
-          "bundled": true,
+          "version": "4.1.26",
+          "resolved": "https://registry.npmjs.org/bpk-component-input/-/bpk-component-input-4.1.26.tgz",
+          "integrity": "sha512-+5P8u4+tmf+pABR9fhqDvMcVDaThFZgiEk9yPOcv0m9rgPZMzWXxOcEpN7Wzr2fdW6P/kCAtFA0jwUKtuzEyWQ==",
           "dev": true,
           "requires": {
-            "bpk-component-icon": "^3.31.5",
-            "bpk-mixins": "^17.24.5",
-            "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-component-link": {
-          "version": "1.2.76",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.5",
+            "bpk-component-icon": "^3.31.4",
+            "bpk-mixins": "^17.24.4",
             "bpk-react-utils": "^2.7.9",
             "prop-types": "^15.6.2"
           }
         },
         "bpk-component-modal": {
-          "version": "1.8.74",
-          "bundled": true,
+          "version": "1.8.73",
+          "resolved": "https://registry.npmjs.org/bpk-component-modal/-/bpk-component-modal-1.8.73.tgz",
+          "integrity": "sha512-P3XSsRB8QzPnUnNNKXTj9mBSua976Kfsl7R2gSQbb+Jclm1GBboxx/ma4oqND2ywAHEPyv8cePWv2TwN/J7E/g==",
           "dev": true,
           "requires": {
-            "bpk-component-close-button": "^1.0.142",
-            "bpk-component-icon": "^3.31.5",
-            "bpk-component-link": "^1.2.76",
-            "bpk-mixins": "^17.24.5",
+            "bpk-component-close-button": "^1.0.141",
+            "bpk-component-icon": "^3.31.4",
+            "bpk-component-link": "^1.2.75",
+            "bpk-mixins": "^17.24.4",
             "bpk-react-utils": "^2.7.9",
-            "bpk-scrim-utils": "^3.2.76",
+            "bpk-scrim-utils": "^3.2.75",
             "prop-types": "^15.6.2"
           }
         },
         "bpk-component-popover": {
-          "version": "2.2.50",
-          "bundled": true,
+          "version": "2.2.49",
+          "resolved": "https://registry.npmjs.org/bpk-component-popover/-/bpk-component-popover-2.2.49.tgz",
+          "integrity": "sha512-BSnRBLjK6V9he2MQescsfU+bONFKzo8IDE75c5cLRIvXTa+NWxtYh+yB0jh1lz3A8ycLHpNnFcDHYb5icOQ84A==",
           "dev": true,
           "requires": {
             "@skyscanner/popper.js": "^1.12.9-beta.1",
             "a11y-focus-scope": "^1.1.3",
             "a11y-focus-store": "^1.0.0",
-            "bpk-component-close-button": "^1.0.142",
-            "bpk-component-link": "^1.2.76",
-            "bpk-component-text": "^1.1.7",
-            "bpk-mixins": "^17.24.5",
-            "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-component-select": {
-          "version": "2.3.8",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.5",
-            "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-component-text": {
-          "version": "1.1.7",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.5",
+            "bpk-component-close-button": "^1.0.141",
+            "bpk-component-link": "^1.2.75",
+            "bpk-component-text": "^1.1.6",
+            "bpk-mixins": "^17.24.4",
             "bpk-react-utils": "^2.7.9",
             "prop-types": "^15.6.2"
           }
         },
         "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
+          "version": "17.24.4",
+          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
+          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
+            "bpk-svgs": "^6.9.2",
+            "bpk-tokens": "^27.6.4"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
+          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
@@ -3527,17 +3067,16 @@
             "recompose": "^0.30.0"
           }
         },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
+        "bpk-scrim-utils": {
+          "version": "3.2.75",
+          "resolved": "https://registry.npmjs.org/bpk-scrim-utils/-/bpk-scrim-utils-3.2.75.tgz",
+          "integrity": "sha512-8CSMp/znOPIza3/3jBCdHPNQF68AxpizJ87VLiXz/ILy1o9dNjsEW6AnzDuhuy1U38sAc2JGeIxOwCWIJPZfQw==",
           "dev": true,
           "requires": {
-            "color": "^3.0.0"
+            "a11y-focus-scope": "^1.1.3",
+            "a11y-focus-store": "^1.0.0",
+            "bpk-mixins": "^17.24.4",
+            "bpk-react-utils": "^2.7.9"
           }
         }
       }
@@ -3552,36 +3091,25 @@
       },
       "dependencies": {
         "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
+          "version": "17.24.4",
+          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
+          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
+            "bpk-svgs": "^6.9.2",
+            "bpk-tokens": "^27.6.4"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
+          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
             "prop-types": "^15.6.2",
             "react-transition-group": "^2.5.3",
             "recompose": "^0.30.0"
-          }
-        },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
           }
         }
       }
@@ -3594,84 +3122,31 @@
         "prop-types": "^15.6.2"
       },
       "dependencies": {
-        "bpk-component-close-button": {
-          "version": "1.0.142",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-component-icon": "^3.31.5",
-            "bpk-mixins": "^17.24.5",
-            "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-component-icon": {
-          "version": "3.31.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.5",
-            "bpk-react-utils": "^2.7.9",
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-component-link": {
-          "version": "1.2.76",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.5",
-            "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
-          }
-        },
         "bpk-component-modal": {
-          "version": "1.8.74",
-          "bundled": true,
+          "version": "1.8.73",
+          "resolved": "https://registry.npmjs.org/bpk-component-modal/-/bpk-component-modal-1.8.73.tgz",
+          "integrity": "sha512-P3XSsRB8QzPnUnNNKXTj9mBSua976Kfsl7R2gSQbb+Jclm1GBboxx/ma4oqND2ywAHEPyv8cePWv2TwN/J7E/g==",
           "dev": true,
           "requires": {
-            "bpk-component-close-button": "^1.0.142",
-            "bpk-component-icon": "^3.31.5",
-            "bpk-component-link": "^1.2.76",
-            "bpk-mixins": "^17.24.5",
+            "bpk-component-close-button": "^1.0.141",
+            "bpk-component-icon": "^3.31.4",
+            "bpk-component-link": "^1.2.75",
+            "bpk-mixins": "^17.24.4",
             "bpk-react-utils": "^2.7.9",
-            "bpk-scrim-utils": "^3.2.76",
+            "bpk-scrim-utils": "^3.2.75",
             "prop-types": "^15.6.2"
           }
         },
-        "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
+        "bpk-scrim-utils": {
+          "version": "3.2.75",
+          "resolved": "https://registry.npmjs.org/bpk-scrim-utils/-/bpk-scrim-utils-3.2.75.tgz",
+          "integrity": "sha512-8CSMp/znOPIza3/3jBCdHPNQF68AxpizJ87VLiXz/ILy1o9dNjsEW6AnzDuhuy1U38sAc2JGeIxOwCWIJPZfQw==",
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
+            "a11y-focus-scope": "^1.1.3",
+            "a11y-focus-store": "^1.0.0",
+            "bpk-mixins": "^17.24.4",
+            "bpk-react-utils": "^2.7.9"
           }
         }
       }
@@ -3692,50 +3167,55 @@
       },
       "dependencies": {
         "bpk-component-close-button": {
-          "version": "1.0.142",
-          "bundled": true,
+          "version": "1.0.141",
+          "resolved": "https://registry.npmjs.org/bpk-component-close-button/-/bpk-component-close-button-1.0.141.tgz",
+          "integrity": "sha512-Yd2kQnwuEQ3Myoqk2z/NDVIxB3YebCZrtgFJlQ/C6otp3sH3lbWLg4INREQqAyK1ZU5GK96qhvneubMA1tPLqQ==",
           "dev": true,
           "requires": {
-            "bpk-component-icon": "^3.31.5",
-            "bpk-mixins": "^17.24.5",
+            "bpk-component-icon": "^3.31.4",
+            "bpk-mixins": "^17.24.4",
             "bpk-react-utils": "^2.7.9",
             "prop-types": "^15.6.2"
           }
         },
         "bpk-component-icon": {
-          "version": "3.31.5",
-          "bundled": true,
+          "version": "3.31.4",
+          "resolved": "https://registry.npmjs.org/bpk-component-icon/-/bpk-component-icon-3.31.4.tgz",
+          "integrity": "sha512-DAiwhBYyyFmy2jonUFxEtxLpj2RlN17EDgd1zwZGpjfIhryyA+vL4XlSr8EkfPjZ6z+I6NWwbfmEUqDZgrn7Ag==",
           "dev": true,
           "requires": {
-            "bpk-mixins": "^17.24.5",
+            "bpk-mixins": "^17.24.4",
             "bpk-react-utils": "^2.7.9",
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5",
+            "bpk-svgs": "^6.9.2",
+            "bpk-tokens": "^27.6.4",
             "prop-types": "^15.6.2"
           }
         },
         "bpk-component-link": {
-          "version": "1.2.76",
-          "bundled": true,
+          "version": "1.2.75",
+          "resolved": "https://registry.npmjs.org/bpk-component-link/-/bpk-component-link-1.2.75.tgz",
+          "integrity": "sha512-qoosptvwz8ZjxRt2WvoERb2E71zrBhs5+USNjy6FtDl+cXndmMOsINB1JiAmMB9TO6PgUZJkj7FBN7Vm7rZ+bQ==",
           "dev": true,
           "requires": {
-            "bpk-mixins": "^17.24.5",
+            "bpk-mixins": "^17.24.4",
             "bpk-react-utils": "^2.7.9",
             "prop-types": "^15.6.2"
           }
         },
         "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
+          "version": "17.24.4",
+          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
+          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
+            "bpk-svgs": "^6.9.2",
+            "bpk-tokens": "^27.6.4"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
+          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
@@ -3744,17 +3224,37 @@
             "recompose": "^0.30.0"
           }
         },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
+        "bpk-scrim-utils": {
+          "version": "3.2.75",
+          "resolved": "https://registry.npmjs.org/bpk-scrim-utils/-/bpk-scrim-utils-3.2.75.tgz",
+          "integrity": "sha512-8CSMp/znOPIza3/3jBCdHPNQF68AxpizJ87VLiXz/ILy1o9dNjsEW6AnzDuhuy1U38sAc2JGeIxOwCWIJPZfQw==",
+          "dev": true,
+          "requires": {
+            "a11y-focus-scope": "^1.1.3",
+            "a11y-focus-store": "^1.0.0",
+            "bpk-mixins": "^17.24.4",
+            "bpk-react-utils": "^2.7.9"
+          }
         },
         "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
+          "version": "27.6.4",
+          "resolved": "https://registry.npmjs.org/bpk-tokens/-/bpk-tokens-27.6.4.tgz",
+          "integrity": "sha512-/7BXdfw5Ft2UxkpLlme4x2TXoTEtITeJX1IzxqdgKZF0+fb+WT4SywoO0g9iM/nfQ1893ZEdNkG25u49v43dsQ==",
           "dev": true,
           "requires": {
             "color": "^3.0.0"
+          },
+          "dependencies": {
+            "color": {
+              "version": "3.1.2",
+              "resolved": "https://registry.npmjs.org/color/-/color-3.1.2.tgz",
+              "integrity": "sha512-vXTJhHebByxZn3lDvDJYw4lR5+uB3vuoHsuYA5AKuxRVn5wzzIfQKGLBmgdVRHKTJYeK5rvJcHnrd0Li49CFpg==",
+              "dev": true,
+              "requires": {
+                "color-convert": "^1.9.1",
+                "color-string": "^1.5.2"
+              }
+            }
           }
         }
       }
@@ -3770,66 +3270,49 @@
         "prop-types": "^15.6.2"
       },
       "dependencies": {
-        "bpk-animate-height": {
-          "version": "1.1.113",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "prop-types": "^15.6.2"
-          }
-        },
         "bpk-component-form-validation": {
-          "version": "2.0.27",
-          "bundled": true,
+          "version": "2.0.26",
+          "resolved": "https://registry.npmjs.org/bpk-component-form-validation/-/bpk-component-form-validation-2.0.26.tgz",
+          "integrity": "sha512-APA045h/x0cWVmyUKkVfzJR7R6L2un8EngRcr4MrhN12EC3Ppoc58WilzfkWYf2gq7uOt1HDZyXVbyxiWn0Naw==",
           "dev": true,
           "requires": {
-            "bpk-animate-height": "^1.1.113",
-            "bpk-mixins": "^17.24.5",
+            "bpk-animate-height": "^1.1.112",
+            "bpk-mixins": "^17.24.4",
             "bpk-react-utils": "^2.7.9",
             "prop-types": "^15.6.2"
           }
         },
         "bpk-component-label": {
-          "version": "3.2.145",
-          "bundled": true,
+          "version": "3.2.144",
+          "resolved": "https://registry.npmjs.org/bpk-component-label/-/bpk-component-label-3.2.144.tgz",
+          "integrity": "sha512-78mIbPwaeOwidu76SlPVo4fJG6d7kfSQ2JGlvZ4yU70it793xmj/ll0E2+PcAaAWoeNTVwreQmctg/RkwgNTRQ==",
           "dev": true,
           "requires": {
-            "bpk-mixins": "^17.24.5",
+            "bpk-mixins": "^17.24.4",
             "bpk-react-utils": "^2.7.9",
             "prop-types": "^15.6.2"
           }
         },
         "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
+          "version": "17.24.4",
+          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
+          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
+            "bpk-svgs": "^6.9.2",
+            "bpk-tokens": "^27.6.4"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
+          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
             "prop-types": "^15.6.2",
             "react-transition-group": "^2.5.3",
             "recompose": "^0.30.0"
-          }
-        },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
           }
         }
       }
@@ -3845,44 +3328,34 @@
       },
       "dependencies": {
         "bpk-animate-height": {
-          "version": "1.1.113",
-          "bundled": true,
+          "version": "1.1.112",
+          "resolved": "https://registry.npmjs.org/bpk-animate-height/-/bpk-animate-height-1.1.112.tgz",
+          "integrity": "sha512-xX5wT7YKYgFbwRlOZVQXhqNKm7d1tlnp8Pk5sCf1CKVzgZO+be9W7GgZ9HF6wTUoWuMIAt/31f3fP80mDwlvFg==",
           "dev": true,
           "requires": {
             "prop-types": "^15.6.2"
           }
         },
         "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
+          "version": "17.24.4",
+          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
+          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
+            "bpk-svgs": "^6.9.2",
+            "bpk-tokens": "^27.6.4"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
+          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
             "prop-types": "^15.6.2",
             "react-transition-group": "^2.5.3",
             "recompose": "^0.30.0"
-          }
-        },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
           }
         }
       }
@@ -3897,36 +3370,25 @@
       },
       "dependencies": {
         "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
+          "version": "17.24.4",
+          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
+          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
+            "bpk-svgs": "^6.9.2",
+            "bpk-tokens": "^27.6.4"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
+          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
             "prop-types": "^15.6.2",
             "react-transition-group": "^2.5.3",
             "recompose": "^0.30.0"
-          }
-        },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
           }
         }
       }
@@ -3942,46 +3404,36 @@
       },
       "dependencies": {
         "bpk-component-link": {
-          "version": "1.2.76",
-          "bundled": true,
+          "version": "1.2.75",
+          "resolved": "https://registry.npmjs.org/bpk-component-link/-/bpk-component-link-1.2.75.tgz",
+          "integrity": "sha512-qoosptvwz8ZjxRt2WvoERb2E71zrBhs5+USNjy6FtDl+cXndmMOsINB1JiAmMB9TO6PgUZJkj7FBN7Vm7rZ+bQ==",
           "dev": true,
           "requires": {
-            "bpk-mixins": "^17.24.5",
+            "bpk-mixins": "^17.24.4",
             "bpk-react-utils": "^2.7.9",
             "prop-types": "^15.6.2"
           }
         },
         "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
+          "version": "17.24.4",
+          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
+          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
+            "bpk-svgs": "^6.9.2",
+            "bpk-tokens": "^27.6.4"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
+          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
             "prop-types": "^15.6.2",
             "react-transition-group": "^2.5.3",
             "recompose": "^0.30.0"
-          }
-        },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
           }
         }
       }
@@ -3997,47 +3449,37 @@
       },
       "dependencies": {
         "bpk-component-mobile-scroll-container": {
-          "version": "1.1.82",
-          "bundled": true,
+          "version": "1.1.81",
+          "resolved": "https://registry.npmjs.org/bpk-component-mobile-scroll-container/-/bpk-component-mobile-scroll-container-1.1.81.tgz",
+          "integrity": "sha512-j+UYBa/vMZjqcCaz2cwoQWdcg3Tvt33iNdLNzrI/MWb92wqxW+BQ6PDazAX9L4VklzzEIAkOGS/76/DyIu57mg==",
           "dev": true,
           "requires": {
-            "bpk-mixins": "^17.24.5",
+            "bpk-mixins": "^17.24.4",
             "bpk-react-utils": "^2.7.9",
             "lodash.debounce": "^4.0.8",
             "prop-types": "^15.6.2"
           }
         },
         "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
+          "version": "17.24.4",
+          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
+          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
+            "bpk-svgs": "^6.9.2",
+            "bpk-tokens": "^27.6.4"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
+          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
             "prop-types": "^15.6.2",
             "react-transition-group": "^2.5.3",
             "recompose": "^0.30.0"
-          }
-        },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
           }
         }
       }
@@ -4054,17 +3496,19 @@
       },
       "dependencies": {
         "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
+          "version": "17.24.4",
+          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
+          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
+            "bpk-svgs": "^6.9.2",
+            "bpk-tokens": "^27.6.4"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
+          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
@@ -4074,16 +3518,30 @@
           }
         },
         "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
+          "version": "6.9.2",
+          "resolved": "https://registry.npmjs.org/bpk-svgs/-/bpk-svgs-6.9.2.tgz",
+          "integrity": "sha512-gicoSPPzsQVc0eBUtpn0vGfs/azztQIsA5IDeJaW50G1MHst9C7KBUdegnf64oRwjuVRZbdXsTz5I7h1UqgXKA==",
           "dev": true
         },
         "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
+          "version": "27.6.4",
+          "resolved": "https://registry.npmjs.org/bpk-tokens/-/bpk-tokens-27.6.4.tgz",
+          "integrity": "sha512-/7BXdfw5Ft2UxkpLlme4x2TXoTEtITeJX1IzxqdgKZF0+fb+WT4SywoO0g9iM/nfQ1893ZEdNkG25u49v43dsQ==",
           "dev": true,
           "requires": {
             "color": "^3.0.0"
+          },
+          "dependencies": {
+            "color": {
+              "version": "3.1.2",
+              "resolved": "https://registry.npmjs.org/color/-/color-3.1.2.tgz",
+              "integrity": "sha512-vXTJhHebByxZn3lDvDJYw4lR5+uB3vuoHsuYA5AKuxRVn5wzzIfQKGLBmgdVRHKTJYeK5rvJcHnrd0Li49CFpg==",
+              "dev": true,
+              "requires": {
+                "color-convert": "^1.9.1",
+                "color-string": "^1.5.2"
+              }
+            }
           }
         }
       }
@@ -4100,47 +3558,37 @@
       },
       "dependencies": {
         "bpk-component-spinner": {
-          "version": "2.2.107",
-          "bundled": true,
+          "version": "2.2.106",
+          "resolved": "https://registry.npmjs.org/bpk-component-spinner/-/bpk-component-spinner-2.2.106.tgz",
+          "integrity": "sha512-iOd+i+VMT0lN35FPhr9bEvet205lD911cf7Nu75tAgrBOL/n8B23p4KWkJU8WOB6pccUZ1gC9EClQ2UDSMOXFQ==",
           "dev": true,
           "requires": {
-            "bpk-mixins": "^17.24.5",
+            "bpk-mixins": "^17.24.4",
             "bpk-react-utils": "^2.7.9",
-            "bpk-svgs": "^6.9.3",
+            "bpk-svgs": "^6.9.2",
             "prop-types": "^15.6.2"
           }
         },
         "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
+          "version": "17.24.4",
+          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
+          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
+            "bpk-svgs": "^6.9.2",
+            "bpk-tokens": "^27.6.4"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
+          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
             "prop-types": "^15.6.2",
             "react-transition-group": "^2.5.3",
             "recompose": "^0.30.0"
-          }
-        },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
           }
         }
       }
@@ -4156,17 +3604,19 @@
       },
       "dependencies": {
         "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
+          "version": "17.24.4",
+          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
+          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
+            "bpk-svgs": "^6.9.2",
+            "bpk-tokens": "^27.6.4"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
+          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
@@ -4175,18 +3625,11 @@
             "recompose": "^0.30.0"
           }
         },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
+        "intersection-observer": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/intersection-observer/-/intersection-observer-0.7.0.tgz",
+          "integrity": "sha512-Id0Fij0HsB/vKWGeBe9PxeY45ttRiBmhFyyt/geBdDHBYNctMRTE3dC1U3ujzz3lap+hVXlEcVaB56kZP/eEUg==",
           "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
-          }
         }
       }
     },
@@ -4201,48 +3644,38 @@
       },
       "dependencies": {
         "bpk-component-icon": {
-          "version": "3.31.5",
-          "bundled": true,
+          "version": "3.31.4",
+          "resolved": "https://registry.npmjs.org/bpk-component-icon/-/bpk-component-icon-3.31.4.tgz",
+          "integrity": "sha512-DAiwhBYyyFmy2jonUFxEtxLpj2RlN17EDgd1zwZGpjfIhryyA+vL4XlSr8EkfPjZ6z+I6NWwbfmEUqDZgrn7Ag==",
           "dev": true,
           "requires": {
-            "bpk-mixins": "^17.24.5",
+            "bpk-mixins": "^17.24.4",
             "bpk-react-utils": "^2.7.9",
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5",
+            "bpk-svgs": "^6.9.2",
+            "bpk-tokens": "^27.6.4",
             "prop-types": "^15.6.2"
           }
         },
         "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
+          "version": "17.24.4",
+          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
+          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
+            "bpk-svgs": "^6.9.2",
+            "bpk-tokens": "^27.6.4"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
+          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
             "prop-types": "^15.6.2",
             "react-transition-group": "^2.5.3",
             "recompose": "^0.30.0"
-          }
-        },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
           }
         }
       }
@@ -4257,36 +3690,25 @@
       },
       "dependencies": {
         "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
+          "version": "17.24.4",
+          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
+          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
+            "bpk-svgs": "^6.9.2",
+            "bpk-tokens": "^27.6.4"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
+          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
             "prop-types": "^15.6.2",
             "react-transition-group": "^2.5.3",
             "recompose": "^0.30.0"
-          }
-        },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
           }
         }
       }
@@ -4301,36 +3723,25 @@
       },
       "dependencies": {
         "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
+          "version": "17.24.4",
+          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
+          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
+            "bpk-svgs": "^6.9.2",
+            "bpk-tokens": "^27.6.4"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
+          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
             "prop-types": "^15.6.2",
             "react-transition-group": "^2.5.3",
             "recompose": "^0.30.0"
-          }
-        },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
           }
         }
       }
@@ -4345,36 +3756,25 @@
       },
       "dependencies": {
         "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
+          "version": "17.24.4",
+          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
+          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
+            "bpk-svgs": "^6.9.2",
+            "bpk-tokens": "^27.6.4"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
+          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
             "prop-types": "^15.6.2",
             "react-transition-group": "^2.5.3",
             "recompose": "^0.30.0"
-          }
-        },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
           }
         }
       }
@@ -4392,68 +3792,60 @@
       },
       "dependencies": {
         "bpk-component-button": {
-          "version": "2.4.2",
-          "bundled": true,
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/bpk-component-button/-/bpk-component-button-2.4.1.tgz",
+          "integrity": "sha512-4jJ5wxgquUUVGHpblXf0yWlpVFNtmDo0DjLMkGL5U4HxFIgc0XZp911KjIzUVeCh+3eGASeAthQgLCruQghzOg==",
           "dev": true,
           "requires": {
-            "bpk-mixins": "^17.24.5",
+            "bpk-mixins": "^17.24.4",
             "prop-types": "^15.6.2"
           }
         },
         "bpk-component-icon": {
-          "version": "3.31.5",
-          "bundled": true,
+          "version": "3.31.4",
+          "resolved": "https://registry.npmjs.org/bpk-component-icon/-/bpk-component-icon-3.31.4.tgz",
+          "integrity": "sha512-DAiwhBYyyFmy2jonUFxEtxLpj2RlN17EDgd1zwZGpjfIhryyA+vL4XlSr8EkfPjZ6z+I6NWwbfmEUqDZgrn7Ag==",
           "dev": true,
           "requires": {
-            "bpk-mixins": "^17.24.5",
+            "bpk-mixins": "^17.24.4",
             "bpk-react-utils": "^2.7.9",
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5",
+            "bpk-svgs": "^6.9.2",
+            "bpk-tokens": "^27.6.4",
             "prop-types": "^15.6.2"
           }
         },
         "bpk-component-spinner": {
-          "version": "2.2.107",
-          "bundled": true,
+          "version": "2.2.106",
+          "resolved": "https://registry.npmjs.org/bpk-component-spinner/-/bpk-component-spinner-2.2.106.tgz",
+          "integrity": "sha512-iOd+i+VMT0lN35FPhr9bEvet205lD911cf7Nu75tAgrBOL/n8B23p4KWkJU8WOB6pccUZ1gC9EClQ2UDSMOXFQ==",
           "dev": true,
           "requires": {
-            "bpk-mixins": "^17.24.5",
+            "bpk-mixins": "^17.24.4",
             "bpk-react-utils": "^2.7.9",
-            "bpk-svgs": "^6.9.3",
+            "bpk-svgs": "^6.9.2",
             "prop-types": "^15.6.2"
           }
         },
         "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
+          "version": "17.24.4",
+          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
+          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
+            "bpk-svgs": "^6.9.2",
+            "bpk-tokens": "^27.6.4"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
+          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
             "prop-types": "^15.6.2",
             "react-transition-group": "^2.5.3",
             "recompose": "^0.30.0"
-          }
-        },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
           }
         }
       }
@@ -4470,47 +3862,37 @@
       },
       "dependencies": {
         "bpk-component-spinner": {
-          "version": "2.2.107",
-          "bundled": true,
+          "version": "2.2.106",
+          "resolved": "https://registry.npmjs.org/bpk-component-spinner/-/bpk-component-spinner-2.2.106.tgz",
+          "integrity": "sha512-iOd+i+VMT0lN35FPhr9bEvet205lD911cf7Nu75tAgrBOL/n8B23p4KWkJU8WOB6pccUZ1gC9EClQ2UDSMOXFQ==",
           "dev": true,
           "requires": {
-            "bpk-mixins": "^17.24.5",
+            "bpk-mixins": "^17.24.4",
             "bpk-react-utils": "^2.7.9",
-            "bpk-svgs": "^6.9.3",
+            "bpk-svgs": "^6.9.2",
             "prop-types": "^15.6.2"
           }
         },
         "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
+          "version": "17.24.4",
+          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
+          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
+            "bpk-svgs": "^6.9.2",
+            "bpk-tokens": "^27.6.4"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
+          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
             "prop-types": "^15.6.2",
             "react-transition-group": "^2.5.3",
             "recompose": "^0.30.0"
-          }
-        },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
           }
         }
       }
@@ -4526,36 +3908,25 @@
       },
       "dependencies": {
         "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
+          "version": "17.24.4",
+          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
+          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
+            "bpk-svgs": "^6.9.2",
+            "bpk-tokens": "^27.6.4"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
+          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
             "prop-types": "^15.6.2",
             "react-transition-group": "^2.5.3",
             "recompose": "^0.30.0"
-          }
-        },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
           }
         }
       }
@@ -4574,50 +3945,55 @@
       },
       "dependencies": {
         "bpk-component-close-button": {
-          "version": "1.0.142",
-          "bundled": true,
+          "version": "1.0.141",
+          "resolved": "https://registry.npmjs.org/bpk-component-close-button/-/bpk-component-close-button-1.0.141.tgz",
+          "integrity": "sha512-Yd2kQnwuEQ3Myoqk2z/NDVIxB3YebCZrtgFJlQ/C6otp3sH3lbWLg4INREQqAyK1ZU5GK96qhvneubMA1tPLqQ==",
           "dev": true,
           "requires": {
-            "bpk-component-icon": "^3.31.5",
-            "bpk-mixins": "^17.24.5",
+            "bpk-component-icon": "^3.31.4",
+            "bpk-mixins": "^17.24.4",
             "bpk-react-utils": "^2.7.9",
             "prop-types": "^15.6.2"
           }
         },
         "bpk-component-icon": {
-          "version": "3.31.5",
-          "bundled": true,
+          "version": "3.31.4",
+          "resolved": "https://registry.npmjs.org/bpk-component-icon/-/bpk-component-icon-3.31.4.tgz",
+          "integrity": "sha512-DAiwhBYyyFmy2jonUFxEtxLpj2RlN17EDgd1zwZGpjfIhryyA+vL4XlSr8EkfPjZ6z+I6NWwbfmEUqDZgrn7Ag==",
           "dev": true,
           "requires": {
-            "bpk-mixins": "^17.24.5",
+            "bpk-mixins": "^17.24.4",
             "bpk-react-utils": "^2.7.9",
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5",
+            "bpk-svgs": "^6.9.2",
+            "bpk-tokens": "^27.6.4",
             "prop-types": "^15.6.2"
           }
         },
         "bpk-component-link": {
-          "version": "1.2.76",
-          "bundled": true,
+          "version": "1.2.75",
+          "resolved": "https://registry.npmjs.org/bpk-component-link/-/bpk-component-link-1.2.75.tgz",
+          "integrity": "sha512-qoosptvwz8ZjxRt2WvoERb2E71zrBhs5+USNjy6FtDl+cXndmMOsINB1JiAmMB9TO6PgUZJkj7FBN7Vm7rZ+bQ==",
           "dev": true,
           "requires": {
-            "bpk-mixins": "^17.24.5",
+            "bpk-mixins": "^17.24.4",
             "bpk-react-utils": "^2.7.9",
             "prop-types": "^15.6.2"
           }
         },
         "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
+          "version": "17.24.4",
+          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
+          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
+            "bpk-svgs": "^6.9.2",
+            "bpk-tokens": "^27.6.4"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
+          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
@@ -4626,17 +4002,16 @@
             "recompose": "^0.30.0"
           }
         },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
+        "bpk-scrim-utils": {
+          "version": "3.2.75",
+          "resolved": "https://registry.npmjs.org/bpk-scrim-utils/-/bpk-scrim-utils-3.2.75.tgz",
+          "integrity": "sha512-8CSMp/znOPIza3/3jBCdHPNQF68AxpizJ87VLiXz/ILy1o9dNjsEW6AnzDuhuy1U38sAc2JGeIxOwCWIJPZfQw==",
           "dev": true,
           "requires": {
-            "color": "^3.0.0"
+            "a11y-focus-scope": "^1.1.3",
+            "a11y-focus-store": "^1.0.0",
+            "bpk-mixins": "^17.24.4",
+            "bpk-react-utils": "^2.7.9"
           }
         }
       }
@@ -4654,79 +4029,59 @@
       },
       "dependencies": {
         "bpk-component-close-button": {
-          "version": "1.0.142",
-          "bundled": true,
+          "version": "1.0.141",
+          "resolved": "https://registry.npmjs.org/bpk-component-close-button/-/bpk-component-close-button-1.0.141.tgz",
+          "integrity": "sha512-Yd2kQnwuEQ3Myoqk2z/NDVIxB3YebCZrtgFJlQ/C6otp3sH3lbWLg4INREQqAyK1ZU5GK96qhvneubMA1tPLqQ==",
           "dev": true,
           "requires": {
-            "bpk-component-icon": "^3.31.5",
-            "bpk-mixins": "^17.24.5",
+            "bpk-component-icon": "^3.31.4",
+            "bpk-mixins": "^17.24.4",
             "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-component-icon": {
-          "version": "3.31.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.5",
-            "bpk-react-utils": "^2.7.9",
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5",
             "prop-types": "^15.6.2"
           }
         },
         "bpk-component-link": {
-          "version": "1.2.76",
-          "bundled": true,
+          "version": "1.2.75",
+          "resolved": "https://registry.npmjs.org/bpk-component-link/-/bpk-component-link-1.2.75.tgz",
+          "integrity": "sha512-qoosptvwz8ZjxRt2WvoERb2E71zrBhs5+USNjy6FtDl+cXndmMOsINB1JiAmMB9TO6PgUZJkj7FBN7Vm7rZ+bQ==",
           "dev": true,
           "requires": {
-            "bpk-mixins": "^17.24.5",
+            "bpk-mixins": "^17.24.4",
             "bpk-react-utils": "^2.7.9",
             "prop-types": "^15.6.2"
           }
         },
         "bpk-component-text": {
-          "version": "1.1.7",
-          "bundled": true,
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/bpk-component-text/-/bpk-component-text-1.1.6.tgz",
+          "integrity": "sha512-U4wp5+Fz1Rd9LeJphQRKwKx2ekIbzGj0SFdvjDkVOkG120YVtVb4YQN/3xEl/zb7Csku5HLvkJIJK4C+wR22nQ==",
           "dev": true,
           "requires": {
-            "bpk-mixins": "^17.24.5",
+            "bpk-mixins": "^17.24.4",
             "bpk-react-utils": "^2.7.9",
             "prop-types": "^15.6.2"
           }
         },
         "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
+          "version": "17.24.4",
+          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
+          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
+            "bpk-svgs": "^6.9.2",
+            "bpk-tokens": "^27.6.4"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
+          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
             "prop-types": "^15.6.2",
             "react-transition-group": "^2.5.3",
             "recompose": "^0.30.0"
-          }
-        },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
           }
         }
       }
@@ -4743,17 +4098,19 @@
       },
       "dependencies": {
         "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
+          "version": "17.24.4",
+          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
+          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
+            "bpk-svgs": "^6.9.2",
+            "bpk-tokens": "^27.6.4"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
+          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
@@ -4762,17 +4119,25 @@
             "recompose": "^0.30.0"
           }
         },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
         "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
+          "version": "27.6.4",
+          "resolved": "https://registry.npmjs.org/bpk-tokens/-/bpk-tokens-27.6.4.tgz",
+          "integrity": "sha512-/7BXdfw5Ft2UxkpLlme4x2TXoTEtITeJX1IzxqdgKZF0+fb+WT4SywoO0g9iM/nfQ1893ZEdNkG25u49v43dsQ==",
           "dev": true,
           "requires": {
             "color": "^3.0.0"
+          },
+          "dependencies": {
+            "color": {
+              "version": "3.1.2",
+              "resolved": "https://registry.npmjs.org/color/-/color-3.1.2.tgz",
+              "integrity": "sha512-vXTJhHebByxZn3lDvDJYw4lR5+uB3vuoHsuYA5AKuxRVn5wzzIfQKGLBmgdVRHKTJYeK5rvJcHnrd0Li49CFpg==",
+              "dev": true,
+              "requires": {
+                "color-convert": "^1.9.1",
+                "color-string": "^1.5.2"
+              }
+            }
           }
         }
       }
@@ -4791,38 +4156,42 @@
       },
       "dependencies": {
         "bpk-component-button": {
-          "version": "2.4.2",
-          "bundled": true,
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/bpk-component-button/-/bpk-component-button-2.4.1.tgz",
+          "integrity": "sha512-4jJ5wxgquUUVGHpblXf0yWlpVFNtmDo0DjLMkGL5U4HxFIgc0XZp911KjIzUVeCh+3eGASeAthQgLCruQghzOg==",
           "dev": true,
           "requires": {
-            "bpk-mixins": "^17.24.5",
+            "bpk-mixins": "^17.24.4",
             "prop-types": "^15.6.2"
           }
         },
         "bpk-component-icon": {
-          "version": "3.31.5",
-          "bundled": true,
+          "version": "3.31.4",
+          "resolved": "https://registry.npmjs.org/bpk-component-icon/-/bpk-component-icon-3.31.4.tgz",
+          "integrity": "sha512-DAiwhBYyyFmy2jonUFxEtxLpj2RlN17EDgd1zwZGpjfIhryyA+vL4XlSr8EkfPjZ6z+I6NWwbfmEUqDZgrn7Ag==",
           "dev": true,
           "requires": {
-            "bpk-mixins": "^17.24.5",
+            "bpk-mixins": "^17.24.4",
             "bpk-react-utils": "^2.7.9",
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5",
+            "bpk-svgs": "^6.9.2",
+            "bpk-tokens": "^27.6.4",
             "prop-types": "^15.6.2"
           }
         },
         "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
+          "version": "17.24.4",
+          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
+          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
+            "bpk-svgs": "^6.9.2",
+            "bpk-tokens": "^27.6.4"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
+          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
@@ -4831,17 +4200,25 @@
             "recompose": "^0.30.0"
           }
         },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
         "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
+          "version": "27.6.4",
+          "resolved": "https://registry.npmjs.org/bpk-tokens/-/bpk-tokens-27.6.4.tgz",
+          "integrity": "sha512-/7BXdfw5Ft2UxkpLlme4x2TXoTEtITeJX1IzxqdgKZF0+fb+WT4SywoO0g9iM/nfQ1893ZEdNkG25u49v43dsQ==",
           "dev": true,
           "requires": {
             "color": "^3.0.0"
+          },
+          "dependencies": {
+            "color": {
+              "version": "3.1.2",
+              "resolved": "https://registry.npmjs.org/color/-/color-3.1.2.tgz",
+              "integrity": "sha512-vXTJhHebByxZn3lDvDJYw4lR5+uB3vuoHsuYA5AKuxRVn5wzzIfQKGLBmgdVRHKTJYeK5rvJcHnrd0Li49CFpg==",
+              "dev": true,
+              "requires": {
+                "color-convert": "^1.9.1",
+                "color-string": "^1.5.2"
+              }
+            }
           }
         }
       }
@@ -4857,45 +4234,35 @@
       },
       "dependencies": {
         "bpk-component-button": {
-          "version": "2.4.2",
-          "bundled": true,
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/bpk-component-button/-/bpk-component-button-2.4.1.tgz",
+          "integrity": "sha512-4jJ5wxgquUUVGHpblXf0yWlpVFNtmDo0DjLMkGL5U4HxFIgc0XZp911KjIzUVeCh+3eGASeAthQgLCruQghzOg==",
           "dev": true,
           "requires": {
-            "bpk-mixins": "^17.24.5",
+            "bpk-mixins": "^17.24.4",
             "prop-types": "^15.6.2"
           }
         },
         "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
+          "version": "17.24.4",
+          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
+          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
+            "bpk-svgs": "^6.9.2",
+            "bpk-tokens": "^27.6.4"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
+          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
             "prop-types": "^15.6.2",
             "react-transition-group": "^2.5.3",
             "recompose": "^0.30.0"
-          }
-        },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
           }
         }
       }
@@ -4910,36 +4277,25 @@
       },
       "dependencies": {
         "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
+          "version": "17.24.4",
+          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
+          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
+            "bpk-svgs": "^6.9.2",
+            "bpk-tokens": "^27.6.4"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
+          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
             "prop-types": "^15.6.2",
             "react-transition-group": "^2.5.3",
             "recompose": "^0.30.0"
-          }
-        },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
           }
         }
       }
@@ -4958,71 +4314,65 @@
         "prop-types": "^15.6.2"
       },
       "dependencies": {
-        "bpk-component-icon": {
-          "version": "3.31.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.5",
-            "bpk-react-utils": "^2.7.9",
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5",
-            "prop-types": "^15.6.2"
-          }
-        },
         "bpk-component-input": {
-          "version": "4.1.27",
-          "bundled": true,
+          "version": "4.1.26",
+          "resolved": "https://registry.npmjs.org/bpk-component-input/-/bpk-component-input-4.1.26.tgz",
+          "integrity": "sha512-+5P8u4+tmf+pABR9fhqDvMcVDaThFZgiEk9yPOcv0m9rgPZMzWXxOcEpN7Wzr2fdW6P/kCAtFA0jwUKtuzEyWQ==",
           "dev": true,
           "requires": {
-            "bpk-component-icon": "^3.31.5",
-            "bpk-mixins": "^17.24.5",
+            "bpk-component-icon": "^3.31.4",
+            "bpk-mixins": "^17.24.4",
             "bpk-react-utils": "^2.7.9",
             "prop-types": "^15.6.2"
           }
         },
         "bpk-component-label": {
-          "version": "3.2.145",
-          "bundled": true,
+          "version": "3.2.144",
+          "resolved": "https://registry.npmjs.org/bpk-component-label/-/bpk-component-label-3.2.144.tgz",
+          "integrity": "sha512-78mIbPwaeOwidu76SlPVo4fJG6d7kfSQ2JGlvZ4yU70it793xmj/ll0E2+PcAaAWoeNTVwreQmctg/RkwgNTRQ==",
           "dev": true,
           "requires": {
-            "bpk-mixins": "^17.24.5",
+            "bpk-mixins": "^17.24.4",
             "bpk-react-utils": "^2.7.9",
             "prop-types": "^15.6.2"
           }
         },
         "bpk-component-select": {
-          "version": "2.3.8",
-          "bundled": true,
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/bpk-component-select/-/bpk-component-select-2.3.7.tgz",
+          "integrity": "sha512-5A3duQQ58GmdgHfI8GCvbMA8b8IzyUh+b+7mRQVR0NBCqY2HUL1rrjly95ejfZx1OhUWfEwwYU3fAOFgpj6o3A==",
           "dev": true,
           "requires": {
-            "bpk-mixins": "^17.24.5",
+            "bpk-mixins": "^17.24.4",
             "bpk-react-utils": "^2.7.9",
             "prop-types": "^15.6.2"
           }
         },
         "bpk-component-text": {
-          "version": "1.1.7",
-          "bundled": true,
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/bpk-component-text/-/bpk-component-text-1.1.6.tgz",
+          "integrity": "sha512-U4wp5+Fz1Rd9LeJphQRKwKx2ekIbzGj0SFdvjDkVOkG120YVtVb4YQN/3xEl/zb7Csku5HLvkJIJK4C+wR22nQ==",
           "dev": true,
           "requires": {
-            "bpk-mixins": "^17.24.5",
+            "bpk-mixins": "^17.24.4",
             "bpk-react-utils": "^2.7.9",
             "prop-types": "^15.6.2"
           }
         },
         "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
+          "version": "17.24.4",
+          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
+          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
+            "bpk-svgs": "^6.9.2",
+            "bpk-tokens": "^27.6.4"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
+          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
@@ -5031,17 +4381,25 @@
             "recompose": "^0.30.0"
           }
         },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
         "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
+          "version": "27.6.4",
+          "resolved": "https://registry.npmjs.org/bpk-tokens/-/bpk-tokens-27.6.4.tgz",
+          "integrity": "sha512-/7BXdfw5Ft2UxkpLlme4x2TXoTEtITeJX1IzxqdgKZF0+fb+WT4SywoO0g9iM/nfQ1893ZEdNkG25u49v43dsQ==",
           "dev": true,
           "requires": {
             "color": "^3.0.0"
+          },
+          "dependencies": {
+            "color": {
+              "version": "3.1.2",
+              "resolved": "https://registry.npmjs.org/color/-/color-3.1.2.tgz",
+              "integrity": "sha512-vXTJhHebByxZn3lDvDJYw4lR5+uB3vuoHsuYA5AKuxRVn5wzzIfQKGLBmgdVRHKTJYeK5rvJcHnrd0Li49CFpg==",
+              "dev": true,
+              "requires": {
+                "color-convert": "^1.9.1",
+                "color-string": "^1.5.2"
+              }
+            }
           }
         }
       }
@@ -5062,79 +4420,59 @@
       },
       "dependencies": {
         "bpk-component-close-button": {
-          "version": "1.0.142",
-          "bundled": true,
+          "version": "1.0.141",
+          "resolved": "https://registry.npmjs.org/bpk-component-close-button/-/bpk-component-close-button-1.0.141.tgz",
+          "integrity": "sha512-Yd2kQnwuEQ3Myoqk2z/NDVIxB3YebCZrtgFJlQ/C6otp3sH3lbWLg4INREQqAyK1ZU5GK96qhvneubMA1tPLqQ==",
           "dev": true,
           "requires": {
-            "bpk-component-icon": "^3.31.5",
-            "bpk-mixins": "^17.24.5",
+            "bpk-component-icon": "^3.31.4",
+            "bpk-mixins": "^17.24.4",
             "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-component-icon": {
-          "version": "3.31.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.5",
-            "bpk-react-utils": "^2.7.9",
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5",
             "prop-types": "^15.6.2"
           }
         },
         "bpk-component-link": {
-          "version": "1.2.76",
-          "bundled": true,
+          "version": "1.2.75",
+          "resolved": "https://registry.npmjs.org/bpk-component-link/-/bpk-component-link-1.2.75.tgz",
+          "integrity": "sha512-qoosptvwz8ZjxRt2WvoERb2E71zrBhs5+USNjy6FtDl+cXndmMOsINB1JiAmMB9TO6PgUZJkj7FBN7Vm7rZ+bQ==",
           "dev": true,
           "requires": {
-            "bpk-mixins": "^17.24.5",
+            "bpk-mixins": "^17.24.4",
             "bpk-react-utils": "^2.7.9",
             "prop-types": "^15.6.2"
           }
         },
         "bpk-component-text": {
-          "version": "1.1.7",
-          "bundled": true,
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/bpk-component-text/-/bpk-component-text-1.1.6.tgz",
+          "integrity": "sha512-U4wp5+Fz1Rd9LeJphQRKwKx2ekIbzGj0SFdvjDkVOkG120YVtVb4YQN/3xEl/zb7Csku5HLvkJIJK4C+wR22nQ==",
           "dev": true,
           "requires": {
-            "bpk-mixins": "^17.24.5",
+            "bpk-mixins": "^17.24.4",
             "bpk-react-utils": "^2.7.9",
             "prop-types": "^15.6.2"
           }
         },
         "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
+          "version": "17.24.4",
+          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
+          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
+            "bpk-svgs": "^6.9.2",
+            "bpk-tokens": "^27.6.4"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
+          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
             "prop-types": "^15.6.2",
             "react-transition-group": "^2.5.3",
             "recompose": "^0.30.0"
-          }
-        },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
           }
         }
       }
@@ -5151,17 +4489,19 @@
       },
       "dependencies": {
         "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
+          "version": "17.24.4",
+          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
+          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
+            "bpk-svgs": "^6.9.2",
+            "bpk-tokens": "^27.6.4"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
+          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
@@ -5170,17 +4510,25 @@
             "recompose": "^0.30.0"
           }
         },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
         "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
+          "version": "27.6.4",
+          "resolved": "https://registry.npmjs.org/bpk-tokens/-/bpk-tokens-27.6.4.tgz",
+          "integrity": "sha512-/7BXdfw5Ft2UxkpLlme4x2TXoTEtITeJX1IzxqdgKZF0+fb+WT4SywoO0g9iM/nfQ1893ZEdNkG25u49v43dsQ==",
           "dev": true,
           "requires": {
             "color": "^3.0.0"
+          },
+          "dependencies": {
+            "color": {
+              "version": "3.1.2",
+              "resolved": "https://registry.npmjs.org/color/-/color-3.1.2.tgz",
+              "integrity": "sha512-vXTJhHebByxZn3lDvDJYw4lR5+uB3vuoHsuYA5AKuxRVn5wzzIfQKGLBmgdVRHKTJYeK5rvJcHnrd0Li49CFpg==",
+              "dev": true,
+              "requires": {
+                "color-convert": "^1.9.1",
+                "color-string": "^1.5.2"
+              }
+            }
           }
         }
       }
@@ -5195,36 +4543,25 @@
       },
       "dependencies": {
         "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
+          "version": "17.24.4",
+          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
+          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
+            "bpk-svgs": "^6.9.2",
+            "bpk-tokens": "^27.6.4"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
+          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
             "prop-types": "^15.6.2",
             "react-transition-group": "^2.5.3",
             "recompose": "^0.30.0"
-          }
-        },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
           }
         }
       }
@@ -5239,36 +4576,25 @@
       },
       "dependencies": {
         "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
+          "version": "17.24.4",
+          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
+          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
+            "bpk-svgs": "^6.9.2",
+            "bpk-tokens": "^27.6.4"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
+          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
             "prop-types": "^15.6.2",
             "react-transition-group": "^2.5.3",
             "recompose": "^0.30.0"
-          }
-        },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
           }
         }
       }
@@ -5283,46 +4609,26 @@
       },
       "dependencies": {
         "bpk-component-link": {
-          "version": "1.2.76",
-          "bundled": true,
+          "version": "1.2.75",
+          "resolved": "https://registry.npmjs.org/bpk-component-link/-/bpk-component-link-1.2.75.tgz",
+          "integrity": "sha512-qoosptvwz8ZjxRt2WvoERb2E71zrBhs5+USNjy6FtDl+cXndmMOsINB1JiAmMB9TO6PgUZJkj7FBN7Vm7rZ+bQ==",
           "dev": true,
           "requires": {
-            "bpk-mixins": "^17.24.5",
+            "bpk-mixins": "^17.24.4",
             "bpk-react-utils": "^2.7.9",
             "prop-types": "^15.6.2"
           }
         },
-        "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
-          }
-        },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
+          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
             "prop-types": "^15.6.2",
             "react-transition-group": "^2.5.3",
             "recompose": "^0.30.0"
-          }
-        },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
           }
         }
       }
@@ -5340,82 +4646,51 @@
       },
       "dependencies": {
         "bpk-component-calendar": {
-          "version": "5.0.27",
-          "bundled": true,
+          "version": "5.0.26",
+          "resolved": "https://registry.npmjs.org/bpk-component-calendar/-/bpk-component-calendar-5.0.26.tgz",
+          "integrity": "sha512-eBo5tfZyTczqZn0EH5Xv1Weahf1S/hR92PpZlJV3GPs7yMrYsf0C+Bxn1edkvCKZu4lX83bl2Er6zfPAgfkUdg==",
           "dev": true,
           "requires": {
-            "bpk-component-icon": "^3.31.5",
-            "bpk-component-select": "^2.3.8",
-            "bpk-mixins": "^17.24.5",
+            "bpk-component-icon": "^3.31.4",
+            "bpk-component-select": "^2.3.7",
+            "bpk-mixins": "^17.24.4",
             "bpk-react-utils": "^2.7.9",
-            "bpk-tokens": "^27.6.5",
+            "bpk-tokens": "^27.6.4",
             "date-fns": "^1.29.0",
             "prop-types": "^15.6.2"
           }
         },
-        "bpk-component-icon": {
-          "version": "3.31.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.5",
-            "bpk-react-utils": "^2.7.9",
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "bpk-component-select": {
-          "version": "2.3.8",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bpk-mixins": "^17.24.5",
-            "bpk-react-utils": "^2.7.9",
-            "prop-types": "^15.6.2"
-          }
-        },
         "bpk-component-text": {
-          "version": "1.1.7",
-          "bundled": true,
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/bpk-component-text/-/bpk-component-text-1.1.6.tgz",
+          "integrity": "sha512-U4wp5+Fz1Rd9LeJphQRKwKx2ekIbzGj0SFdvjDkVOkG120YVtVb4YQN/3xEl/zb7Csku5HLvkJIJK4C+wR22nQ==",
           "dev": true,
           "requires": {
-            "bpk-mixins": "^17.24.5",
+            "bpk-mixins": "^17.24.4",
             "bpk-react-utils": "^2.7.9",
             "prop-types": "^15.6.2"
           }
         },
         "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
+          "version": "17.24.4",
+          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
+          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
+            "bpk-svgs": "^6.9.2",
+            "bpk-tokens": "^27.6.4"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
+          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
             "prop-types": "^15.6.2",
             "react-transition-group": "^2.5.3",
             "recompose": "^0.30.0"
-          }
-        },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
           }
         }
       }
@@ -5433,39 +4708,43 @@
       },
       "dependencies": {
         "bpk-component-icon": {
-          "version": "3.31.5",
-          "bundled": true,
+          "version": "3.31.4",
+          "resolved": "https://registry.npmjs.org/bpk-component-icon/-/bpk-component-icon-3.31.4.tgz",
+          "integrity": "sha512-DAiwhBYyyFmy2jonUFxEtxLpj2RlN17EDgd1zwZGpjfIhryyA+vL4XlSr8EkfPjZ6z+I6NWwbfmEUqDZgrn7Ag==",
           "dev": true,
           "requires": {
-            "bpk-mixins": "^17.24.5",
+            "bpk-mixins": "^17.24.4",
             "bpk-react-utils": "^2.7.9",
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5",
+            "bpk-svgs": "^6.9.2",
+            "bpk-tokens": "^27.6.4",
             "prop-types": "^15.6.2"
           }
         },
         "bpk-component-text": {
-          "version": "1.1.7",
-          "bundled": true,
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/bpk-component-text/-/bpk-component-text-1.1.6.tgz",
+          "integrity": "sha512-U4wp5+Fz1Rd9LeJphQRKwKx2ekIbzGj0SFdvjDkVOkG120YVtVb4YQN/3xEl/zb7Csku5HLvkJIJK4C+wR22nQ==",
           "dev": true,
           "requires": {
-            "bpk-mixins": "^17.24.5",
+            "bpk-mixins": "^17.24.4",
             "bpk-react-utils": "^2.7.9",
             "prop-types": "^15.6.2"
           }
         },
         "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
+          "version": "17.24.4",
+          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
+          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
+            "bpk-svgs": "^6.9.2",
+            "bpk-tokens": "^27.6.4"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
+          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
@@ -5474,17 +4753,25 @@
             "recompose": "^0.30.0"
           }
         },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
         "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
+          "version": "27.6.4",
+          "resolved": "https://registry.npmjs.org/bpk-tokens/-/bpk-tokens-27.6.4.tgz",
+          "integrity": "sha512-/7BXdfw5Ft2UxkpLlme4x2TXoTEtITeJX1IzxqdgKZF0+fb+WT4SywoO0g9iM/nfQ1893ZEdNkG25u49v43dsQ==",
           "dev": true,
           "requires": {
             "color": "^3.0.0"
+          },
+          "dependencies": {
+            "color": {
+              "version": "3.1.2",
+              "resolved": "https://registry.npmjs.org/color/-/color-3.1.2.tgz",
+              "integrity": "sha512-vXTJhHebByxZn3lDvDJYw4lR5+uB3vuoHsuYA5AKuxRVn5wzzIfQKGLBmgdVRHKTJYeK5rvJcHnrd0Li49CFpg==",
+              "dev": true,
+              "requires": {
+                "color-convert": "^1.9.1",
+                "color-string": "^1.5.2"
+              }
+            }
           }
         }
       }
@@ -5499,36 +4786,25 @@
       },
       "dependencies": {
         "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
+          "version": "17.24.4",
+          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
+          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
+            "bpk-svgs": "^6.9.2",
+            "bpk-tokens": "^27.6.4"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
+          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
             "prop-types": "^15.6.2",
             "react-transition-group": "^2.5.3",
             "recompose": "^0.30.0"
-          }
-        },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
           }
         }
       }
@@ -5545,17 +4821,19 @@
       },
       "dependencies": {
         "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
+          "version": "17.24.4",
+          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
+          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
+            "bpk-svgs": "^6.9.2",
+            "bpk-tokens": "^27.6.4"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
+          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
@@ -5564,17 +4842,25 @@
             "recompose": "^0.30.0"
           }
         },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
         "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
+          "version": "27.6.4",
+          "resolved": "https://registry.npmjs.org/bpk-tokens/-/bpk-tokens-27.6.4.tgz",
+          "integrity": "sha512-/7BXdfw5Ft2UxkpLlme4x2TXoTEtITeJX1IzxqdgKZF0+fb+WT4SywoO0g9iM/nfQ1893ZEdNkG25u49v43dsQ==",
           "dev": true,
           "requires": {
             "color": "^3.0.0"
+          },
+          "dependencies": {
+            "color": {
+              "version": "3.1.2",
+              "resolved": "https://registry.npmjs.org/color/-/color-3.1.2.tgz",
+              "integrity": "sha512-vXTJhHebByxZn3lDvDJYw4lR5+uB3vuoHsuYA5AKuxRVn5wzzIfQKGLBmgdVRHKTJYeK5rvJcHnrd0Li49CFpg==",
+              "dev": true,
+              "requires": {
+                "color-convert": "^1.9.1",
+                "color-string": "^1.5.2"
+              }
+            }
           }
         }
       }
@@ -5590,17 +4876,19 @@
       },
       "dependencies": {
         "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
+          "version": "17.24.4",
+          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
+          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
+            "bpk-svgs": "^6.9.2",
+            "bpk-tokens": "^27.6.4"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
+          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
@@ -5610,17 +4898,10 @@
           }
         },
         "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
+          "version": "6.9.2",
+          "resolved": "https://registry.npmjs.org/bpk-svgs/-/bpk-svgs-6.9.2.tgz",
+          "integrity": "sha512-gicoSPPzsQVc0eBUtpn0vGfs/azztQIsA5IDeJaW50G1MHst9C7KBUdegnf64oRwjuVRZbdXsTz5I7h1UqgXKA==",
           "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
-          }
         }
       }
     },
@@ -5635,48 +4916,38 @@
       },
       "dependencies": {
         "bpk-component-icon": {
-          "version": "3.31.5",
-          "bundled": true,
+          "version": "3.31.4",
+          "resolved": "https://registry.npmjs.org/bpk-component-icon/-/bpk-component-icon-3.31.4.tgz",
+          "integrity": "sha512-DAiwhBYyyFmy2jonUFxEtxLpj2RlN17EDgd1zwZGpjfIhryyA+vL4XlSr8EkfPjZ6z+I6NWwbfmEUqDZgrn7Ag==",
           "dev": true,
           "requires": {
-            "bpk-mixins": "^17.24.5",
+            "bpk-mixins": "^17.24.4",
             "bpk-react-utils": "^2.7.9",
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5",
+            "bpk-svgs": "^6.9.2",
+            "bpk-tokens": "^27.6.4",
             "prop-types": "^15.6.2"
           }
         },
         "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
+          "version": "17.24.4",
+          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
+          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
+            "bpk-svgs": "^6.9.2",
+            "bpk-tokens": "^27.6.4"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
+          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
             "prop-types": "^15.6.2",
             "react-transition-group": "^2.5.3",
             "recompose": "^0.30.0"
-          }
-        },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
           }
         }
       }
@@ -5691,36 +4962,25 @@
       },
       "dependencies": {
         "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
+          "version": "17.24.4",
+          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
+          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
+            "bpk-svgs": "^6.9.2",
+            "bpk-tokens": "^27.6.4"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
+          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
             "prop-types": "^15.6.2",
             "react-transition-group": "^2.5.3",
             "recompose": "^0.30.0"
-          }
-        },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
           }
         }
       }
@@ -5735,36 +4995,25 @@
       },
       "dependencies": {
         "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
+          "version": "17.24.4",
+          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
+          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
+            "bpk-svgs": "^6.9.2",
+            "bpk-tokens": "^27.6.4"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
+          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
             "prop-types": "^15.6.2",
             "react-transition-group": "^2.5.3",
             "recompose": "^0.30.0"
-          }
-        },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
           }
         }
       }
@@ -5779,36 +5028,25 @@
       },
       "dependencies": {
         "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
+          "version": "17.24.4",
+          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
+          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
+            "bpk-svgs": "^6.9.2",
+            "bpk-tokens": "^27.6.4"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
+          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
             "prop-types": "^15.6.2",
             "react-transition-group": "^2.5.3",
             "recompose": "^0.30.0"
-          }
-        },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
           }
         }
       }
@@ -5826,37 +5064,41 @@
       },
       "dependencies": {
         "bpk-component-label": {
-          "version": "3.2.145",
-          "bundled": true,
+          "version": "3.2.144",
+          "resolved": "https://registry.npmjs.org/bpk-component-label/-/bpk-component-label-3.2.144.tgz",
+          "integrity": "sha512-78mIbPwaeOwidu76SlPVo4fJG6d7kfSQ2JGlvZ4yU70it793xmj/ll0E2+PcAaAWoeNTVwreQmctg/RkwgNTRQ==",
           "dev": true,
           "requires": {
-            "bpk-mixins": "^17.24.5",
+            "bpk-mixins": "^17.24.4",
             "bpk-react-utils": "^2.7.9",
             "prop-types": "^15.6.2"
           }
         },
         "bpk-component-select": {
-          "version": "2.3.8",
-          "bundled": true,
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/bpk-component-select/-/bpk-component-select-2.3.7.tgz",
+          "integrity": "sha512-5A3duQQ58GmdgHfI8GCvbMA8b8IzyUh+b+7mRQVR0NBCqY2HUL1rrjly95ejfZx1OhUWfEwwYU3fAOFgpj6o3A==",
           "dev": true,
           "requires": {
-            "bpk-mixins": "^17.24.5",
+            "bpk-mixins": "^17.24.4",
             "bpk-react-utils": "^2.7.9",
             "prop-types": "^15.6.2"
           }
         },
         "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
+          "version": "17.24.4",
+          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
+          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
+            "bpk-svgs": "^6.9.2",
+            "bpk-tokens": "^27.6.4"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
+          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
@@ -5865,17 +5107,25 @@
             "recompose": "^0.30.0"
           }
         },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
         "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
+          "version": "27.6.4",
+          "resolved": "https://registry.npmjs.org/bpk-tokens/-/bpk-tokens-27.6.4.tgz",
+          "integrity": "sha512-/7BXdfw5Ft2UxkpLlme4x2TXoTEtITeJX1IzxqdgKZF0+fb+WT4SywoO0g9iM/nfQ1893ZEdNkG25u49v43dsQ==",
           "dev": true,
           "requires": {
             "color": "^3.0.0"
+          },
+          "dependencies": {
+            "color": {
+              "version": "3.1.2",
+              "resolved": "https://registry.npmjs.org/color/-/color-3.1.2.tgz",
+              "integrity": "sha512-vXTJhHebByxZn3lDvDJYw4lR5+uB3vuoHsuYA5AKuxRVn5wzzIfQKGLBmgdVRHKTJYeK5rvJcHnrd0Li49CFpg==",
+              "dev": true,
+              "requires": {
+                "color-convert": "^1.9.1",
+                "color-string": "^1.5.2"
+              }
+            }
           }
         }
       }
@@ -5890,36 +5140,25 @@
       },
       "dependencies": {
         "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
+          "version": "17.24.4",
+          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
+          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
+            "bpk-svgs": "^6.9.2",
+            "bpk-tokens": "^27.6.4"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
+          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
             "prop-types": "^15.6.2",
             "react-transition-group": "^2.5.3",
             "recompose": "^0.30.0"
-          }
-        },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
           }
         }
       }
@@ -5935,36 +5174,25 @@
       },
       "dependencies": {
         "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
+          "version": "17.24.4",
+          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
+          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
+            "bpk-svgs": "^6.9.2",
+            "bpk-tokens": "^27.6.4"
           }
         },
         "bpk-react-utils": {
           "version": "2.7.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
+          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
           "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
             "prop-types": "^15.6.2",
             "react-transition-group": "^2.5.3",
             "recompose": "^0.30.0"
-          }
-        },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
           }
         }
       }
@@ -5978,16 +5206,30 @@
       },
       "dependencies": {
         "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
+          "version": "6.9.2",
+          "resolved": "https://registry.npmjs.org/bpk-svgs/-/bpk-svgs-6.9.2.tgz",
+          "integrity": "sha512-gicoSPPzsQVc0eBUtpn0vGfs/azztQIsA5IDeJaW50G1MHst9C7KBUdegnf64oRwjuVRZbdXsTz5I7h1UqgXKA==",
           "dev": true
         },
         "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
+          "version": "27.6.4",
+          "resolved": "https://registry.npmjs.org/bpk-tokens/-/bpk-tokens-27.6.4.tgz",
+          "integrity": "sha512-/7BXdfw5Ft2UxkpLlme4x2TXoTEtITeJX1IzxqdgKZF0+fb+WT4SywoO0g9iM/nfQ1893ZEdNkG25u49v43dsQ==",
           "dev": true,
           "requires": {
             "color": "^3.0.0"
+          },
+          "dependencies": {
+            "color": {
+              "version": "3.1.2",
+              "resolved": "https://registry.npmjs.org/color/-/color-3.1.2.tgz",
+              "integrity": "sha512-vXTJhHebByxZn3lDvDJYw4lR5+uB3vuoHsuYA5AKuxRVn5wzzIfQKGLBmgdVRHKTJYeK5rvJcHnrd0Li49CFpg==",
+              "dev": true,
+              "requires": {
+                "color-convert": "^1.9.1",
+                "color-string": "^1.5.2"
+              }
+            }
           }
         }
       }
@@ -6002,57 +5244,6 @@
         "recompose": "^0.30.0"
       }
     },
-    "bpk-scrim-utils": {
-      "version": "3.2.76",
-      "resolved": "https://registry.npmjs.org/bpk-scrim-utils/-/bpk-scrim-utils-3.2.76.tgz",
-      "integrity": "sha512-aDl5SN+smHgLXYf2IzjOKnmgNlxQVZ8tNR/uxlpzld5Uigl55eBlzJ+IfMVZlMIHmN0esm8xX2qpnEhG0jTkyw==",
-      "dev": true,
-      "requires": {
-        "a11y-focus-scope": "^1.1.3",
-        "a11y-focus-store": "^1.0.0",
-        "bpk-mixins": "^17.24.5",
-        "bpk-react-utils": "^2.7.9"
-      },
-      "dependencies": {
-        "bpk-mixins": {
-          "version": "17.24.5",
-          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.5.tgz",
-          "integrity": "sha512-qxpqlGH3V1+s1mOG5J6/wA5Qg9b4UHYfmDXBYKyf/A2cJZSZZgzI+JiTaEAuyluz9xF2s2hYWskrjttyc8Leeg==",
-          "dev": true,
-          "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
-          }
-        },
-        "bpk-react-utils": {
-          "version": "2.7.9",
-          "resolved": "https://registry.npmjs.org/bpk-react-utils/-/bpk-react-utils-2.7.9.tgz",
-          "integrity": "sha512-mUcXwAmlbi3NfiIpJEQvxj8mJNu0HhGxfeSgCsrh0AICgyZqZwUf59b2+HODmEKgwR9BGrnELxC0n6ZZfXE2NA==",
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-transition-group": "^2.5.3",
-            "recompose": "^0.30.0"
-          }
-        },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "resolved": "https://registry.npmjs.org/bpk-svgs/-/bpk-svgs-6.9.3.tgz",
-          "integrity": "sha512-OV/VTXqq2NmnJqqToY74RoLAapa+LPEHS/lI0gYnJYb/CUx1vBAp19qerRQfWb8ca6bNbpIol6YHIktSR83frg==",
-          "dev": true
-        },
-        "bpk-tokens": {
-          "version": "27.6.5",
-          "resolved": "https://registry.npmjs.org/bpk-tokens/-/bpk-tokens-27.6.5.tgz",
-          "integrity": "sha512-wALtOBOSwSkN7t6GI3J3zamynysYD8eD8rwzN4xc7oTqVzKarVxLWi/CPHo5Xa2eByyIwhyGREcAkgKpY5Fr0w==",
-          "dev": true,
-          "requires": {
-            "color": "^3.0.0"
-          }
-        }
-      }
-    },
     "bpk-stylesheets": {
       "version": "file:backpack/packages/bpk-stylesheets",
       "dev": true,
@@ -6063,25 +5254,34 @@
       },
       "dependencies": {
         "bpk-mixins": {
-          "version": "17.24.5",
-          "bundled": true,
+          "version": "17.24.4",
+          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-17.24.4.tgz",
+          "integrity": "sha512-EbtdvwpqoDlSVOZj6ovCBzykuC3wgBmFqeCSiPZR4Flr+P4OiFbUiaz+QhfMuL25D7hgtrrENbtcHCRi5Sl0HQ==",
           "dev": true,
           "requires": {
-            "bpk-svgs": "^6.9.3",
-            "bpk-tokens": "^27.6.5"
+            "bpk-svgs": "^6.9.2",
+            "bpk-tokens": "^27.6.4"
           }
         },
-        "bpk-svgs": {
-          "version": "6.9.3",
-          "bundled": true,
-          "dev": true
-        },
         "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
+          "version": "27.6.4",
+          "resolved": "https://registry.npmjs.org/bpk-tokens/-/bpk-tokens-27.6.4.tgz",
+          "integrity": "sha512-/7BXdfw5Ft2UxkpLlme4x2TXoTEtITeJX1IzxqdgKZF0+fb+WT4SywoO0g9iM/nfQ1893ZEdNkG25u49v43dsQ==",
           "dev": true,
           "requires": {
             "color": "^3.0.0"
+          },
+          "dependencies": {
+            "color": {
+              "version": "3.1.2",
+              "resolved": "https://registry.npmjs.org/color/-/color-3.1.2.tgz",
+              "integrity": "sha512-vXTJhHebByxZn3lDvDJYw4lR5+uB3vuoHsuYA5AKuxRVn5wzzIfQKGLBmgdVRHKTJYeK5rvJcHnrd0Li49CFpg==",
+              "dev": true,
+              "requires": {
+                "color-convert": "^1.9.1",
+                "color-string": "^1.5.2"
+              }
+            }
           }
         }
       }
@@ -6099,11 +5299,24 @@
       },
       "dependencies": {
         "bpk-tokens": {
-          "version": "27.6.5",
-          "bundled": true,
+          "version": "27.6.4",
+          "resolved": "https://registry.npmjs.org/bpk-tokens/-/bpk-tokens-27.6.4.tgz",
+          "integrity": "sha512-/7BXdfw5Ft2UxkpLlme4x2TXoTEtITeJX1IzxqdgKZF0+fb+WT4SywoO0g9iM/nfQ1893ZEdNkG25u49v43dsQ==",
           "dev": true,
           "requires": {
             "color": "^3.0.0"
+          },
+          "dependencies": {
+            "color": {
+              "version": "3.1.2",
+              "resolved": "https://registry.npmjs.org/color/-/color-3.1.2.tgz",
+              "integrity": "sha512-vXTJhHebByxZn3lDvDJYw4lR5+uB3vuoHsuYA5AKuxRVn5wzzIfQKGLBmgdVRHKTJYeK5rvJcHnrd0Li49CFpg==",
+              "dev": true,
+              "requires": {
+                "color-convert": "^1.9.1",
+                "color-string": "^1.5.2"
+              }
+            }
           }
         }
       }
@@ -6113,6 +5326,28 @@
       "dev": true,
       "requires": {
         "color": "^3.0.0"
+      },
+      "dependencies": {
+        "color": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/color/-/color-3.1.1.tgz",
+          "integrity": "sha512-PvUltIXRjehRKPSy89VnDWFKY58xyhTLyxIg21vwQBI6qLwZNPmC8k3C1uytIgFKEpOIzN4y32iPm8231zFHIg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.1",
+            "color-string": "^1.5.2"
+          }
+        },
+        "color-string": {
+          "version": "1.5.3",
+          "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.3.tgz",
+          "integrity": "sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==",
+          "dev": true,
+          "requires": {
+            "color-name": "^1.0.0",
+            "simple-swizzle": "^0.2.2"
+          }
+        }
       }
     },
     "brace-expansion": {
@@ -6123,17 +5358,43 @@
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
+      },
+      "dependencies": {
+        "balanced-match": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+          "dev": true
+        }
       }
     },
     "braces": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-      "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+      "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
       "dev": true,
       "requires": {
-        "expand-range": "^1.8.1",
-        "preserve": "^0.2.0",
-        "repeat-element": "^1.1.2"
+        "arr-flatten": "^1.1.0",
+        "array-unique": "^0.3.2",
+        "extend-shallow": "^2.0.1",
+        "fill-range": "^4.0.0",
+        "isobject": "^3.0.1",
+        "repeat-element": "^1.1.2",
+        "snapdragon": "^0.8.1",
+        "snapdragon-node": "^2.0.1",
+        "split-string": "^3.0.2",
+        "to-regex": "^3.0.1"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
       }
     },
     "brorand": {
@@ -6230,21 +5491,10 @@
         "pako": "~1.0.5"
       }
     },
-    "browserslist": {
-      "version": "4.6.6",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.6.6.tgz",
-      "integrity": "sha512-D2Nk3W9JL9Fp/gIcWei8LrERCS+eXu9AM5cfXA8WEZ84lFks+ARnZ0q/R69m2SV3Wjma83QDDPxsNKXUwdIsyA==",
-      "dev": true,
-      "requires": {
-        "caniuse-lite": "^1.0.30000984",
-        "electron-to-chromium": "^1.3.191",
-        "node-releases": "^1.1.25"
-      }
-    },
     "bser": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.0.tgz",
-      "integrity": "sha512-8zsjWrQkkBoLK6uxASk1nJ2SKv97ltiGDo6A3wA0/yRPz+CwmEyDo0hUrhIuukG2JHpAl3bvFIixw2/3Hi0DOg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/bser/-/bser-2.0.0.tgz",
+      "integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
       "dev": true,
       "requires": {
         "node-int64": "^0.4.0"
@@ -6289,6 +5539,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.1.tgz",
       "integrity": "sha1-qfuAbOgUXVQoUQznLyeLs2OmOL8=",
+      "dev": true
+    },
+    "buffer-shims": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+      "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
       "dev": true
     },
     "buffer-xor": {
@@ -6340,6 +5596,14 @@
         "ssri": "^5.2.4",
         "unique-filename": "^1.1.0",
         "y18n": "^4.0.0"
+      },
+      "dependencies": {
+        "y18n": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+          "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+          "dev": true
+        }
       }
     },
     "cache-base": {
@@ -6357,43 +5621,6 @@
         "to-object-path": "^0.3.0",
         "union-value": "^1.0.0",
         "unset-value": "^1.0.0"
-      },
-      "dependencies": {
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
-        }
-      }
-    },
-    "cacheable-request": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-2.1.4.tgz",
-      "integrity": "sha1-DYCIAbY0KtM8kd+dC0TcCbkeXD0=",
-      "dev": true,
-      "requires": {
-        "clone-response": "1.0.2",
-        "get-stream": "3.0.0",
-        "http-cache-semantics": "3.8.1",
-        "keyv": "3.0.0",
-        "lowercase-keys": "1.0.0",
-        "normalize-url": "2.0.1",
-        "responselike": "1.0.2"
-      },
-      "dependencies": {
-        "get-stream": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-          "dev": true
-        },
-        "lowercase-keys": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
-          "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY=",
-          "dev": true
-        }
       }
     },
     "call-me-maybe": {
@@ -6409,14 +5636,6 @@
       "dev": true,
       "requires": {
         "callsites": "^2.0.0"
-      },
-      "dependencies": {
-        "callsites": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
-          "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
-          "dev": true
-        }
       }
     },
     "caller-path": {
@@ -6429,15 +5648,15 @@
       }
     },
     "callsites": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+      "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
       "dev": true
     },
     "camelcase": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-      "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+      "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
       "dev": true
     },
     "camelcase-keys": {
@@ -6465,15 +5684,15 @@
       "dev": true
     },
     "caniuse-db": {
-      "version": "1.0.30000985",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000985.tgz",
-      "integrity": "sha512-1m3CC9+dYNh/FHd0V1/McOB73CxjmzzrcXi360x8mKoApUY8QIOYXg4bU5QeJmlenn++20GBI38EKw6qQpJ3kQ==",
+      "version": "1.0.30000966",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000966.tgz",
+      "integrity": "sha512-PDXDry9EACH5Ld4s1JZMKR9BOnhO5qX/2Saqq9SeQhOSJbauFDwUzSefVyDuXN3trnR9MOicR9apPKcb1sihEA==",
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30000985",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000985.tgz",
-      "integrity": "sha512-1ngiwkgqAYPG0JSSUp3PUDGPKKY59EK7NrGGX+VOxaKCNzRbNc7uXMny+c3VJfZxtoK3wSImTvG9T9sXiTw2+w==",
+      "version": "1.0.30000966",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000966.tgz",
+      "integrity": "sha512-qqLQ/uYrpZmFhPY96VuBkMEo8NhVFBZ9y/Bh+KnvGzGJ5I8hvpIaWlF2pw5gqe4PLAL+ZjsPgMOvoXSpX21Keg==",
       "dev": true
     },
     "capture-exit": {
@@ -6492,9 +5711,9 @@
       "dev": true
     },
     "ccount": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/ccount/-/ccount-1.0.4.tgz",
-      "integrity": "sha512-fpZ81yYfzentuieinmGnphk0pLkOTMm6MZdVqwd77ROvhko6iujLNGrHH5E7utq3ygWklwfmwuG+A7P+NpqT6w==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-1.0.3.tgz",
+      "integrity": "sha512-Jt9tIBkRc9POUof7QA/VwWd+58fKkEEfI+/t1/eOlxKM7ZhrczNzMFefge7Ai+39y1pR/pP6cI19guHy3FSLmw==",
       "dev": true
     },
     "center-align": {
@@ -6534,9 +5753,9 @@
       "dev": true
     },
     "character-entities": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.3.tgz",
-      "integrity": "sha512-yB4oYSAa9yLcGyTbB4ItFwHw43QHdH129IJ5R+WvxOkWlyFnR5FAaBNnUq4mcxsTVZGh28bHoeTHMKXH1wZf3w==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.2.tgz",
+      "integrity": "sha512-sMoHX6/nBiy3KKfC78dnEalnpn0Az0oSNvqUWYTtYrhRI5iUIYsROU48G+E+kMFQzqXaJ8kHJZ85n7y6/PHgwQ==",
       "dev": true
     },
     "character-entities-html4": {
@@ -6546,21 +5765,15 @@
       "dev": true
     },
     "character-entities-legacy": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.3.tgz",
-      "integrity": "sha512-YAxUpPoPwxYFsslbdKkhrGnXAtXoHNgYjlBM3WMXkWGTl5RsY3QmOyhwAgL8Nxm9l5LBThXGawxKPn68y6/fww==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.2.tgz",
+      "integrity": "sha512-9NB2VbXtXYWdXzqrvAHykE/f0QJxzaKIpZ5QzNZrrgQ7Iyxr2vnfS8fCBNVW9nUEZE0lo57nxKRqnzY/dKrwlA==",
       "dev": true
     },
     "character-reference-invalid": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.3.tgz",
-      "integrity": "sha512-VOq6PRzQBam/8Jm6XBGk2fNEnHXAdGd6go0rtd4weAGECBamHDwwCQSOT12TACIYUZegUXnV6xBXqUssijtxIg==",
-      "dev": true
-    },
-    "chardet": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.2.tgz",
+      "integrity": "sha512-7I/xceXfKyUJmSAn/jw8ve/9DyOP7XxufNYLI9Px7CmsKgEUaZLUTax6nZxGQtaoiZCjpu6cHPj20xC/vqRReQ==",
       "dev": true
     },
     "charenc": {
@@ -6584,9 +5797,9 @@
       }
     },
     "chokidar": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.6.tgz",
-      "integrity": "sha512-V2jUo67OKkc6ySiRpJrjlpJKl9kDuG+Xb8VgsGzb+aEouhgS1D0weyPU4lEzdAcsCAvrih2J2BqyXqHWvVLw5g==",
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.5.tgz",
+      "integrity": "sha512-i0TprVWp+Kj4WRPtInjexJ8Q+BqTE909VpH8xVhXrJkoc5QC8VO9TryGOqTr+2hljzc1sC62t22h5tZePodM/A==",
       "dev": true,
       "requires": {
         "anymatch": "^2.0.0",
@@ -6601,117 +5814,12 @@
         "path-is-absolute": "^1.0.0",
         "readdirp": "^2.2.1",
         "upath": "^1.1.1"
-      },
-      "dependencies": {
-        "array-unique": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-          "dev": true
-        },
-        "braces": {
-          "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-          "dev": true,
-          "requires": {
-            "arr-flatten": "^1.1.0",
-            "array-unique": "^0.3.2",
-            "extend-shallow": "^2.0.1",
-            "fill-range": "^4.0.0",
-            "isobject": "^3.0.1",
-            "repeat-element": "^1.1.2",
-            "snapdragon": "^0.8.1",
-            "snapdragon-node": "^2.0.1",
-            "split-string": "^3.0.2",
-            "to-regex": "^3.0.1"
-          }
-        },
-        "fill-range": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-          "dev": true,
-          "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1",
-            "to-regex-range": "^2.1.0"
-          }
-        },
-        "glob-parent": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
-          "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
-          "dev": true,
-          "requires": {
-            "is-glob": "^3.1.0",
-            "path-dirname": "^1.0.0"
-          },
-          "dependencies": {
-            "is-glob": {
-              "version": "3.1.0",
-              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-              "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-              "dev": true,
-              "requires": {
-                "is-extglob": "^2.1.0"
-              }
-            }
-          }
-        },
-        "is-extglob": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-          "dev": true
-        },
-        "is-glob": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
-          "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
-          "dev": true,
-          "requires": {
-            "is-extglob": "^2.1.1"
-          }
-        },
-        "is-number": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "dev": true,
-          "requires": {
-            "kind-of": "^3.0.2"
-          }
-        },
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
-        },
-        "normalize-path": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-          "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-          "dev": true
-        },
-        "to-regex-range": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
-          "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
-          "dev": true,
-          "requires": {
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1"
-          }
-        }
       }
     },
     "chownr": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.2.tgz",
-      "integrity": "sha512-GkfeAQh+QNy3wquu9oIZr6SS5x7wGdSgNQvD10X3r+AZr1Oys22HW8kAmDMvNg2+Dm0TeGaEuO8gFwdBXxwO8A==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
+      "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
       "dev": true
     },
     "ci-info": {
@@ -6756,12 +5864,6 @@
           "requires": {
             "is-descriptor": "^0.1.0"
           }
-        },
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
         }
       }
     },
@@ -6784,31 +5886,11 @@
         "string-width": "^1.0.1"
       },
       "dependencies": {
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true,
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
         "slice-ansi": {
           "version": "0.0.4",
           "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
           "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
           "dev": true
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "dev": true,
-          "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
-          }
         }
       }
     },
@@ -6819,31 +5901,14 @@
       "dev": true
     },
     "cliui": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
-      "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+      "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
       "dev": true,
       "requires": {
-        "string-width": "^2.1.1",
-        "strip-ansi": "^4.0.0",
-        "wrap-ansi": "^2.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^3.0.0"
-          }
-        }
+        "center-align": "^0.1.1",
+        "right-align": "^0.1.1",
+        "wordwrap": "0.0.2"
       }
     },
     "clone-deep": {
@@ -6885,15 +5950,6 @@
         "is-supported-regexp-flag": "^1.0.0"
       }
     },
-    "clone-response": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
-      "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
-      "dev": true,
-      "requires": {
-        "mimic-response": "^1.0.0"
-      }
-    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -6931,16 +5987,6 @@
       "requires": {
         "map-visit": "^1.0.0",
         "object-visit": "^1.0.0"
-      }
-    },
-    "color": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/color/-/color-3.1.2.tgz",
-      "integrity": "sha512-vXTJhHebByxZn3lDvDJYw4lR5+uB3vuoHsuYA5AKuxRVn5wzzIfQKGLBmgdVRHKTJYeK5rvJcHnrd0Li49CFpg==",
-      "dev": true,
-      "requires": {
-        "color-convert": "^1.9.1",
-        "color-string": "^1.5.2"
       }
     },
     "color-convert": {
@@ -7088,9 +6134,9 @@
       "dev": true
     },
     "combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
+      "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
       "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
@@ -7156,12 +6202,6 @@
         "typedarray": "^0.0.6"
       }
     },
-    "confusing-browser-globals": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.7.tgz",
-      "integrity": "sha512-cgHI1azax5ATrZ8rJ+ODDML9Fvu67PimB6aNxBrc/QwSaDaM9eTfIEUHx3bBLJJ82ioSb+/5zfsMCCEJax3ByQ==",
-      "dev": true
-    },
     "connect-history-api-fallback": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz",
@@ -7196,13 +6236,10 @@
       "dev": true
     },
     "content-disposition": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
-      "integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.2"
-      }
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+      "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ=",
+      "dev": true
     },
     "content-type": {
       "version": "1.0.4",
@@ -7226,9 +6263,9 @@
       }
     },
     "cookie": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
-      "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
       "dev": true
     },
     "cookie-signature": {
@@ -7287,21 +6324,6 @@
             "slash": "^1.0.0"
           }
         },
-        "is-extglob": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-          "dev": true
-        },
-        "is-glob": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
-          "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
-          "dev": true,
-          "requires": {
-            "is-extglob": "^2.1.1"
-          }
-        },
         "pify": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
@@ -7311,9 +6333,9 @@
       }
     },
     "core-js": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.1.4.tgz",
-      "integrity": "sha512-YNZN8lt82XIMLnLirj9MhKDFZHalwzzrL9YLt6eb0T5D0EDl4IQ90IGkua8mHbnxNrkj1d8hbdizMc0Qmg1WnQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.0.1.tgz",
+      "integrity": "sha512-sco40rF+2KlE0ROMvydjkrVMMG1vYilP2ALoRXcYR4obqbYIuV3Bg+51GEDW+HF8n7NRA+iaA4qD0nD9lo9mew==",
       "dev": true
     },
     "core-util-is": {
@@ -7332,43 +6354,15 @@
       }
     },
     "cosmiconfig": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
-      "integrity": "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-4.0.0.tgz",
+      "integrity": "sha512-6e5vDdrXZD+t5v0L8CrurPeybg4Fmf+FCSYxXKYVAqLUtyCSbuyqE059d0kDthTNRzKVjL7QMgNpEUlsoYH3iQ==",
       "dev": true,
       "requires": {
-        "import-fresh": "^2.0.0",
         "is-directory": "^0.3.1",
-        "js-yaml": "^3.13.1",
-        "parse-json": "^4.0.0"
-      },
-      "dependencies": {
-        "import-fresh": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
-          "integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
-          "dev": true,
-          "requires": {
-            "caller-path": "^2.0.0",
-            "resolve-from": "^3.0.0"
-          }
-        },
-        "parse-json": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-          "dev": true,
-          "requires": {
-            "error-ex": "^1.3.1",
-            "json-parse-better-errors": "^1.0.1"
-          }
-        },
-        "resolve-from": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-          "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
-          "dev": true
-        }
+        "js-yaml": "^3.9.0",
+        "parse-json": "^4.0.0",
+        "require-from-string": "^2.0.1"
       }
     },
     "create-ecdh": {
@@ -7419,24 +6413,14 @@
       }
     },
     "cross-spawn": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "dev": true,
       "requires": {
-        "nice-try": "^1.0.4",
-        "path-key": "^2.0.1",
-        "semver": "^5.5.0",
+        "lru-cache": "^4.0.1",
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
-          "dev": true
-        }
       }
     },
     "crypt": {
@@ -7464,12 +6448,6 @@
         "randomfill": "^1.0.3"
       }
     },
-    "css-color-names": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.3.tgz",
-      "integrity": "sha1-3gzvFvTYqoIioyDVttfpu62nufY=",
-      "dev": true
-    },
     "css-loader": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-1.0.1.tgz",
@@ -7488,25 +6466,6 @@
         "postcss-modules-values": "^1.3.0",
         "postcss-value-parser": "^3.3.0",
         "source-list-map": "^2.0.0"
-      },
-      "dependencies": {
-        "postcss": {
-          "version": "6.0.23",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.4.1",
-            "source-map": "^0.6.1",
-            "supports-color": "^5.4.0"
-          }
-        },
-        "postcss-value-parser": {
-          "version": "3.3.1",
-          "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-          "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
-          "dev": true
-        }
       }
     },
     "css-mediaquery": {
@@ -7613,19 +6572,6 @@
         "cssesc": "^0.1.0",
         "fastparse": "^1.1.1",
         "regexpu-core": "^1.0.0"
-      },
-      "dependencies": {
-        "regexpu-core": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
-          "integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
-          "dev": true,
-          "requires": {
-            "regenerate": "^1.2.1",
-            "regjsgen": "^0.2.0",
-            "regjsparser": "^0.1.4"
-          }
-        }
       }
     },
     "css-tokenize": {
@@ -7665,12 +6611,12 @@
       }
     },
     "css-tree": {
-      "version": "1.0.0-alpha.33",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.33.tgz",
-      "integrity": "sha512-SPt57bh5nQnpsTBsx/IXbO14sRc9xXu5MtMAVuo0BaQQmyf0NupNPPSoMaqiAF5tDFafYsTkfeH4Q/HCKXkg4w==",
+      "version": "1.0.0-alpha.28",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.28.tgz",
+      "integrity": "sha512-joNNW1gCp3qFFzj4St6zk+Wh/NBv0vM5YbEreZk0SD4S23S+1xBKb6cLDg2uj4P4k/GUMlIm6cKIDqIG+vdt0w==",
       "dev": true,
       "requires": {
-        "mdn-data": "2.0.4",
+        "mdn-data": "~1.1.0",
         "source-map": "^0.5.3"
       },
       "dependencies": {
@@ -7681,6 +6627,12 @@
           "dev": true
         }
       }
+    },
+    "css-url-regex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/css-url-regex/-/css-url-regex-1.1.0.tgz",
+      "integrity": "sha1-g4NCMMyfdMRX3lnuvRVD/uuDt+w=",
+      "dev": true
     },
     "css-what": {
       "version": "2.1.3",
@@ -7713,12 +6665,6 @@
             "source-map": "^0.5.3"
           }
         },
-        "mdn-data": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-1.1.4.tgz",
-          "integrity": "sha512-FSYbp3lyKjyj3E7fMl6rYvUdX0FBXaluGqlFoYESWQlyUTq8R+wp0rkFxoYFqZlHCvsUXGjyJmLQSnXToYhOSA==",
-          "dev": true
-        },
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -7728,9 +6674,9 @@
       }
     },
     "cssom": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
-      "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.6.tgz",
+      "integrity": "sha512-DtUeseGk9/GBW0hl0vVPpU22iHL6YB5BUX7ml1hB+GMpo0NX5G4voX3kdWiMSEguFtcW3Vh3djqNF4aIe6ne0A==",
       "dev": true
     },
     "cssstyle": {
@@ -7764,13 +6710,12 @@
       "dev": true
     },
     "d": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
-      "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+      "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "dev": true,
       "requires": {
-        "es5-ext": "^0.10.50",
-        "type": "^1.0.1"
+        "es5-ext": "^0.10.9"
       }
     },
     "d3-array": {
@@ -7786,9 +6731,9 @@
       "dev": true
     },
     "d3-color": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.2.8.tgz",
-      "integrity": "sha512-yeANXzP37PHk0DbSTMNPhnJD+Nn4G//O5E825bR6fAfHH43hobSBpgB9G9oWVl9+XgUaQ4yCnsX1H+l8DoaL9A==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.2.3.tgz",
+      "integrity": "sha512-x37qq3ChOTLd26hnps36lexMRhNXEtVxZ4B25rL0DVdDsGQIJGB18S7y9XDwlDD6MD/ZBzITCf4JjGMM10TZkw==",
       "dev": true
     },
     "d3-format": {
@@ -7842,9 +6787,9 @@
       }
     },
     "damerau-levenshtein": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.5.tgz",
-      "integrity": "sha512-CBCRqFnpu715iPmw1KrdOrzRqbdFwQTwAWyyyYS42+iAgHCuXZ+/TdMgQkUENPomxEz9z1BEzuQU2Xw0kUuAgA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.4.tgz",
+      "integrity": "sha1-AxkcQyy27qFou3fzpV/9zLiXhRQ=",
       "dev": true
     },
     "danger": {
@@ -7903,6 +6848,12 @@
             "minimist": "^1.2.0"
           }
         },
+        "lodash.keys": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-4.2.0.tgz",
+          "integrity": "sha1-oIYCrBLk+4P5H8H7ejYKTZujUgU=",
+          "dev": true
+        },
         "minimist": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
@@ -7910,15 +6861,15 @@
           "dev": true
         },
         "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
           "dev": true
         },
         "node-fetch": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-          "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.5.0.tgz",
+          "integrity": "sha512-YuZKluhWGJwCcUu4RlZstdAxr8bFfOVHakc1mplwHkk8J+tqM1Y5yraYvIUpeX8aY7+crCwiELJq7Vl0o0LWXw==",
           "dev": true
         }
       }
@@ -7991,9 +6942,9 @@
       "dev": true
     },
     "deep-equal": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.2.tgz",
-      "integrity": "sha1-hLdFiW80xoTpjyzg5Cq69Du6AX0=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
       "dev": true
     },
     "deep-is": {
@@ -8009,6 +6960,17 @@
       "dev": true,
       "requires": {
         "strip-bom": "^2.0.0"
+      },
+      "dependencies": {
+        "strip-bom": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "dev": true,
+          "requires": {
+            "is-utf8": "^0.2.0"
+          }
+        }
       }
     },
     "define-properties": {
@@ -8059,60 +7021,10 @@
             "kind-of": "^6.0.2"
           }
         },
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
-        },
         "kind-of": {
           "version": "6.0.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
           "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-          "dev": true
-        }
-      }
-    },
-    "del": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/del/-/del-4.1.1.tgz",
-      "integrity": "sha512-QwGuEUouP2kVwQenAsOof5Fv8K9t3D8Ca8NxcXKrIpEHjTXK5J2nXLdP+ALI1cgv8wj7KuwBhTwBkOZSJKM5XQ==",
-      "dev": true,
-      "requires": {
-        "@types/glob": "^7.1.1",
-        "globby": "^6.1.0",
-        "is-path-cwd": "^2.0.0",
-        "is-path-in-cwd": "^2.0.0",
-        "p-map": "^2.0.0",
-        "pify": "^4.0.1",
-        "rimraf": "^2.6.3"
-      },
-      "dependencies": {
-        "globby": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
-          "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
-          "dev": true,
-          "requires": {
-            "array-union": "^1.0.1",
-            "glob": "^7.0.3",
-            "object-assign": "^4.0.1",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
-          },
-          "dependencies": {
-            "pify": {
-              "version": "2.3.0",
-              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-              "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-              "dev": true
-            }
-          }
-        },
-        "pify": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
           "dev": true
         }
       }
@@ -8241,9 +7153,9 @@
       }
     },
     "doctrine": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
-      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
       "dev": true,
       "requires": {
         "esutils": "^2.0.2"
@@ -8338,15 +7250,6 @@
           "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
           "dev": true
         },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true,
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
         "isarray": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -8403,17 +7306,6 @@
             "amdefine": ">=0.0.4"
           }
         },
-        "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "dev": true,
-          "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
-          }
-        },
         "string_decoder": {
           "version": "0.10.31",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
@@ -8453,10 +7345,10 @@
             }
           }
         },
-        "y18n": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+        "window-size": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
+          "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY=",
           "dev": true
         },
         "yargs": {
@@ -8594,9 +7486,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.200",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.200.tgz",
-      "integrity": "sha512-PUurrpyDA74MuAjJRD+79ss5BqJlU3mdArRbuu4wO/dt6jc3Ic/6BDmFJxkdwbfq39cHf/XKm2vW98XSvut9Dg==",
+      "version": "1.3.131",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.131.tgz",
+      "integrity": "sha512-NSO4jLeyGLWrT4mzzfYX8vt1MYCoMI5LxSYAjt0H9+LF/14JyiKJSyyjA6AJTxflZlEM5v3QU33F0ohbPMCAPg==",
       "dev": true
     },
     "elegant-spinner": {
@@ -8606,9 +7498,9 @@
       "dev": true
     },
     "elliptic": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.0.tgz",
-      "integrity": "sha512-eFOJTMyCYb7xtE/caJ6JJu+bhi67WCYNbkGSknu20pmM8Ke/bqOfdnZWxyoGN26JgfxTbXrsCkEw4KheCT/KGg==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.1.tgz",
+      "integrity": "sha512-BsXLz5sqX8OHcsh7CqBMztyXARmGQ3LWPtGjJi6DiJHq5C/qvi9P3OqgswKSDftbu8+IoI/QDTAm2fFnQ9SZSQ==",
       "dev": true,
       "requires": {
         "bn.js": "^4.4.0",
@@ -8675,9 +7567,9 @@
       "dev": true
     },
     "enzyme": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/enzyme/-/enzyme-3.10.0.tgz",
-      "integrity": "sha512-p2yy9Y7t/PFbPoTvrWde7JIYB2ZyGC+NgTNbVEGvZ5/EyoYSr9aG/2rSbVvyNvMHEhw9/dmGUJHWtfQIEiX9pg==",
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/enzyme/-/enzyme-3.9.0.tgz",
+      "integrity": "sha512-JqxI2BRFHbmiP7/UFqvsjxTirWoM1HfeaJrmVSZ9a1EADKkZgdPcAuISPMpoUiHlac9J4dYt81MC5BBIrbJGMg==",
       "dev": true,
       "requires": {
         "array.prototype.flat": "^1.2.1",
@@ -8704,19 +7596,18 @@
       }
     },
     "enzyme-adapter-react-16": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.14.0.tgz",
-      "integrity": "sha512-7PcOF7pb4hJUvjY7oAuPGpq3BmlCig3kxXGi2kFx0YzJHppqX1K8IIV9skT1IirxXlu8W7bneKi+oQ10QRnhcA==",
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.12.1.tgz",
+      "integrity": "sha512-GB61gvY97XvrA6qljExGY+lgI6BBwz+ASLaRKct9VQ3ozu0EraqcNn3CcrUckSGIqFGa1+CxO5gj5is5t3lwrw==",
       "dev": true,
       "requires": {
-        "enzyme-adapter-utils": "^1.12.0",
-        "has": "^1.0.3",
+        "enzyme-adapter-utils": "^1.11.0",
         "object.assign": "^4.1.0",
         "object.values": "^1.1.0",
         "prop-types": "^15.7.2",
         "react-is": "^16.8.6",
         "react-test-renderer": "^16.0.0-0",
-        "semver": "^5.7.0"
+        "semver": "^5.6.0"
       },
       "dependencies": {
         "semver": {
@@ -8728,12 +7619,12 @@
       }
     },
     "enzyme-adapter-utils": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/enzyme-adapter-utils/-/enzyme-adapter-utils-1.12.0.tgz",
-      "integrity": "sha512-wkZvE0VxcFx/8ZsBw0iAbk3gR1d9hK447ebnSYBf95+r32ezBq+XDSAvRErkc4LZosgH8J7et7H7/7CtUuQfBA==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/enzyme-adapter-utils/-/enzyme-adapter-utils-1.11.0.tgz",
+      "integrity": "sha512-0VZeoE9MNx+QjTfsjmO1Mo+lMfunucYB4wt5ficU85WB/LoetTJrbuujmHP3PJx6pSoaAuLA+Mq877x4LoxdNg==",
       "dev": true,
       "requires": {
-        "airbnb-prop-types": "^2.13.2",
+        "airbnb-prop-types": "^2.12.0",
         "function.prototype.name": "^1.1.0",
         "object.assign": "^4.1.0",
         "object.fromentries": "^2.0.0",
@@ -8838,9 +7729,9 @@
       }
     },
     "es6-promise": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.6.tgz",
+      "integrity": "sha512-aRVgGdnmW2OiySVPUC9e6m+plolMAJKjZnQlCwNSuK5yQ0JN61DZSO1X1Ufd1foqWRAlig0rhduTCHe7sVtK5Q==",
       "dev": true
     },
     "es6-promisify": {
@@ -8876,14 +7767,14 @@
       }
     },
     "es6-weak-map": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
-      "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
+      "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
       "dev": true,
       "requires": {
         "d": "1",
-        "es5-ext": "^0.10.46",
-        "es6-iterator": "^2.0.3",
+        "es5-ext": "^0.10.14",
+        "es6-iterator": "^2.0.1",
         "es6-symbol": "^3.1.1"
       }
     },
@@ -8982,6 +7873,25 @@
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
+        "chardet": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+          "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+          "dev": true
+        },
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "dev": true,
+          "requires": {
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
         "debug": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -8989,6 +7899,26 @@
           "dev": true,
           "requires": {
             "ms": "^2.1.1"
+          }
+        },
+        "doctrine": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+          "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2"
+          }
+        },
+        "external-editor": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.0.3.tgz",
+          "integrity": "sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==",
+          "dev": true,
+          "requires": {
+            "chardet": "^0.7.0",
+            "iconv-lite": "^0.4.24",
+            "tmp": "^0.0.33"
           }
         },
         "globals": {
@@ -9003,10 +7933,70 @@
           "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
           "dev": true
         },
+        "import-fresh": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.0.0.tgz",
+          "integrity": "sha512-pOnA9tfM3Uwics+SaBLCNyZZZbK+4PTu0OPZtLlMIrv17EdBoC15S9Kn8ckJ9TZTyKb3ywNE5y1yeDxxGA7nTQ==",
+          "dev": true,
+          "requires": {
+            "parent-module": "^1.0.0",
+            "resolve-from": "^4.0.0"
+          }
+        },
+        "inquirer": {
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.3.1.tgz",
+          "integrity": "sha512-MmL624rfkFt4TG9y/Jvmt8vdmOo836U7Y0Hxr2aFk3RelZEGX4Igk0KabWrcaaZaTv9uzglOqWh1Vly+FAWAXA==",
+          "dev": true,
+          "requires": {
+            "ansi-escapes": "^3.2.0",
+            "chalk": "^2.4.2",
+            "cli-cursor": "^2.1.0",
+            "cli-width": "^2.0.0",
+            "external-editor": "^3.0.3",
+            "figures": "^2.0.0",
+            "lodash": "^4.17.11",
+            "mute-stream": "0.0.7",
+            "run-async": "^2.2.0",
+            "rxjs": "^6.4.0",
+            "string-width": "^2.1.0",
+            "strip-ansi": "^5.1.0",
+            "through": "^2.3.6"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+              "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+              "dev": true
+            },
+            "strip-ansi": {
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+              "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^4.1.0"
+              }
+            }
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
         "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        },
+        "resolve-from": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
           "dev": true
         },
         "semver": {
@@ -9014,6 +8004,16 @@
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
           "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
           "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
         },
         "strip-ansi": {
           "version": "4.0.0",
@@ -9027,25 +8027,25 @@
       }
     },
     "eslint-config-airbnb": {
-      "version": "17.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-config-airbnb/-/eslint-config-airbnb-17.1.1.tgz",
-      "integrity": "sha512-xCu//8a/aWqagKljt+1/qAM62BYZeNq04HmdevG5yUGWpja0I/xhqd6GdLRch5oetEGFiJAnvtGuTEAese53Qg==",
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-airbnb/-/eslint-config-airbnb-17.1.0.tgz",
+      "integrity": "sha512-R9jw28hFfEQnpPau01NO5K/JWMGLi6aymiF6RsnMURjTk+MqZKllCqGK/0tOvHkPi/NWSSOU2Ced/GX++YxLnw==",
       "dev": true,
       "requires": {
-        "eslint-config-airbnb-base": "^13.2.0",
+        "eslint-config-airbnb-base": "^13.1.0",
         "object.assign": "^4.1.0",
-        "object.entries": "^1.1.0"
+        "object.entries": "^1.0.4"
       }
     },
     "eslint-config-airbnb-base": {
-      "version": "13.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-13.2.0.tgz",
-      "integrity": "sha512-1mg/7eoB4AUeB0X1c/ho4vb2gYkNH8Trr/EgCT/aGmKhhG+F6vF5s8+iRBlWAzFIAphxIdp3YfEKgEl0f9Xg+w==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-13.1.0.tgz",
+      "integrity": "sha512-XWwQtf3U3zIoKO1BbHh6aUhJZQweOwSt4c2JrPDg9FP3Ltv3+YfEv7jIDB8275tVnO/qOHbfuYg3kzw6Je7uWw==",
       "dev": true,
       "requires": {
-        "confusing-browser-globals": "^1.0.5",
+        "eslint-restricted-globals": "^0.1.1",
         "object.assign": "^4.1.0",
-        "object.entries": "^1.1.0"
+        "object.entries": "^1.0.4"
       }
     },
     "eslint-config-prettier": {
@@ -9094,9 +8094,9 @@
       }
     },
     "eslint-module-utils": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.4.1.tgz",
-      "integrity": "sha512-H6DOj+ejw7Tesdgbfs4jeS4YMFrT8uI8xwd1gtQqXssaR0EQ26L+2O/w6wkYFy2MymON0fTwHmXBvvfLNZVZEw==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.4.0.tgz",
+      "integrity": "sha512-14tltLm38Eu3zS+mt0KvILC3q8jyIAH518MlG+HO0p+yK885Lb1UHTY/UgR91eOyGdmxAPb+OLoW4znqIT6Ndw==",
       "dev": true,
       "requires": {
         "debug": "^2.6.8",
@@ -9115,29 +8115,49 @@
       },
       "dependencies": {
         "bpk-tokens": {
-          "version": "27.6.5",
-          "resolved": "https://registry.npmjs.org/bpk-tokens/-/bpk-tokens-27.6.5.tgz",
-          "integrity": "sha512-wALtOBOSwSkN7t6GI3J3zamynysYD8eD8rwzN4xc7oTqVzKarVxLWi/CPHo5Xa2eByyIwhyGREcAkgKpY5Fr0w==",
+          "version": "27.6.0",
+          "resolved": "https://registry.npmjs.org/bpk-tokens/-/bpk-tokens-27.6.0.tgz",
+          "integrity": "sha512-H2LBrJZPECKehpIzrEYDztcTyH9Kc5zrSVKMmfG1AWu5Z1Hir0ozz/6XNwxhTwIuicWr74N5CWFcsKv/iV5H+g==",
           "dev": true,
           "requires": {
             "color": "^3.0.0"
+          }
+        },
+        "color": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/color/-/color-3.1.1.tgz",
+          "integrity": "sha512-PvUltIXRjehRKPSy89VnDWFKY58xyhTLyxIg21vwQBI6qLwZNPmC8k3C1uytIgFKEpOIzN4y32iPm8231zFHIg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.1",
+            "color-string": "^1.5.2"
+          }
+        },
+        "color-string": {
+          "version": "1.5.3",
+          "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.3.tgz",
+          "integrity": "sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==",
+          "dev": true,
+          "requires": {
+            "color-name": "^1.0.0",
+            "simple-swizzle": "^0.2.2"
           }
         }
       }
     },
     "eslint-plugin-flowtype": {
-      "version": "3.12.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-flowtype/-/eslint-plugin-flowtype-3.12.1.tgz",
-      "integrity": "sha512-NZqf5iRgsfHOC31HQdtX2pvzCi0n/j9pB+L7Cf9QtuYxpx0i2wObT+R3rPKhQK4KtEDzGuzPYVf75j4eg+s9ZQ==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-flowtype/-/eslint-plugin-flowtype-3.7.0.tgz",
+      "integrity": "sha512-6PAYrfSAd23C6ZTc9OhEpSn4uz5HnaXSOYzBLPiKNAE+WmNnWkgkfrswOK2Rlvn91ofZoba7SR04gitnmW9sqg==",
       "dev": true,
       "requires": {
         "lodash": "^4.17.11"
       }
     },
     "eslint-plugin-import": {
-      "version": "2.18.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.18.2.tgz",
-      "integrity": "sha512-5ohpsHAiUBRNaBWAF08izwUGlbrJoJJ+W9/TBwsGoR1MnlgfwMIKrFeSjWbt6moabiXW9xNvtFz+97KHRfI4HQ==",
+      "version": "2.17.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.17.2.tgz",
+      "integrity": "sha512-m+cSVxM7oLsIpmwNn2WXTJoReOF9f/CtLMo7qOVmKd1KntBy0hEcuNZ3erTmWjx+DxRO0Zcrm5KwAvI9wHcV5g==",
       "dev": true,
       "requires": {
         "array-includes": "^3.0.3",
@@ -9147,10 +8167,10 @@
         "eslint-import-resolver-node": "^0.3.2",
         "eslint-module-utils": "^2.4.0",
         "has": "^1.0.3",
+        "lodash": "^4.17.11",
         "minimatch": "^3.0.4",
-        "object.values": "^1.1.0",
         "read-pkg-up": "^2.0.0",
-        "resolve": "^1.11.0"
+        "resolve": "^1.10.0"
       },
       "dependencies": {
         "doctrine": {
@@ -9162,64 +8182,15 @@
             "esutils": "^2.0.2",
             "isarray": "^1.0.0"
           }
-        },
-        "load-json-file": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-          "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^2.2.0",
-            "pify": "^2.0.0",
-            "strip-bom": "^3.0.0"
-          }
-        },
-        "path-type": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
-          "dev": true,
-          "requires": {
-            "pify": "^2.0.0"
-          }
-        },
-        "read-pkg": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-          "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
-          "dev": true,
-          "requires": {
-            "load-json-file": "^2.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^2.0.0"
-          }
-        },
-        "read-pkg-up": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-          "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
-          "dev": true,
-          "requires": {
-            "find-up": "^2.0.0",
-            "read-pkg": "^2.0.0"
-          }
-        },
-        "strip-bom": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-          "dev": true
         }
       }
     },
     "eslint-plugin-jsx-a11y": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.2.3.tgz",
-      "integrity": "sha512-CawzfGt9w83tyuVekn0GDPU9ytYtxyxyFZ3aSWROmnRRFQFT2BiPJd7jvRdzNDi6oLWaS2asMeYSNMjWTV4eNg==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.2.1.tgz",
+      "integrity": "sha512-cjN2ObWrRz0TTw7vEcGQrx+YltMvZoOEx4hWU8eEERDnBIU00OTq7Vr+jA7DFKxiwLNv4tTh5Pq2GUNEa8b6+w==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.4.5",
         "aria-query": "^3.0.0",
         "array-includes": "^3.0.3",
         "ast-types-flow": "^0.0.7",
@@ -9227,45 +8198,38 @@
         "damerau-levenshtein": "^1.0.4",
         "emoji-regex": "^7.0.2",
         "has": "^1.0.3",
-        "jsx-ast-utils": "^2.2.1"
+        "jsx-ast-utils": "^2.0.1"
       }
     },
     "eslint-plugin-prettier": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.0.tgz",
-      "integrity": "sha512-XWX2yVuwVNLOUhQijAkXz+rMPPoCr7WFiAl8ig6I7Xn+pPVhDhzg4DxHpmbeb0iqjO9UronEA3Tb09ChnFVHHA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.0.1.tgz",
+      "integrity": "sha512-/PMttrarPAY78PLvV3xfWibMOdMDl57hmlQ2XqFeA37wd+CJ7WSxV7txqjVPHi/AAFKd2lX0ZqfsOc/i5yFCSQ==",
       "dev": true,
       "requires": {
         "prettier-linter-helpers": "^1.0.0"
       }
     },
     "eslint-plugin-react": {
-      "version": "7.14.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.14.3.tgz",
-      "integrity": "sha512-EzdyyBWC4Uz2hPYBiEJrKCUi2Fn+BJ9B/pJQcjw5X+x/H2Nm59S4MJIvL4O5NEE0+WbnQwEBxWY03oUk+Bc3FA==",
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.13.0.tgz",
+      "integrity": "sha512-uA5LrHylu8lW/eAH3bEQe9YdzpPaFd9yAJTwTi/i/BKTD7j6aQMKVAdGM/ML72zD6womuSK7EiGtMKuK06lWjQ==",
       "dev": true,
       "requires": {
         "array-includes": "^3.0.3",
         "doctrine": "^2.1.0",
         "has": "^1.0.3",
         "jsx-ast-utils": "^2.1.0",
-        "object.entries": "^1.1.0",
         "object.fromentries": "^2.0.0",
-        "object.values": "^1.1.0",
         "prop-types": "^15.7.2",
         "resolve": "^1.10.1"
-      },
-      "dependencies": {
-        "doctrine": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-          "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
-          "dev": true,
-          "requires": {
-            "esutils": "^2.0.2"
-          }
-        }
       }
+    },
+    "eslint-restricted-globals": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-restricted-globals/-/eslint-restricted-globals-0.1.1.tgz",
+      "integrity": "sha1-NfDVy8ZMLj7WLpO0saevBbp+1Nc=",
+      "dev": true
     },
     "eslint-scope": {
       "version": "4.0.3",
@@ -9278,13 +8242,10 @@
       }
     },
     "eslint-utils": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.0.tgz",
-      "integrity": "sha512-7ehnzPaP5IIEh1r1tkjuIrxqhNkzUJa9z3R92tLJdZIVdWaczEhr3EbhGtsMrVxi1KeR8qA7Off6SWc5WNQqyQ==",
-      "dev": true,
-      "requires": {
-        "eslint-visitor-keys": "^1.0.0"
-      }
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.3.1.tgz",
+      "integrity": "sha512-Z7YjnIldX+2XMcjr7ZkgEsOj/bREONV60qYeB/bjMAqqqZ4zxKyWX+BOUkdmRmA9riiIPVvo5x86m5elviOk0Q==",
+      "dev": true
     },
     "eslint-visitor-keys": {
       "version": "1.0.0",
@@ -9315,13 +8276,15 @@
         "acorn": "^6.0.7",
         "acorn-jsx": "^5.0.0",
         "eslint-visitor-keys": "^1.0.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "6.1.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
+          "integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==",
+          "dev": true
+        }
       }
-    },
-    "esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true
     },
     "esquery": {
       "version": "1.0.1",
@@ -9360,9 +8323,9 @@
       "dev": true
     },
     "eval": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/eval/-/eval-0.1.4.tgz",
-      "integrity": "sha512-npGsebJejyjMRnLdFu+T/97dnigqIU0Ov3IGrZ8ygd1v7RL1vGkEKtvyWZobqUH1AQgKlg0Yqqe2BtMA9/QZLw==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/eval/-/eval-0.1.3.tgz",
+      "integrity": "sha512-lDBa3hl9YynB+3J7aNPaajAapr+7ZiAylqFeUmx/r9s7I0tkkUJFLw2CQ2oMRYGg/rL7g4IYkZenbKaQGKPnGQ==",
       "dev": true,
       "requires": {
         "require-like": ">= 0.1.1"
@@ -9382,12 +8345,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
       "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
-      "dev": true
-    },
-    "events": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-3.0.0.tgz",
-      "integrity": "sha512-Dc381HFWJzEOhQ+d8pkNon++bk9h6cdAoAj4iE6Q4y6xgTzySWXlKn05/TVNpjnfRqi/X0EpJEJohPjNI3zpVA==",
       "dev": true
     },
     "eventsource": {
@@ -9419,13 +8376,13 @@
       }
     },
     "execa": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
-      "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+      "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
       "dev": true,
       "requires": {
-        "cross-spawn": "^6.0.0",
-        "get-stream": "^4.0.0",
+        "cross-spawn": "^5.0.1",
+        "get-stream": "^3.0.0",
         "is-stream": "^1.1.0",
         "npm-run-path": "^2.0.0",
         "p-finally": "^1.0.0",
@@ -9455,12 +8412,38 @@
       "dev": true
     },
     "expand-brackets": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-      "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+      "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
       "dev": true,
       "requires": {
-        "is-posix-bracket": "^0.1.0"
+        "debug": "^2.3.3",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "posix-character-classes": "^0.1.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
       }
     },
     "expand-range": {
@@ -9470,6 +8453,39 @@
       "dev": true,
       "requires": {
         "fill-range": "^2.1.0"
+      },
+      "dependencies": {
+        "fill-range": {
+          "version": "2.2.4",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
+          "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
+          "dev": true,
+          "requires": {
+            "is-number": "^2.1.0",
+            "isobject": "^2.0.0",
+            "randomatic": "^3.0.0",
+            "repeat-element": "^1.1.2",
+            "repeat-string": "^1.5.2"
+          }
+        },
+        "is-number": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+          "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          }
+        },
+        "isobject": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+          "dev": true,
+          "requires": {
+            "isarray": "1.0.0"
+          }
+        }
       }
     },
     "expand-tilde": {
@@ -9496,59 +8512,47 @@
       }
     },
     "express": {
-      "version": "4.17.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
-      "integrity": "sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==",
+      "version": "4.16.4",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.16.4.tgz",
+      "integrity": "sha512-j12Uuyb4FMrd/qQAm6uCHAkPtO8FDTRJZBDd5D2KOL2eLaz1yUNdUB/NOIyq0iU4q4cFarsUCrnFDPBcnksuOg==",
       "dev": true,
       "requires": {
-        "accepts": "~1.3.7",
+        "accepts": "~1.3.5",
         "array-flatten": "1.1.1",
-        "body-parser": "1.19.0",
-        "content-disposition": "0.5.3",
+        "body-parser": "1.18.3",
+        "content-disposition": "0.5.2",
         "content-type": "~1.0.4",
-        "cookie": "0.4.0",
+        "cookie": "0.3.1",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "~1.1.2",
         "encodeurl": "~1.0.2",
         "escape-html": "~1.0.3",
         "etag": "~1.8.1",
-        "finalhandler": "~1.1.2",
+        "finalhandler": "1.1.1",
         "fresh": "0.5.2",
         "merge-descriptors": "1.0.1",
         "methods": "~1.1.2",
         "on-finished": "~2.3.0",
-        "parseurl": "~1.3.3",
+        "parseurl": "~1.3.2",
         "path-to-regexp": "0.1.7",
-        "proxy-addr": "~2.0.5",
-        "qs": "6.7.0",
-        "range-parser": "~1.2.1",
+        "proxy-addr": "~2.0.4",
+        "qs": "6.5.2",
+        "range-parser": "~1.2.0",
         "safe-buffer": "5.1.2",
-        "send": "0.17.1",
-        "serve-static": "1.14.1",
-        "setprototypeof": "1.1.1",
-        "statuses": "~1.5.0",
-        "type-is": "~1.6.18",
+        "send": "0.16.2",
+        "serve-static": "1.13.2",
+        "setprototypeof": "1.1.0",
+        "statuses": "~1.4.0",
+        "type-is": "~1.6.16",
         "utils-merge": "1.0.1",
         "vary": "~1.1.2"
       },
       "dependencies": {
-        "array-flatten": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-          "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
-          "dev": true
-        },
-        "path-to-regexp": {
-          "version": "0.1.7",
-          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-          "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
-          "dev": true
-        },
         "qs": {
-          "version": "6.7.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
-          "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
           "dev": true
         }
       }
@@ -9560,32 +8564,95 @@
       "dev": true
     },
     "extend-shallow": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
       "dev": true,
       "requires": {
-        "is-extendable": "^0.1.0"
-      }
-    },
-    "external-editor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
-      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
-      "dev": true,
-      "requires": {
-        "chardet": "^0.7.0",
-        "iconv-lite": "^0.4.24",
-        "tmp": "^0.0.33"
+        "assign-symbols": "^1.0.0",
+        "is-extendable": "^1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "^2.0.4"
+          }
+        }
       }
     },
     "extglob": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-      "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+      "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
       "dev": true,
       "requires": {
-        "is-extglob": "^1.0.0"
+        "array-unique": "^0.3.2",
+        "define-property": "^1.0.0",
+        "expand-brackets": "^2.1.4",
+        "extend-shallow": "^2.0.1",
+        "fragment-cache": "^0.2.1",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        },
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
+        }
       }
     },
     "extract-text-webpack-plugin": {
@@ -9598,6 +8665,41 @@
         "loader-utils": "^1.1.0",
         "schema-utils": "^0.3.0",
         "webpack-sources": "^1.0.1"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "5.5.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+          "dev": true,
+          "requires": {
+            "co": "^4.6.0",
+            "fast-deep-equal": "^1.0.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.3.0"
+          }
+        },
+        "fast-deep-equal": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+          "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+          "dev": true
+        },
+        "json-schema-traverse": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+          "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+          "dev": true
+        },
+        "schema-utils": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.3.0.tgz",
+          "integrity": "sha1-9YdyIs4+kx7a4DnxfrNxbnE3+M8=",
+          "dev": true,
+          "requires": {
+            "ajv": "^5.0.0"
+          }
+        }
       }
     },
     "extsprintf": {
@@ -9625,9 +8727,9 @@
       "dev": true
     },
     "fast-glob": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.0.4.tgz",
-      "integrity": "sha512-wkIbV6qg37xTJwqSsdnIphL1e+LaGz4AIQqr00mIubMaEhv1/HEmJ0uuCGZRNRUkZZmOB5mJKO0ZUTVq+SxMQg==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.0.3.tgz",
+      "integrity": "sha512-scDJbDhN+6S4ELXzzN96Fqm5y1CMRn+Io3C4Go+n/gUKP+LW26Wma6IxLSsX2eAMBUOFmyHKDBrUSuoHsycQ5A==",
       "dev": true,
       "requires": {
         "@nodelib/fs.stat": "^2.0.1",
@@ -9665,20 +8767,11 @@
             "is-glob": "^4.0.1"
           }
         },
-        "is-extglob": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
           "dev": true
-        },
-        "is-glob": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
-          "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
-          "dev": true,
-          "requires": {
-            "is-extglob": "^2.1.1"
-          }
         },
         "micromatch": {
           "version": "4.0.2",
@@ -9688,6 +8781,15 @@
           "requires": {
             "braces": "^3.0.1",
             "picomatch": "^2.0.5"
+          }
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "dev": true,
+          "requires": {
+            "is-number": "^7.0.0"
           }
         }
       }
@@ -9720,9 +8822,9 @@
       }
     },
     "faye-websocket": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
-      "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.1.tgz",
+      "integrity": "sha1-8O/hjE9W5PQK/H4Gxxn9XuYYjzg=",
       "dev": true,
       "requires": {
         "websocket-driver": ">=0.5.1"
@@ -9818,30 +8920,40 @@
       }
     },
     "fill-range": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
-      "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+      "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
       "dev": true,
       "requires": {
-        "is-number": "^2.1.0",
-        "isobject": "^2.0.0",
-        "randomatic": "^3.0.0",
-        "repeat-element": "^1.1.2",
-        "repeat-string": "^1.5.2"
+        "extend-shallow": "^2.0.1",
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1",
+        "to-regex-range": "^2.1.0"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
       }
     },
     "finalhandler": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
-      "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+      "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
       "dev": true,
       "requires": {
         "debug": "2.6.9",
         "encodeurl": "~1.0.2",
         "escape-html": "~1.0.3",
         "on-finished": "~2.3.0",
-        "parseurl": "~1.3.3",
-        "statuses": "~1.5.0",
+        "parseurl": "~1.3.2",
+        "statuses": "~1.4.0",
         "unpipe": "~1.0.0"
       }
     },
@@ -9877,9 +8989,9 @@
       }
     },
     "flatted": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz",
-      "integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.0.tgz",
+      "integrity": "sha512-R+H8IZclI8AAkSBRQJLVOsxwAoHd6WC40b4QTNWIjzAa6BXOBfQcM587MXDTVPeYaopFNWHUFLx7eNmHDSxMWg==",
       "dev": true
     },
     "flatten": {
@@ -9889,133 +9001,181 @@
       "dev": true
     },
     "flow-bin": {
-      "version": "0.101.1",
-      "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.101.1.tgz",
-      "integrity": "sha512-+HVuoMgWNK8vIM662Rt6OzlJNTnC+BWChdeYjkPpl70TKiRMt//j6/5x6PH8HVZ/vytOfPZw2b/JrlBHdlGCkQ==",
+      "version": "0.101.0",
+      "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.101.0.tgz",
+      "integrity": "sha512-2xriPEOSrGQklAArNw1ixoIUiLTWhIquYV26WqnxEu7IcXWgoZUcfJXufG9kIvrNbdwCNd5RBjTwbB0p6L6XaA==",
       "dev": true
     },
     "flow-typed": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/flow-typed/-/flow-typed-2.6.0.tgz",
-      "integrity": "sha512-aTd2ygnb9e0/O4Rskzh/zYMU0NJR3PygoheTfiDEOCbEVdXS6mpX/TfcpcbpPVcJpqqV44+pjhOt36VXlYkLRA==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/flow-typed/-/flow-typed-2.5.1.tgz",
+      "integrity": "sha1-D/VlzJTSr4xVd0S6NktvFHJqa58=",
       "dev": true,
       "requires": {
-        "@babel/polyfill": "^7.0.0",
-        "@octokit/rest": "^15.12.1",
-        "colors": "^1.3.2",
-        "flowgen": "^1.9.0",
-        "fs-extra": "^7.0.0",
-        "glob": "^7.1.3",
-        "got": "^8.3.2",
-        "md5": "^2.2.1",
+        "@octokit/rest": "^15.2.6",
+        "babel-polyfill": "^6.26.0",
+        "colors": "^1.1.2",
+        "fs-extra": "^5.0.0",
+        "glob": "^7.1.2",
+        "got": "^7.1.0",
+        "md5": "^2.1.0",
         "mkdirp": "^0.5.1",
-        "prettier": "^1.18.2",
         "rimraf": "^2.6.2",
-        "semver": "^5.5.1",
-        "table": "^5.0.2",
+        "semver": "^5.5.0",
+        "table": "^4.0.2",
         "through": "^2.3.8",
-        "unzipper": "^0.9.3",
-        "which": "^1.3.1",
-        "yargs": "^12.0.2"
+        "unzipper": "^0.8.11",
+        "which": "^1.3.0",
+        "yargs": "^4.2.0"
       },
       "dependencies": {
-        "camelcase": {
-          "version": "5.3.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
+        },
+        "camelcase": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+          "dev": true
+        },
+        "cliui": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+          "dev": true,
+          "requires": {
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wrap-ansi": "^2.0.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+              "dev": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+              "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+              "dev": true,
+              "requires": {
+                "number-is-nan": "^1.0.0"
+              }
+            },
+            "string-width": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+              "dev": true,
+              "requires": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^2.0.0"
+              }
+            }
+          }
         },
         "find-up": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "dev": true,
           "requires": {
-            "locate-path": "^3.0.0"
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
-        "invert-kv": {
+        "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
-          "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
-        "lcid": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
-          "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
+        "load-json-file": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "dev": true,
           "requires": {
-            "invert-kv": "^2.0.0"
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0",
+            "strip-bom": "^2.0.0"
           }
-        },
-        "locate-path": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-          "dev": true,
-          "requires": {
-            "p-locate": "^3.0.0",
-            "path-exists": "^3.0.0"
-          }
-        },
-        "mem": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
-          "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
-          "dev": true,
-          "requires": {
-            "map-age-cleaner": "^0.1.1",
-            "mimic-fn": "^2.0.0",
-            "p-is-promise": "^2.0.0"
-          }
-        },
-        "mimic-fn": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-          "dev": true
         },
         "os-locale": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
-          "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+          "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
           "dev": true,
           "requires": {
-            "execa": "^1.0.0",
-            "lcid": "^2.0.0",
-            "mem": "^4.0.0"
+            "lcid": "^1.0.0"
           }
         },
-        "p-is-promise": {
+        "parse-json": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.2.0"
+          }
+        },
+        "path-exists": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.1.0.tgz",
-          "integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==",
-          "dev": true
-        },
-        "p-limit": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
-          "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "dev": true,
           "requires": {
-            "p-try": "^2.0.0"
+            "pinkie-promise": "^2.0.0"
           }
         },
-        "p-locate": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+        "path-type": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
           "dev": true,
           "requires": {
-            "p-limit": "^2.0.0"
+            "graceful-fs": "^4.1.2",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
-        "p-try": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-          "dev": true
+        "read-pkg": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "^1.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^1.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+          "dev": true,
+          "requires": {
+            "find-up": "^1.0.0",
+            "read-pkg": "^1.0.0"
+          }
         },
         "semver": {
           "version": "5.7.0",
@@ -10023,53 +9183,138 @@
           "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
           "dev": true
         },
-        "yargs": {
-          "version": "12.0.5",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
-          "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
+        "slice-ansi": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
+          "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
           "dev": true,
           "requires": {
-            "cliui": "^4.0.0",
-            "decamelize": "^1.2.0",
-            "find-up": "^3.0.0",
+            "is-fullwidth-code-point": "^2.0.0"
+          }
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        },
+        "strip-bom": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "dev": true,
+          "requires": {
+            "is-utf8": "^0.2.0"
+          }
+        },
+        "table": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/table/-/table-4.0.3.tgz",
+          "integrity": "sha512-S7rnFITmBH1EnyKcvxBh1LjYeQMmnZtCXSEbHcH6S0NoKit24ZuFO/T1vDcLdYsLQkM188PVVhQmzKIuThNkKg==",
+          "dev": true,
+          "requires": {
+            "ajv": "^6.0.1",
+            "ajv-keywords": "^3.0.0",
+            "chalk": "^2.1.0",
+            "lodash": "^4.17.4",
+            "slice-ansi": "1.0.0",
+            "string-width": "^2.1.1"
+          }
+        },
+        "which-module": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+          "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
+          "dev": true
+        },
+        "window-size": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
+          "integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU=",
+          "dev": true
+        },
+        "yargs": {
+          "version": "4.8.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
+          "integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
+          "dev": true,
+          "requires": {
+            "cliui": "^3.2.0",
+            "decamelize": "^1.1.1",
             "get-caller-file": "^1.0.1",
-            "os-locale": "^3.0.0",
+            "lodash.assign": "^4.0.3",
+            "os-locale": "^1.4.0",
+            "read-pkg-up": "^1.0.1",
             "require-directory": "^2.1.1",
             "require-main-filename": "^1.0.1",
             "set-blocking": "^2.0.0",
-            "string-width": "^2.0.0",
-            "which-module": "^2.0.0",
-            "y18n": "^3.2.1 || ^4.0.0",
-            "yargs-parser": "^11.1.1"
+            "string-width": "^1.0.1",
+            "which-module": "^1.0.0",
+            "window-size": "^0.2.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^2.4.1"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+              "dev": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+              "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+              "dev": true,
+              "requires": {
+                "number-is-nan": "^1.0.0"
+              }
+            },
+            "string-width": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+              "dev": true,
+              "requires": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^2.0.0"
+              }
+            }
           }
         },
         "yargs-parser": {
-          "version": "11.1.1",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
-          "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
+          "integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
           "dev": true,
           "requires": {
-            "camelcase": "^5.0.0",
-            "decamelize": "^1.2.0"
+            "camelcase": "^3.0.0",
+            "lodash.assign": "^4.0.6"
           }
         }
-      }
-    },
-    "flowgen": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/flowgen/-/flowgen-1.9.2.tgz",
-      "integrity": "sha512-YKKNGUqLX/J8nNClaaoaAmICZVVUACRERbyuZPSLN/sDEK5DWRStvV+cUG/QL2ZCLRc1obZgHvkF2LR5CEK2oQ==",
-      "dev": true,
-      "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/highlight": "^7.0.0",
-        "commander": "^2.11.0",
-        "lodash": "^4.17.4",
-        "paralleljs": "^0.2.1",
-        "prettier": "^1.16.4",
-        "shelljs": "^0.8.3",
-        "typescript": "^3.3.3333",
-        "typescript-compiler": "^1.4.1-2"
       }
     },
     "flush-write-stream": {
@@ -10107,9 +9352,9 @@
           }
         },
         "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
           "dev": true
         }
       }
@@ -10184,9 +9429,9 @@
       "dev": true
     },
     "fs-extra": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
+      "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.2",
@@ -10225,24 +9470,29 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
           "dev": true,
           "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "dev": true
+          "resolved": false,
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
           "dev": true,
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -10252,13 +9502,17 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "dev": true
+          "resolved": false,
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -10266,34 +9520,43 @@
         },
         "chownr": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
           "dev": true,
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "dev": true
+          "resolved": false,
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "dev": true
+          "resolved": false,
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "dev": true
+          "resolved": false,
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "dev": true,
           "optional": true
         },
         "debug": {
           "version": "4.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -10302,25 +9565,29 @@
         },
         "deep-extend": {
           "version": "0.6.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
           "dev": true,
           "optional": true
         },
         "delegates": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "dev": true,
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
           "dev": true,
           "optional": true
         },
         "fs-minipass": {
           "version": "1.2.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -10329,13 +9596,15 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "dev": true,
           "optional": true
         },
         "gauge": {
           "version": "2.7.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -10351,7 +9620,8 @@
         },
         "glob": {
           "version": "7.1.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -10365,13 +9635,15 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "dev": true,
           "optional": true
         },
         "iconv-lite": {
           "version": "0.4.24",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -10380,7 +9652,8 @@
         },
         "ignore-walk": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -10389,7 +9662,8 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -10399,46 +9673,58 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "dev": true
+          "resolved": false,
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
           "dev": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true,
           "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "dev": true
+          "resolved": false,
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -10446,7 +9732,8 @@
         },
         "minizlib": {
           "version": "1.2.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -10455,21 +9742,25 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
         },
         "ms": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
           "dev": true,
           "optional": true
         },
         "needle": {
           "version": "2.3.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-QBZu7aAFR0522EyaXZM0FZ9GLpq6lvQ3uq8gteiDUp7wKdy0lSd2hPlgFwVuW1CBkfEs9PfDQsQzZghLs/psdg==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -10480,7 +9771,8 @@
         },
         "node-pre-gyp": {
           "version": "0.12.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -10498,7 +9790,8 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -10508,13 +9801,15 @@
         },
         "npm-bundled": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
           "dev": true,
           "optional": true
         },
         "npm-packlist": {
           "version": "1.4.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -10524,7 +9819,8 @@
         },
         "npmlog": {
           "version": "4.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -10536,38 +9832,46 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "dev": true
+          "resolved": false,
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true,
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
         },
         "os-homedir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "dev": true,
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "dev": true,
           "optional": true
         },
         "osenv": {
           "version": "0.1.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -10577,19 +9881,22 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "dev": true,
           "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
           "dev": true,
           "optional": true
         },
         "rc": {
           "version": "1.2.8",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -10601,7 +9908,8 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "dev": true,
               "optional": true
             }
@@ -10609,7 +9917,8 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -10624,7 +9933,8 @@
         },
         "rimraf": {
           "version": "2.6.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -10633,43 +9943,52 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "dev": true
+          "resolved": false,
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
           "dev": true,
           "optional": true
         },
         "sax": {
           "version": "1.2.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
           "dev": true,
           "optional": true
         },
         "semver": {
           "version": "5.7.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
           "dev": true,
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true,
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "dev": true,
           "optional": true
         },
         "string-width": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -10678,7 +9997,8 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -10687,21 +10007,25 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "dev": true,
           "optional": true
         },
         "tar": {
           "version": "4.4.8",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -10716,13 +10040,15 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "dev": true,
           "optional": true
         },
         "wide-align": {
           "version": "1.1.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -10731,20 +10057,24 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "dev": true
+          "resolved": false,
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
-          "dev": true
+          "resolved": false,
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+          "dev": true,
+          "optional": true
         }
       }
     },
     "fstream": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
-      "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+      "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.2",
@@ -10796,28 +10126,6 @@
         "string-width": "^1.0.1",
         "strip-ansi": "^3.0.1",
         "wide-align": "^1.1.0"
-      },
-      "dependencies": {
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true,
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "dev": true,
-          "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
-          }
-        }
       }
     },
     "gaze": {
@@ -10848,25 +10156,10 @@
       "dev": true
     },
     "get-stream": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-      "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
-      "dev": true,
-      "requires": {
-        "pump": "^3.0.0"
-      },
-      "dependencies": {
-        "pump": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-          "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-          "dev": true,
-          "requires": {
-            "end-of-stream": "^1.1.0",
-            "once": "^1.3.1"
-          }
-        }
-      }
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+      "dev": true
     },
     "get-value": {
       "version": "2.0.6",
@@ -10892,12 +10185,23 @@
         "extend-shallow": "^2.0.1",
         "fs-exists-sync": "^0.1.0",
         "homedir-polyfill": "^1.0.0"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
       }
     },
     "glob": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-      "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
       "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
@@ -10916,15 +10220,53 @@
       "requires": {
         "glob-parent": "^2.0.0",
         "is-glob": "^2.0.0"
+      },
+      "dependencies": {
+        "glob-parent": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+          "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+          "dev": true,
+          "requires": {
+            "is-glob": "^2.0.0"
+          }
+        },
+        "is-extglob": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "^1.0.0"
+          }
+        }
       }
     },
     "glob-parent": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-      "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+      "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
       "dev": true,
       "requires": {
-        "is-glob": "^2.0.0"
+        "is-glob": "^3.1.0",
+        "path-dirname": "^1.0.0"
+      },
+      "dependencies": {
+        "is-glob": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+          "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "^2.1.0"
+          }
+        }
       }
     },
     "glob-to-regexp": {
@@ -10933,34 +10275,6 @@
       "integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=",
       "dev": true
     },
-    "global-modules": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
-      "integrity": "sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==",
-      "dev": true,
-      "requires": {
-        "global-prefix": "^3.0.0"
-      }
-    },
-    "global-prefix": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
-      "integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
-      "dev": true,
-      "requires": {
-        "ini": "^1.3.5",
-        "kind-of": "^6.0.2",
-        "which": "^1.3.1"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-          "dev": true
-        }
-      }
-    },
     "globals": {
       "version": "9.18.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
@@ -10968,9 +10282,9 @@
       "dev": true
     },
     "globby": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-10.0.1.tgz",
-      "integrity": "sha512-sSs4inE1FB2YQiymcmTv6NWENryABjUNPeWhOvmn4SjtKybglsyPZxFB3U1/+L1bYi0rNZDqCLlHyLYDl1Pq5A==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-10.0.0.tgz",
+      "integrity": "sha512-3LifW9M4joGZasyYPz2A1U74zbC/45fvpXUvO/9KbSa+VV0aGZarWkfdgKyR9sExNP0t0x0ss/UMJpNpcaTspw==",
       "dev": true,
       "requires": {
         "@types/glob": "^7.1.1",
@@ -11059,48 +10373,31 @@
       "dev": true
     },
     "got": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/got/-/got-8.3.2.tgz",
-      "integrity": "sha512-qjUJ5U/hawxosMryILofZCkm3C84PLJS/0grRIpjAwu+Lkxxj5cxeCU25BG0/3mDSpXKTyZr8oh8wIgLaH0QCw==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
+      "integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
       "dev": true,
       "requires": {
-        "@sindresorhus/is": "^0.7.0",
-        "cacheable-request": "^2.1.1",
-        "decompress-response": "^3.3.0",
+        "decompress-response": "^3.2.0",
         "duplexer3": "^0.1.4",
         "get-stream": "^3.0.0",
-        "into-stream": "^3.1.0",
-        "is-retry-allowed": "^1.1.0",
+        "is-plain-obj": "^1.1.0",
+        "is-retry-allowed": "^1.0.0",
+        "is-stream": "^1.0.0",
         "isurl": "^1.0.0-alpha5",
         "lowercase-keys": "^1.0.0",
-        "mimic-response": "^1.0.0",
-        "p-cancelable": "^0.4.0",
-        "p-timeout": "^2.0.1",
-        "pify": "^3.0.0",
-        "safe-buffer": "^5.1.1",
-        "timed-out": "^4.0.1",
-        "url-parse-lax": "^3.0.0",
+        "p-cancelable": "^0.3.0",
+        "p-timeout": "^1.1.1",
+        "safe-buffer": "^5.0.1",
+        "timed-out": "^4.0.0",
+        "url-parse-lax": "^1.0.0",
         "url-to-options": "^1.0.1"
-      },
-      "dependencies": {
-        "get-stream": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-          "dev": true
-        },
-        "pify": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-          "dev": true
-        }
       }
     },
     "graceful-fs": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.0.tgz",
-      "integrity": "sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg==",
+      "version": "4.1.15",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
       "dev": true
     },
     "growly": {
@@ -11125,6 +10422,19 @@
         "optimist": "^0.6.1",
         "source-map": "^0.6.1",
         "uglify-js": "^3.1.4"
+      },
+      "dependencies": {
+        "uglify-js": {
+          "version": "3.5.11",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.11.tgz",
+          "integrity": "sha512-izPJg8RsSyqxbdnqX36ExpbH3K7tDBsAU/VfNv89VkMFy3z39zFjunQGsSHOlGlyIfGLGprGeosgQno3bo2/Kg==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "commander": "~2.20.0",
+            "source-map": "~0.6.1"
+          }
+        }
       }
     },
     "har-schema": {
@@ -11203,14 +10513,6 @@
         "get-value": "^2.0.6",
         "has-values": "^1.0.0",
         "isobject": "^3.0.0"
-      },
-      "dependencies": {
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
-        }
       }
     },
     "has-values": {
@@ -11223,26 +10525,6 @@
         "kind-of": "^4.0.0"
       },
       "dependencies": {
-        "is-number": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "dev": true,
-          "requires": {
-            "kind-of": "^3.0.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "^1.1.5"
-              }
-            }
-          }
-        },
         "kind-of": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
@@ -11299,12 +10581,6 @@
         "minimalistic-crypto-utils": "^1.0.1"
       }
     },
-    "hoist-non-react-statics": {
-      "version": "2.5.5",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
-      "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==",
-      "dev": true
-    },
     "home-or-tmp": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
@@ -11343,12 +10619,20 @@
       }
     },
     "html-element-map": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/html-element-map/-/html-element-map-1.1.0.tgz",
-      "integrity": "sha512-iqiG3dTZmy+uUaTmHarTL+3/A2VW9ox/9uasKEZC+R/wAtUrTcRlXPSaPqsnWPfIu8wqn09jQNwMRqzL54jSYA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/html-element-map/-/html-element-map-1.0.1.tgz",
+      "integrity": "sha512-BZSfdEm6n706/lBfXKWa4frZRZcT5k1cOusw95ijZsHlI+GdgY0v95h6IzO3iIDf2ROwq570YTwqNPqHcNMozw==",
       "dev": true,
       "requires": {
         "array-filter": "^1.0.0"
+      },
+      "dependencies": {
+        "array-filter": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-1.0.0.tgz",
+          "integrity": "sha1-uveeYubvTCpMC4MSMtr/7CUfnYM=",
+          "dev": true
+        }
       }
     },
     "html-encoding-sniffer": {
@@ -11400,9 +10684,9 @@
       },
       "dependencies": {
         "readable-stream": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
-          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.3.0.tgz",
+          "integrity": "sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==",
           "dev": true,
           "requires": {
             "inherits": "^2.0.3",
@@ -11412,12 +10696,6 @@
         }
       }
     },
-    "http-cache-semantics": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz",
-      "integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w==",
-      "dev": true
-    },
     "http-deceiver": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz",
@@ -11425,30 +10703,21 @@
       "dev": true
     },
     "http-errors": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
-      "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "dev": true,
       "requires": {
         "depd": "~1.1.2",
         "inherits": "2.0.3",
-        "setprototypeof": "1.1.1",
-        "statuses": ">= 1.5.0 < 2",
-        "toidentifier": "1.0.0"
-      },
-      "dependencies": {
-        "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
-        }
+        "setprototypeof": "1.1.0",
+        "statuses": ">= 1.4.0 < 2"
       }
     },
     "http-parser-js": {
-      "version": "0.4.10",
-      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.10.tgz",
-      "integrity": "sha1-ksnBN0w1CF912zWexWzCV8u5P6Q=",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.0.tgz",
+      "integrity": "sha512-cZdEF7r4gfRIq7ezX9J0T+kQmJNOub71dWbgAXVHDct80TKP4MCETtZQ31xyv38UwgzkWPYF/Xc0ge55dW9Z9w==",
       "dev": true
     },
     "http-proxy": {
@@ -11493,328 +10762,6 @@
         "is-glob": "^4.0.0",
         "lodash": "^4.17.11",
         "micromatch": "^3.1.10"
-      },
-      "dependencies": {
-        "arr-diff": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
-          "dev": true
-        },
-        "array-unique": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-          "dev": true
-        },
-        "braces": {
-          "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-          "dev": true,
-          "requires": {
-            "arr-flatten": "^1.1.0",
-            "array-unique": "^0.3.2",
-            "extend-shallow": "^2.0.1",
-            "fill-range": "^4.0.0",
-            "isobject": "^3.0.1",
-            "repeat-element": "^1.1.2",
-            "snapdragon": "^0.8.1",
-            "snapdragon-node": "^2.0.1",
-            "split-string": "^3.0.2",
-            "to-regex": "^3.0.1"
-          },
-          "dependencies": {
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            }
-          }
-        },
-        "expand-brackets": {
-          "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
-          "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
-          "dev": true,
-          "requires": {
-            "debug": "^2.3.3",
-            "define-property": "^0.2.5",
-            "extend-shallow": "^2.0.1",
-            "posix-character-classes": "^0.1.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
-          },
-          "dependencies": {
-            "define-property": {
-              "version": "0.2.5",
-              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-              "dev": true,
-              "requires": {
-                "is-descriptor": "^0.1.0"
-              }
-            },
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            },
-            "is-accessor-descriptor": {
-              "version": "0.1.6",
-              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-              "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-              "dev": true,
-              "requires": {
-                "kind-of": "^3.0.2"
-              },
-              "dependencies": {
-                "kind-of": {
-                  "version": "3.2.2",
-                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                  "dev": true,
-                  "requires": {
-                    "is-buffer": "^1.1.5"
-                  }
-                }
-              }
-            },
-            "is-data-descriptor": {
-              "version": "0.1.4",
-              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-              "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-              "dev": true,
-              "requires": {
-                "kind-of": "^3.0.2"
-              },
-              "dependencies": {
-                "kind-of": {
-                  "version": "3.2.2",
-                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                  "dev": true,
-                  "requires": {
-                    "is-buffer": "^1.1.5"
-                  }
-                }
-              }
-            },
-            "is-descriptor": {
-              "version": "0.1.6",
-              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-              "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-              "dev": true,
-              "requires": {
-                "is-accessor-descriptor": "^0.1.6",
-                "is-data-descriptor": "^0.1.4",
-                "kind-of": "^5.0.0"
-              }
-            },
-            "kind-of": {
-              "version": "5.1.0",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-              "dev": true
-            }
-          }
-        },
-        "extend-shallow": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
-          "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
-          "dev": true,
-          "requires": {
-            "assign-symbols": "^1.0.0",
-            "is-extendable": "^1.0.1"
-          },
-          "dependencies": {
-            "is-extendable": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-              "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-              "dev": true,
-              "requires": {
-                "is-plain-object": "^2.0.4"
-              }
-            }
-          }
-        },
-        "extglob": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
-          "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
-          "dev": true,
-          "requires": {
-            "array-unique": "^0.3.2",
-            "define-property": "^1.0.0",
-            "expand-brackets": "^2.1.4",
-            "extend-shallow": "^2.0.1",
-            "fragment-cache": "^0.2.1",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
-          },
-          "dependencies": {
-            "define-property": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-              "dev": true,
-              "requires": {
-                "is-descriptor": "^1.0.0"
-              }
-            },
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            }
-          }
-        },
-        "fill-range": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-          "dev": true,
-          "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1",
-            "to-regex-range": "^2.1.0"
-          },
-          "dependencies": {
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            }
-          }
-        },
-        "is-accessor-descriptor": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-          "dev": true,
-          "requires": {
-            "kind-of": "^6.0.0"
-          }
-        },
-        "is-data-descriptor": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-          "dev": true,
-          "requires": {
-            "kind-of": "^6.0.0"
-          }
-        },
-        "is-descriptor": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-          "dev": true,
-          "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
-          }
-        },
-        "is-extglob": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-          "dev": true
-        },
-        "is-glob": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
-          "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
-          "dev": true,
-          "requires": {
-            "is-extglob": "^2.1.1"
-          }
-        },
-        "is-number": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "dev": true,
-          "requires": {
-            "kind-of": "^3.0.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "^1.1.5"
-              }
-            }
-          }
-        },
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
-        },
-        "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-          "dev": true
-        },
-        "micromatch": {
-          "version": "3.1.10",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-          "dev": true,
-          "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "braces": "^2.3.1",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "extglob": "^2.0.4",
-            "fragment-cache": "^0.2.1",
-            "kind-of": "^6.0.2",
-            "nanomatch": "^1.2.9",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.2"
-          }
-        },
-        "to-regex-range": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
-          "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
-          "dev": true,
-          "requires": {
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1"
-          }
-        }
       }
     },
     "http-signature": {
@@ -11835,12 +10782,12 @@
       "dev": true
     },
     "https-proxy-agent": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.2.tgz",
-      "integrity": "sha512-c8Ndjc9Bkpfx/vCJueCPy0jlP4ccCCSNDp8xwCZzPjKJUm+B+u9WX2x98Qx4n1PiMNTWo3D7KK5ifNV/yJyRzg==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
+      "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
       "dev": true,
       "requires": {
-        "agent-base": "^4.3.0",
+        "agent-base": "^4.1.0",
         "debug": "^3.1.0"
       },
       "dependencies": {
@@ -11854,9 +10801,9 @@
           }
         },
         "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
           "dev": true
         }
       }
@@ -11868,12 +10815,11 @@
       "dev": true
     },
     "husky": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-3.0.1.tgz",
-      "integrity": "sha512-PXBv+iGKw23GHUlgELRlVX9932feFL407/wHFwtsGeArp0dDM4u+/QusSQwPKxmNgjpSL+ustbOdQ2jetgAZbA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-3.0.0.tgz",
+      "integrity": "sha512-lKMEn7bRK+7f5eWPNGclDVciYNQt0GIkAQmhKl+uHP1qFzoN0h92kmH9HZ8PCwyVA2EQPD8KHf0FYWqnTxau+Q==",
       "dev": true,
       "requires": {
-        "chalk": "^2.4.2",
         "cosmiconfig": "^5.2.1",
         "execa": "^1.0.0",
         "get-stdin": "^7.0.0",
@@ -11886,6 +10832,46 @@
         "slash": "^3.0.0"
       },
       "dependencies": {
+        "cosmiconfig": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
+          "integrity": "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==",
+          "dev": true,
+          "requires": {
+            "import-fresh": "^2.0.0",
+            "is-directory": "^0.3.1",
+            "js-yaml": "^3.13.1",
+            "parse-json": "^4.0.0"
+          }
+        },
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "dev": true,
+          "requires": {
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "execa": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+          "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^6.0.0",
+            "get-stream": "^4.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          }
+        },
         "find-up": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -11901,6 +10887,15 @@
           "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-7.0.0.tgz",
           "integrity": "sha512-zRKcywvrXlXsA0v0i9Io4KDRaAw7+a1ZpjRwl9Wox8PFlVCCHra7E9c4kqXCoCM9nR5tBkaTTZRBoCm60bFqTQ==",
           "dev": true
+        },
+        "get-stream": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
         },
         "locate-path": {
           "version": "5.0.0",
@@ -11935,18 +10930,6 @@
           "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
           "dev": true
         },
-        "parse-json": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
-          "integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.0.0",
-            "error-ex": "^1.3.1",
-            "json-parse-better-errors": "^1.0.1",
-            "lines-and-columns": "^1.1.6"
-          }
-        },
         "path-exists": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -11962,17 +10945,33 @@
             "find-up": "^4.0.0"
           }
         },
+        "pump": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+          "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+          "dev": true,
+          "requires": {
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
+          }
+        },
         "read-pkg": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
-          "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.1.1.tgz",
+          "integrity": "sha512-dFcTLQi6BZ+aFUaICg7er+/usEoqFdQxiEBsEMNGoipenihtxxtdrQuBXvyANCEI8VuUIVYFgeHGx9sLLvim4w==",
           "dev": true,
           "requires": {
             "@types/normalize-package-data": "^2.4.0",
             "normalize-package-data": "^2.5.0",
-            "parse-json": "^5.0.0",
-            "type-fest": "^0.6.0"
+            "parse-json": "^4.0.0",
+            "type-fest": "^0.4.1"
           }
+        },
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+          "dev": true
         },
         "slash": {
           "version": "3.0.0",
@@ -12022,19 +11021,6 @@
       "dev": true,
       "requires": {
         "postcss": "^6.0.1"
-      },
-      "dependencies": {
-        "postcss": {
-          "version": "6.0.23",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.4.1",
-            "source-map": "^0.6.1",
-            "supports-color": "^5.4.0"
-          }
-        }
       }
     },
     "ieee754": {
@@ -12065,13 +11051,13 @@
       }
     },
     "import-fresh": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.1.0.tgz",
-      "integrity": "sha512-PpuksHKGt8rXfWEr9m9EHIpgyyaltBy8+eF6GJM0QCAxMgxCfucMF3mjecK2QsJr0amJW7gTqh5/wht0z2UhEQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
+      "integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
       "dev": true,
       "requires": {
-        "parent-module": "^1.0.0",
-        "resolve-from": "^4.0.0"
+        "caller-path": "^2.0.0",
+        "resolve-from": "^3.0.0"
       }
     },
     "import-from": {
@@ -12081,21 +11067,7 @@
       "dev": true,
       "requires": {
         "resolve-from": "^3.0.0"
-      },
-      "dependencies": {
-        "resolve-from": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-          "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
-          "dev": true
-        }
       }
-    },
-    "import-lazy": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-3.1.0.tgz",
-      "integrity": "sha512-8/gvXvX2JMn0F+CDlSC4l6kOmVaLOO3XLkksI7CI3Ud95KDYJuYur2b9P/PUt/i/pDAMd/DulQsNbbbmRRsDIQ==",
-      "dev": true
     },
     "import-local": {
       "version": "1.0.0",
@@ -12131,6 +11103,12 @@
       "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc=",
       "dev": true
     },
+    "indexof": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+      "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=",
+      "dev": true
+    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -12142,9 +11120,9 @@
       }
     },
     "inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
       "dev": true
     },
     "ini": {
@@ -12152,44 +11130,6 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
       "dev": true
-    },
-    "inquirer": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.0.tgz",
-      "integrity": "sha512-scfHejeG/lVZSpvCXpsB4j/wQNPM5JC8kiElOI0OUTwmc1RTpXr4H32/HOlQHcZiYl2z2VElwuCVDRG8vFmbnA==",
-      "dev": true,
-      "requires": {
-        "ansi-escapes": "^3.2.0",
-        "chalk": "^2.4.2",
-        "cli-cursor": "^2.1.0",
-        "cli-width": "^2.0.0",
-        "external-editor": "^3.0.3",
-        "figures": "^2.0.0",
-        "lodash": "^4.17.12",
-        "mute-stream": "0.0.7",
-        "run-async": "^2.2.0",
-        "rxjs": "^6.4.0",
-        "string-width": "^2.1.0",
-        "strip-ansi": "^5.1.0",
-        "through": "^2.3.6"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^4.1.0"
-          }
-        }
-      }
     },
     "internal-ip": {
       "version": "1.2.0",
@@ -12205,22 +11145,6 @@
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
       "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==",
       "dev": true
-    },
-    "intersection-observer": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/intersection-observer/-/intersection-observer-0.7.0.tgz",
-      "integrity": "sha512-Id0Fij0HsB/vKWGeBe9PxeY45ttRiBmhFyyt/geBdDHBYNctMRTE3dC1U3ujzz3lap+hVXlEcVaB56kZP/eEUg==",
-      "dev": true
-    },
-    "into-stream": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
-      "integrity": "sha1-lvsKk2wSur1v8XUqF9BWFqvQlMY=",
-      "dev": true,
-      "requires": {
-        "from2": "^2.1.1",
-        "p-is-promise": "^1.1.0"
-      }
     },
     "invariant": {
       "version": "2.2.4",
@@ -12265,9 +11189,9 @@
       }
     },
     "is-alphabetical": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.3.tgz",
-      "integrity": "sha512-eEMa6MKpHFzw38eKm56iNNi6GJ7lf6aLLio7Kr23sJPAECscgRtZvOBYybejWDQ2bM949Y++61PY+udzj5QMLA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.2.tgz",
+      "integrity": "sha512-V0xN4BYezDHcBSKb1QHUFMlR4as/XEuCZBzMJUU4n7+Cbt33SmUnSol+pnXFvLxSHNq2CemUXNdaXV6Flg7+xg==",
       "dev": true
     },
     "is-alphanumeric": {
@@ -12277,9 +11201,9 @@
       "dev": true
     },
     "is-alphanumerical": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.3.tgz",
-      "integrity": "sha512-A1IGAPO5AW9vSh7omxIlOGwIqEvpW/TA+DksVOPM5ODuxKlZS09+TEM1E3275lJqO2oJ38vDpeAL3DCIiHE6eA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.2.tgz",
+      "integrity": "sha512-pyfU/0kHdISIgslFfZN9nfY1Gk3MquQgUm1mJTjdkEPpkAKNWuBTSqFwewOpR7N351VkErCiyV71zX7mlQQqsg==",
       "dev": true,
       "requires": {
         "is-alphabetical": "^1.0.0",
@@ -12353,9 +11277,9 @@
       "dev": true
     },
     "is-decimal": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.3.tgz",
-      "integrity": "sha512-bvLSwoDg2q6Gf+E2LEPiklHZxxiSi3XAh4Mav65mKqTfCO1HM3uBs24TjEH8iJX3bbDdLXKJXBTmGzuTUuAEjQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.2.tgz",
+      "integrity": "sha512-TRzl7mOCchnhchN+f3ICUCzYvL9ul7R+TYOsZ8xia++knyZAJfv/uA1FvQXsAnYIl1T3B2X5E/J7Wb1QXiIBXg==",
       "dev": true
     },
     "is-descriptor": {
@@ -12405,9 +11329,9 @@
       "dev": true
     },
     "is-extglob": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
       "dev": true
     },
     "is-finite": {
@@ -12420,30 +11344,33 @@
       }
     },
     "is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-      "dev": true
-    },
-    "is-glob": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-      "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "dev": true,
       "requires": {
-        "is-extglob": "^1.0.0"
+        "number-is-nan": "^1.0.0"
+      }
+    },
+    "is-glob": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "dev": true,
+      "requires": {
+        "is-extglob": "^2.1.1"
       }
     },
     "is-hexadecimal": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.3.tgz",
-      "integrity": "sha512-zxQ9//Q3D/34poZf8fiy3m3XVpbQc7ren15iKqrTtLPwkPD/t3Scy9Imp63FujULGxuK0ZlCwoo5xNpktFgbOA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.2.tgz",
+      "integrity": "sha512-but/G3sapV3MNyqiDBLrOi4x8uCIw0RY3o/Vb5GT0sMFHrVV7731wFSVy41T5FO1og7G0gXLJh0MkgPRouko/A==",
       "dev": true
     },
     "is-number": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-      "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+      "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
       "dev": true,
       "requires": {
         "kind-of": "^3.0.2"
@@ -12513,14 +11440,6 @@
       "dev": true,
       "requires": {
         "isobject": "^3.0.1"
-      },
-      "dependencies": {
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
-        }
       }
     },
     "is-posix-bracket": {
@@ -12608,9 +11527,9 @@
       "dev": true
     },
     "is-whitespace-character": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-whitespace-character/-/is-whitespace-character-1.0.3.tgz",
-      "integrity": "sha512-SNPgMLz9JzPccD3nPctcj8sZlX9DAMJSKH8bP7Z6bohCwuNgX8xbWr1eTAYXX9Vpi/aSn8Y1akL9WgM3t43YNQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-whitespace-character/-/is-whitespace-character-1.0.2.tgz",
+      "integrity": "sha512-SzM+T5GKUCtLhlHFKt2SDAX2RFzfS6joT91F2/WSi9LxgFdsnhfPK/UIA+JhRR2xuyLdrCys2PiFDrtn1fU5hQ==",
       "dev": true
     },
     "is-windows": {
@@ -12620,9 +11539,9 @@
       "dev": true
     },
     "is-word-character": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-word-character/-/is-word-character-1.0.3.tgz",
-      "integrity": "sha512-0wfcrFgOOOBdgRNT9H33xe6Zi6yhX/uoc4U8NBZGeQQB0ctU1dnlNTyL9JM2646bHDTpsDm1Brb3VPoCIMrd/A==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-word-character/-/is-word-character-1.0.2.tgz",
+      "integrity": "sha512-T3FlsX8rCHAH8e7RE7PfOPZVFQlcV3XRF9eOOBQ1uf70OxO7CjjSOjeImMPCADBdYWcStAbVbYvJ1m2D3tb+EA==",
       "dev": true
     },
     "is-wsl": {
@@ -12644,13 +11563,10 @@
       "dev": true
     },
     "isobject": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-      "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-      "dev": true,
-      "requires": {
-        "isarray": "1.0.0"
-      }
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "dev": true
     },
     "isomorphic-fetch": {
       "version": "2.2.1",
@@ -12777,9 +11693,9 @@
           }
         },
         "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
           "dev": true
         },
         "source-map": {
@@ -12822,6 +11738,38 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "arr-diff": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+          "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "^1.0.1"
+          }
+        },
+        "array-unique": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+          "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+          "dev": true
+        },
+        "braces": {
+          "version": "1.8.5",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+          "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+          "dev": true,
+          "requires": {
+            "expand-range": "^1.8.1",
+            "preserve": "^0.2.0",
+            "repeat-element": "^1.1.2"
+          }
+        },
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
           "dev": true
         },
         "ci-info": {
@@ -12869,6 +11817,24 @@
             }
           }
         },
+        "expand-brackets": {
+          "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+          "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+          "dev": true,
+          "requires": {
+            "is-posix-bracket": "^0.1.0"
+          }
+        },
+        "extglob": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+          "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "^1.0.0"
+          }
+        },
         "is-ci": {
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
@@ -12878,13 +11844,19 @@
             "ci-info": "^1.5.0"
           }
         },
-        "is-fullwidth-code-point": {
+        "is-extglob": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "is-extglob": "^1.0.0"
           }
         },
         "jest-cli": {
@@ -12924,41 +11896,34 @@
             "yargs": "^9.0.0"
           }
         },
-        "load-json-file": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-          "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+        "micromatch": {
+          "version": "2.3.11",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+          "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^2.2.0",
-            "pify": "^2.0.0",
-            "strip-bom": "^3.0.0"
-          },
-          "dependencies": {
-            "pify": {
-              "version": "2.3.0",
-              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-              "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-              "dev": true
-            }
+            "arr-diff": "^2.0.0",
+            "array-unique": "^0.2.1",
+            "braces": "^1.8.2",
+            "expand-brackets": "^0.1.4",
+            "extglob": "^0.3.1",
+            "filename-regex": "^2.0.0",
+            "is-extglob": "^1.0.0",
+            "is-glob": "^2.0.1",
+            "kind-of": "^3.0.2",
+            "normalize-path": "^2.0.1",
+            "object.omit": "^2.0.0",
+            "parse-glob": "^3.0.4",
+            "regex-cache": "^0.4.2"
           }
         },
-        "path-type": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+        "normalize-path": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+          "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
           "dev": true,
           "requires": {
-            "pify": "^2.0.0"
-          },
-          "dependencies": {
-            "pify": {
-              "version": "2.3.0",
-              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-              "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-              "dev": true
-            }
+            "remove-trailing-separator": "^1.0.1"
           }
         },
         "pify": {
@@ -12967,25 +11932,22 @@
           "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
           "dev": true
         },
-        "read-pkg": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-          "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "load-json-file": "^2.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^2.0.0"
-          }
-        },
-        "read-pkg-up": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-          "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
-          "dev": true,
-          "requires": {
-            "find-up": "^2.0.0",
-            "read-pkg": "^2.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          },
+          "dependencies": {
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+              "dev": true
+            }
           }
         },
         "strip-ansi": {
@@ -12996,18 +11958,6 @@
           "requires": {
             "ansi-regex": "^3.0.0"
           }
-        },
-        "strip-bom": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-          "dev": true
-        },
-        "y18n": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
-          "dev": true
         },
         "yargs": {
           "version": "9.0.1",
@@ -13028,15 +11978,6 @@
             "which-module": "^2.0.0",
             "y18n": "^3.2.1",
             "yargs-parser": "^7.0.0"
-          }
-        },
-        "yargs-parser": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
-          "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
-          "dev": true,
-          "requires": {
-            "camelcase": "^4.1.0"
           }
         }
       }
@@ -13126,6 +12067,97 @@
         "micromatch": "^2.3.11",
         "sane": "^2.0.0",
         "worker-farm": "^1.3.1"
+      },
+      "dependencies": {
+        "arr-diff": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+          "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "^1.0.1"
+          }
+        },
+        "array-unique": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+          "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+          "dev": true
+        },
+        "braces": {
+          "version": "1.8.5",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+          "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+          "dev": true,
+          "requires": {
+            "expand-range": "^1.8.1",
+            "preserve": "^0.2.0",
+            "repeat-element": "^1.1.2"
+          }
+        },
+        "expand-brackets": {
+          "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+          "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+          "dev": true,
+          "requires": {
+            "is-posix-bracket": "^0.1.0"
+          }
+        },
+        "extglob": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+          "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "^1.0.0"
+          }
+        },
+        "is-extglob": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "^1.0.0"
+          }
+        },
+        "micromatch": {
+          "version": "2.3.11",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+          "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+          "dev": true,
+          "requires": {
+            "arr-diff": "^2.0.0",
+            "array-unique": "^0.2.1",
+            "braces": "^1.8.2",
+            "expand-brackets": "^0.1.4",
+            "extglob": "^0.3.1",
+            "filename-regex": "^2.0.0",
+            "is-extglob": "^1.0.0",
+            "is-glob": "^2.0.1",
+            "kind-of": "^3.0.2",
+            "normalize-path": "^2.0.1",
+            "object.omit": "^2.0.0",
+            "parse-glob": "^3.0.4",
+            "regex-cache": "^0.4.2"
+          }
+        },
+        "normalize-path": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+          "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+          "dev": true,
+          "requires": {
+            "remove-trailing-separator": "^1.0.1"
+          }
+        }
       }
     },
     "jest-jasmine2": {
@@ -13142,14 +12174,6 @@
         "jest-message-util": "^21.2.1",
         "jest-snapshot": "^21.2.1",
         "p-cancelable": "^0.3.0"
-      },
-      "dependencies": {
-        "p-cancelable": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
-          "integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw==",
-          "dev": true
-        }
       }
     },
     "jest-matcher-utils": {
@@ -13172,6 +12196,97 @@
         "chalk": "^2.0.1",
         "micromatch": "^2.3.11",
         "slash": "^1.0.0"
+      },
+      "dependencies": {
+        "arr-diff": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+          "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "^1.0.1"
+          }
+        },
+        "array-unique": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+          "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+          "dev": true
+        },
+        "braces": {
+          "version": "1.8.5",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+          "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+          "dev": true,
+          "requires": {
+            "expand-range": "^1.8.1",
+            "preserve": "^0.2.0",
+            "repeat-element": "^1.1.2"
+          }
+        },
+        "expand-brackets": {
+          "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+          "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+          "dev": true,
+          "requires": {
+            "is-posix-bracket": "^0.1.0"
+          }
+        },
+        "extglob": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+          "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "^1.0.0"
+          }
+        },
+        "is-extglob": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "^1.0.0"
+          }
+        },
+        "micromatch": {
+          "version": "2.3.11",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+          "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+          "dev": true,
+          "requires": {
+            "arr-diff": "^2.0.0",
+            "array-unique": "^0.2.1",
+            "braces": "^1.8.2",
+            "expand-brackets": "^0.1.4",
+            "extglob": "^0.3.1",
+            "filename-regex": "^2.0.0",
+            "is-extglob": "^1.0.0",
+            "is-glob": "^2.0.1",
+            "kind-of": "^3.0.2",
+            "normalize-path": "^2.0.1",
+            "object.omit": "^2.0.0",
+            "parse-glob": "^3.0.4",
+            "regex-cache": "^0.4.2"
+          }
+        },
+        "normalize-path": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+          "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+          "dev": true,
+          "requires": {
+            "remove-trailing-separator": "^1.0.1"
+          }
+        }
       }
     },
     "jest-mock": {
@@ -13257,6 +12372,27 @@
         "yargs": "^9.0.0"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "arr-diff": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+          "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "^1.0.1"
+          }
+        },
+        "array-unique": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+          "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+          "dev": true
+        },
         "babel-jest": {
           "version": "21.2.0",
           "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-21.2.0.tgz",
@@ -13283,6 +12419,23 @@
             "babel-plugin-syntax-object-rest-spread": "^6.13.0"
           }
         },
+        "braces": {
+          "version": "1.8.5",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+          "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+          "dev": true,
+          "requires": {
+            "expand-range": "^1.8.1",
+            "preserve": "^0.2.0",
+            "repeat-element": "^1.1.2"
+          }
+        },
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+          "dev": true
+        },
         "cliui": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
@@ -13307,68 +12460,95 @@
             }
           }
         },
-        "is-fullwidth-code-point": {
+        "expand-brackets": {
+          "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+          "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+          "dev": true,
+          "requires": {
+            "is-posix-bracket": "^0.1.0"
+          }
+        },
+        "extglob": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+          "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "^1.0.0"
+          }
+        },
+        "is-extglob": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true,
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
-        "load-json-file": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-          "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^2.2.0",
-            "pify": "^2.0.0",
-            "strip-bom": "^3.0.0"
-          }
-        },
-        "path-type": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
-          "dev": true,
-          "requires": {
-            "pify": "^2.0.0"
-          }
-        },
-        "read-pkg": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-          "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
-          "dev": true,
-          "requires": {
-            "load-json-file": "^2.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^2.0.0"
-          }
-        },
-        "read-pkg-up": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-          "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
-          "dev": true,
-          "requires": {
-            "find-up": "^2.0.0",
-            "read-pkg": "^2.0.0"
-          }
-        },
-        "strip-bom": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
           "dev": true
         },
-        "y18n": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
-          "dev": true
+        "is-glob": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "^1.0.0"
+          }
+        },
+        "micromatch": {
+          "version": "2.3.11",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+          "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+          "dev": true,
+          "requires": {
+            "arr-diff": "^2.0.0",
+            "array-unique": "^0.2.1",
+            "braces": "^1.8.2",
+            "expand-brackets": "^0.1.4",
+            "extglob": "^0.3.1",
+            "filename-regex": "^2.0.0",
+            "is-extglob": "^1.0.0",
+            "is-glob": "^2.0.1",
+            "kind-of": "^3.0.2",
+            "normalize-path": "^2.0.1",
+            "object.omit": "^2.0.0",
+            "parse-glob": "^3.0.4",
+            "regex-cache": "^0.4.2"
+          }
+        },
+        "normalize-path": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+          "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+          "dev": true,
+          "requires": {
+            "remove-trailing-separator": "^1.0.1"
+          }
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          },
+          "dependencies": {
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+              "dev": true
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            }
+          }
         },
         "yargs": {
           "version": "9.0.1",
@@ -13389,15 +12569,6 @@
             "which-module": "^2.0.0",
             "y18n": "^3.2.1",
             "yargs-parser": "^7.0.0"
-          }
-        },
-        "yargs-parser": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
-          "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
-          "dev": true,
-          "requires": {
-            "camelcase": "^4.1.0"
           }
         }
       }
@@ -13429,14 +12600,6 @@
         "jest-mock": "^21.2.0",
         "jest-validate": "^21.2.1",
         "mkdirp": "^0.5.1"
-      },
-      "dependencies": {
-        "callsites": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
-          "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
-          "dev": true
-        }
       }
     },
     "jest-validate": {
@@ -13458,9 +12621,9 @@
       "dev": true
     },
     "js-tokens": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true
     },
     "js-yaml": {
@@ -13471,6 +12634,14 @@
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+          "dev": true
+        }
       }
     },
     "jsbn": {
@@ -13521,9 +12692,9 @@
       }
     },
     "jsesc": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-      "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+      "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
       "dev": true
     },
     "jsome": {
@@ -13535,13 +12706,86 @@
         "chalk": "^2.3.0",
         "json-stringify-safe": "^5.0.1",
         "yargs": "^11.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+          "dev": true
+        },
+        "cliui": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+          "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+          "dev": true,
+          "requires": {
+            "string-width": "^2.1.1",
+            "strip-ansi": "^4.0.0",
+            "wrap-ansi": "^2.0.0"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        },
+        "yargs": {
+          "version": "11.1.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
+          "integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
+          "dev": true,
+          "requires": {
+            "cliui": "^4.0.0",
+            "decamelize": "^1.1.1",
+            "find-up": "^2.1.0",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^2.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^9.0.2"
+          }
+        },
+        "yargs-parser": {
+          "version": "9.0.2",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
+          "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
+          "dev": true,
+          "requires": {
+            "camelcase": "^4.1.0"
+          }
+        }
       }
-    },
-    "json-buffer": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
-      "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=",
-      "dev": true
     },
     "json-loader": {
       "version": "0.5.7",
@@ -13589,9 +12833,9 @@
       "dev": true
     },
     "json3": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.3.tgz",
-      "integrity": "sha512-c7/8mbUsKigAbLkD5B010BK4D9LZm7A1pNItkEwiUZRpIN66exu/e7YQWysGun+TRKaJp8MhemM+VkfWv42aCA==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+      "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
       "dev": true
     },
     "json5": {
@@ -13700,9 +12944,9 @@
       },
       "dependencies": {
         "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
           "dev": true
         },
         "semver": {
@@ -13726,13 +12970,12 @@
       }
     },
     "jsx-ast-utils": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.2.1.tgz",
-      "integrity": "sha512-v3FxCcAf20DayI+uxnCuw795+oOIkVu6EnJ1+kSzhqqTZHNkTZ7B66ZgLp4oLJ/gbA64cI0B7WRoHZMSRdyVRQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.1.0.tgz",
+      "integrity": "sha512-yDGDG2DS4JcqhA6blsuYbtsT09xL8AoLuUR2Gb5exrw7UEM19sBcOTq+YBBhrNbl0PUC4R4LnFu+dHg2HKeVvA==",
       "dev": true,
       "requires": {
-        "array-includes": "^3.0.3",
-        "object.assign": "^4.1.0"
+        "array-includes": "^3.0.3"
       }
     },
     "jszip": {
@@ -13763,15 +13006,6 @@
       "requires": {
         "jwa": "^1.4.1",
         "safe-buffer": "^5.0.1"
-      }
-    },
-    "keyv": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.0.0.tgz",
-      "integrity": "sha512-eguHnq22OE3uVoSYG0LVWNP+4ppamWr9+zWBe1bsNcovIMy6huUJFPgy4mGwCd/rnl3vOLGW1MTlu4c57CT1xA==",
-      "dev": true,
-      "requires": {
-        "json-buffer": "3.0.0"
       }
     },
     "killable": {
@@ -13872,16 +13106,10 @@
         "type-check": "~0.3.2"
       }
     },
-    "lines-and-columns": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
-      "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
-      "dev": true
-    },
     "lint-staged": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-9.2.0.tgz",
-      "integrity": "sha512-K/CQWcxYunc8lGMNTFvtI4+ybJcHW3K4Ghudz2OrJhIWdW/i1WWu9rGiVj4yJ0+D/xh8a08kp5slt89VZC9Eqg==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-9.0.0.tgz",
+      "integrity": "sha512-32TJoaeyAaj3rvabaXWe0eOhAhnsYRixEmXuSxKbs0uczFbwVjoDhJ/s2g6r1v8jMTw7t5OzXlHR8iaKtz8nLQ==",
       "dev": true,
       "requires": {
         "chalk": "^2.4.2",
@@ -13908,6 +13136,31 @@
             "fill-range": "^7.0.1"
           }
         },
+        "cosmiconfig": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
+          "integrity": "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==",
+          "dev": true,
+          "requires": {
+            "import-fresh": "^2.0.0",
+            "is-directory": "^0.3.1",
+            "js-yaml": "^3.13.1",
+            "parse-json": "^4.0.0"
+          }
+        },
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "dev": true,
+          "requires": {
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
         "debug": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -13917,10 +13170,25 @@
             "ms": "^2.1.1"
           }
         },
+        "del": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/del/-/del-4.1.1.tgz",
+          "integrity": "sha512-QwGuEUouP2kVwQenAsOof5Fv8K9t3D8Ca8NxcXKrIpEHjTXK5J2nXLdP+ALI1cgv8wj7KuwBhTwBkOZSJKM5XQ==",
+          "dev": true,
+          "requires": {
+            "@types/glob": "^7.1.1",
+            "globby": "^6.1.0",
+            "is-path-cwd": "^2.0.0",
+            "is-path-in-cwd": "^2.0.0",
+            "p-map": "^2.0.0",
+            "pify": "^4.0.1",
+            "rimraf": "^2.6.3"
+          }
+        },
         "execa": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-2.0.3.tgz",
-          "integrity": "sha512-iM124nlyGSrXmuyZF1EMe83ESY2chIYVyDRZKgmcDynid2Q2v/+GuE7gNMl6Sy9Niwf4MC0DDxagOxeMPjuLsw==",
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-2.0.2.tgz",
+          "integrity": "sha512-CkFnhVuWj5stQUvRSeI+zAw0ME+Iprkew4HKSc491vOXLM+hKrDVn+QQoL2CIYy0CpvT0mY+MXlzPreNbuj/8A==",
           "dev": true,
           "requires": {
             "cross-spawn": "^6.0.5",
@@ -13952,11 +13220,47 @@
             "pump": "^3.0.0"
           }
         },
+        "globby": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+          "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
+          "dev": true,
+          "requires": {
+            "array-union": "^1.0.1",
+            "glob": "^7.0.3",
+            "object-assign": "^4.0.1",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          },
+          "dependencies": {
+            "pify": {
+              "version": "2.3.0",
+              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+              "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+              "dev": true
+            }
+          }
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+          "dev": true
+        },
         "is-stream": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
           "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
           "dev": true
+        },
+        "log-symbols": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
+          "integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.4.2"
+          }
         },
         "micromatch": {
           "version": "4.0.2",
@@ -13987,6 +13291,14 @@
           "dev": true,
           "requires": {
             "path-key": "^3.0.0"
+          },
+          "dependencies": {
+            "path-key": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.0.tgz",
+              "integrity": "sha512-8cChqz0RP6SHJkMt48FW0A7+qUOn+OsnOsVtzI59tZ8m+5bCSk7hzwET0pulwOM2YMn9J1efb07KB9l9f30SGg==",
+              "dev": true
+            }
           }
         },
         "onetime": {
@@ -14004,10 +13316,10 @@
           "integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==",
           "dev": true
         },
-        "path-key": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.0.tgz",
-          "integrity": "sha512-8cChqz0RP6SHJkMt48FW0A7+qUOn+OsnOsVtzI59tZ8m+5bCSk7hzwET0pulwOM2YMn9J1efb07KB9l9f30SGg==",
+        "pify": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
           "dev": true
         },
         "pump": {
@@ -14018,6 +13330,21 @@
           "requires": {
             "end-of-stream": "^1.1.0",
             "once": "^1.3.1"
+          }
+        },
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+          "dev": true
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "dev": true,
+          "requires": {
+            "is-number": "^7.0.0"
           }
         }
       }
@@ -14126,16 +13453,26 @@
       }
     },
     "load-json-file": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+      "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.2",
         "parse-json": "^2.2.0",
         "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0",
-        "strip-bom": "^2.0.0"
+        "strip-bom": "^3.0.0"
+      },
+      "dependencies": {
+        "parse-json": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.2.0"
+          }
+        }
       }
     },
     "loader-runner": {
@@ -14183,21 +13520,21 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "dev": true
+    },
+    "lodash.assign": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
       "dev": true
     },
     "lodash.assignin": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.assignin/-/lodash.assignin-4.2.0.tgz",
       "integrity": "sha1-uo31+4QesKPoBEIysOJjqNxqKKI=",
-      "dev": true
-    },
-    "lodash.bind": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-4.2.1.tgz",
-      "integrity": "sha1-euMBfpOWIqwxt9fX3LGzTbFpDTU=",
       "dev": true
     },
     "lodash.camelcase": {
@@ -14314,12 +13651,6 @@
       "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=",
       "dev": true
     },
-    "lodash.keys": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-4.2.0.tgz",
-      "integrity": "sha1-oIYCrBLk+4P5H8H7ejYKTZujUgU=",
-      "dev": true
-    },
     "lodash.map": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
@@ -14327,9 +13658,9 @@
       "dev": true
     },
     "lodash.merge": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
+      "integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ==",
       "dev": true
     },
     "lodash.once": {
@@ -14369,12 +13700,12 @@
       "dev": true
     },
     "log-symbols": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
-      "integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
+      "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
       "dev": true,
       "requires": {
-        "chalk": "^2.4.2"
+        "chalk": "^2.0.1"
       }
     },
     "log-update": {
@@ -14393,6 +13724,22 @@
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
         },
         "strip-ansi": {
           "version": "4.0.0",
@@ -14416,9 +13763,9 @@
       }
     },
     "loglevel": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.3.tgz",
-      "integrity": "sha512-LoEDv5pgpvWgPF4kNYuIp0qqSJVWak/dML0RY74xlzMZiT9w77teNAwKYKWBTYjlokMirg+o3jBwp+vlLrcfAA==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.1.tgz",
+      "integrity": "sha1-4PyVEztu8nbNyIh82vJKpvFW+Po=",
       "dev": true
     },
     "longest": {
@@ -14428,9 +13775,9 @@
       "dev": true
     },
     "longest-streak": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-2.0.3.tgz",
-      "integrity": "sha512-9lz5IVdpwsKLMzQi0MQ+oD9EA0mIGcWYP7jXMTZVXP8D42PwuAk+M/HBFYQoxt1G5OR8m7aSIgb1UymfWGBWEw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-2.0.2.tgz",
+      "integrity": "sha512-TmYTeEYxiAmSVdpbnQDXGtvYOIRsCMg89CVZzwzc2o7GFL1CjoiRPjH5ec0NFAVlAx3fVof9dX/t6KKRAo2OWA==",
       "dev": true
     },
     "loose-envify": {
@@ -14469,9 +13816,9 @@
       }
     },
     "macos-release": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.3.0.tgz",
-      "integrity": "sha512-OHhSbtcviqMPt7yfw5ef5aghS2jzFVKEFyCJndQt2YpSQ9qRVSEv2axSJI1paVThEu+FFGs584h/1YhxjVqajA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.2.0.tgz",
+      "integrity": "sha512-iV2IDxZaX8dIcM7fG6cI46uNmHUxHE4yN+Z8tKHAW1TBPMZDIKHf/3L+YnOuj/FK9il14UaVdHmiQ1tsi90ltA==",
       "dev": true
     },
     "make-dir": {
@@ -14500,15 +13847,6 @@
         "tmpl": "1.0.x"
       }
     },
-    "map-age-cleaner": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
-      "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
-      "dev": true,
-      "requires": {
-        "p-defer": "^1.0.0"
-      }
-    },
     "map-cache": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
@@ -14531,9 +13869,9 @@
       }
     },
     "markdown-escapes": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/markdown-escapes/-/markdown-escapes-1.0.3.tgz",
-      "integrity": "sha512-XUi5HJhhV5R74k8/0H2oCbCiYf/u4cO/rX8tnGkRvrqhsr5BRNU6Mg0yt/8UIx1iIS8220BNJsDb7XnILhLepw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/markdown-escapes/-/markdown-escapes-1.0.2.tgz",
+      "integrity": "sha512-lbRZ2mE3Q9RtLjxZBZ9+IMl68DKIXaVAhwvwn9pmjnPLS0h/6kyBMgNhqi1xFJ/2yv6cSyv0jbiZavZv93JkkA==",
       "dev": true
     },
     "markdown-spellcheck": {
@@ -14645,15 +13983,6 @@
             }
           }
         },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true,
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
         "mute-stream": {
           "version": "0.0.6",
           "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.6.tgz",
@@ -14676,17 +14005,6 @@
             "onetime": "^1.0.0"
           }
         },
-        "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "dev": true,
-          "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
-          }
-        },
         "supports-color": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
@@ -14705,9 +14023,9 @@
       }
     },
     "markdown-table": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-1.1.3.tgz",
-      "integrity": "sha512-1RUZVgQlpJSPWYbFSpmudq5nHY1doEIv89gBtF0s4gW1GF2XorxcA/70M5vq7rLv0a6mhOUccRsqkwhwLCIQ2Q==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-1.1.2.tgz",
+      "integrity": "sha512-NcWuJFHDA8V3wkDgR/j4+gZx+YQwstPgfQDV8ndUeWWzta3dnDTBxpVzqS9lkmJAuV5YX35lmyojl6HO5JXAgw==",
       "dev": true
     },
     "marked": {
@@ -14744,9 +14062,9 @@
       "dev": true
     },
     "mathml-tag-names": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.1.tgz",
-      "integrity": "sha512-pWB896KPGSGkp1XtyzRBftpTzwSOL0Gfk0wLvxt4f2mgzjY19o0LxJ3U25vNWTzsh7da+KTbuXQoQ3lOJZ8WHw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.0.tgz",
+      "integrity": "sha512-3Zs9P/0zzwTob2pdgT0CHZuMbnSUSp8MB1bddfm+HDmnFWHGT4jvEZRf+2RuPoa+cjdn/z25SEt5gFTqdhvJAg==",
       "dev": true
     },
     "md5": {
@@ -14781,18 +14099,18 @@
       }
     },
     "mdast-util-compact": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/mdast-util-compact/-/mdast-util-compact-1.0.3.tgz",
-      "integrity": "sha512-nRiU5GpNy62rZppDKbLwhhtw5DXoFMqw9UNZFmlPsNaQCZ//WLjGKUwWMdJrUH+Se7UvtO2gXtAMe0g/N+eI5w==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-compact/-/mdast-util-compact-1.0.2.tgz",
+      "integrity": "sha512-d2WS98JSDVbpSsBfVvD9TaDMlqPRz7ohM/11G0rp5jOBb5q96RJ6YLszQ/09AAixyzh23FeIpCGqfaamEADtWg==",
       "dev": true,
       "requires": {
         "unist-util-visit": "^1.1.0"
       }
     },
     "mdn-data": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.4.tgz",
-      "integrity": "sha512-iV3XNKw06j5Q7mi6h+9vbx23Tv7JkjEVgKHW4pimwyDGWm0OIQntJJ+u1C6mg6mK1EaTv42XQ7w76yuzH7M2cA==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-1.1.4.tgz",
+      "integrity": "sha512-FSYbp3lyKjyj3E7fMl6rYvUdX0FBXaluGqlFoYESWQlyUTq8R+wp0rkFxoYFqZlHCvsUXGjyJmLQSnXToYhOSA==",
       "dev": true
     },
     "media-typer": {
@@ -14811,9 +14129,9 @@
       }
     },
     "memoize-one": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.0.5.tgz",
-      "integrity": "sha512-ey6EpYv0tEaIbM/nTDOpHciXUvd+ackQrJgEzBwemhZZIWZjcyodqEcrmqDy2BKRTM3a65kKBV4WtLXJDt26SQ==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.0.4.tgz",
+      "integrity": "sha512-P0z5IeAH6qHHGkJIXWw0xC2HNEgkx/9uWWBQw64FJj3/ol14VYdfVGWWr0fXfjhhv3TKVIqUq65os6O4GUNksA==",
       "dev": true
     },
     "memory-fs": {
@@ -14844,11 +14162,93 @@
         "trim-newlines": "^1.0.0"
       },
       "dependencies": {
+        "find-up": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+          "dev": true,
+          "requires": {
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "load-json-file": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0",
+            "strip-bom": "^2.0.0"
+          }
+        },
         "minimist": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
+        },
+        "parse-json": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.2.0"
+          }
+        },
+        "path-exists": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+          "dev": true,
+          "requires": {
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "path-type": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "read-pkg": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "^1.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^1.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+          "dev": true,
+          "requires": {
+            "find-up": "^1.0.0",
+            "read-pkg": "^1.0.0"
+          }
+        },
+        "strip-bom": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "dev": true,
+          "requires": {
+            "is-utf8": "^0.2.0"
+          }
         }
       }
     },
@@ -14883,24 +14283,32 @@
       "dev": true
     },
     "micromatch": {
-      "version": "2.3.11",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-      "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+      "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
       "dev": true,
       "requires": {
-        "arr-diff": "^2.0.0",
-        "array-unique": "^0.2.1",
-        "braces": "^1.8.2",
-        "expand-brackets": "^0.1.4",
-        "extglob": "^0.3.1",
-        "filename-regex": "^2.0.0",
-        "is-extglob": "^1.0.0",
-        "is-glob": "^2.0.1",
-        "kind-of": "^3.0.2",
-        "normalize-path": "^2.0.1",
-        "object.omit": "^2.0.0",
-        "parse-glob": "^3.0.4",
-        "regex-cache": "^0.4.2"
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "braces": "^2.3.1",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "extglob": "^2.0.4",
+        "fragment-cache": "^0.2.1",
+        "kind-of": "^6.0.2",
+        "nanomatch": "^1.2.9",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
+        }
       }
     },
     "miller-rabin": {
@@ -14914,9 +14322,9 @@
       }
     },
     "mime": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+      "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
       "dev": true
     },
     "mime-db": {
@@ -15002,9 +14410,9 @@
       }
     },
     "mixin-deep": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
-      "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
+      "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
       "dev": true,
       "requires": {
         "for-in": "^1.0.2",
@@ -15110,9 +14518,9 @@
       "dev": true
     },
     "nan": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
+      "version": "2.13.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
+      "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==",
       "dev": true
     },
     "nanolru": {
@@ -15140,37 +14548,6 @@
         "to-regex": "^3.0.1"
       },
       "dependencies": {
-        "arr-diff": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
-          "dev": true
-        },
-        "array-unique": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-          "dev": true
-        },
-        "extend-shallow": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
-          "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
-          "dev": true,
-          "requires": {
-            "assign-symbols": "^1.0.0",
-            "is-extendable": "^1.0.1"
-          }
-        },
-        "is-extendable": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-          "dev": true,
-          "requires": {
-            "is-plain-object": "^2.0.4"
-          }
-        },
         "kind-of": {
           "version": "6.0.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
@@ -15225,9 +14602,9 @@
       "dev": true
     },
     "neo-async": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
-      "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.0.tgz",
+      "integrity": "sha512-MFh0d/Wa7vkKO3Y3LlacqAEeHK0mckVqzDieUKTT+KGxi+zIpeVsFxymkIiRpbpDziHc290Xr9A1O4Om7otoRA==",
       "dev": true
     },
     "next-tick": {
@@ -15299,9 +14676,9 @@
       "dev": true
     },
     "node-libs-browser": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.2.1.tgz",
-      "integrity": "sha512-h/zcD8H9kaDZ9ALUWwlBUDo6TKF8a7qBSCSEGfjTVIYeqsioSKaAX+BN7NgiMGp6iSIXZ3PxgCu8KS3b71YK5Q==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.2.0.tgz",
+      "integrity": "sha512-5MQunG/oyOaBdttrL40dA7bUfPORLRWMUJLQtMg7nluxUvk5XwnLdL9twQHFAjRx/y7mIMkLKT9++qPbbk6BZA==",
       "dev": true,
       "requires": {
         "assert": "^1.1.1",
@@ -15314,7 +14691,7 @@
         "events": "^3.0.0",
         "https-browserify": "^1.0.0",
         "os-browserify": "^0.3.0",
-        "path-browserify": "0.0.1",
+        "path-browserify": "0.0.0",
         "process": "^0.11.10",
         "punycode": "^1.2.4",
         "querystring-es3": "^0.2.0",
@@ -15326,9 +14703,21 @@
         "tty-browserify": "0.0.0",
         "url": "^0.11.0",
         "util": "^0.11.0",
-        "vm-browserify": "^1.0.1"
+        "vm-browserify": "0.0.4"
       },
       "dependencies": {
+        "events": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/events/-/events-3.0.0.tgz",
+          "integrity": "sha512-Dc381HFWJzEOhQ+d8pkNon++bk9h6cdAoAj4iE6Q4y6xgTzySWXlKn05/TVNpjnfRqi/X0EpJEJohPjNI3zpVA==",
+          "dev": true
+        },
+        "process": {
+          "version": "0.11.10",
+          "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+          "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
+          "dev": true
+        },
         "punycode": {
           "version": "1.4.1",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
@@ -15359,9 +14748,9 @@
       }
     },
     "node-releases": {
-      "version": "1.1.26",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.26.tgz",
-      "integrity": "sha512-fZPsuhhUHMTlfkhDLGtfY80DSJTjOcx+qD1j5pqPkuhUHVS7xHZIg9EE4DHK8O3f0zTxXHX5VIkDG8pu98/wfQ==",
+      "version": "1.1.17",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.17.tgz",
+      "integrity": "sha512-/SCjetyta1m7YXLgtACZGDYJdCSIBAWorDWkGCGZlydP2Ll7J48l7j/JxNYZ+xsgSPbWfdulVS/aY+GdjUsQ7Q==",
       "dev": true,
       "requires": {
         "semver": "^5.3.0"
@@ -15473,13 +14862,10 @@
       }
     },
     "normalize-path": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-      "dev": true,
-      "requires": {
-        "remove-trailing-separator": "^1.0.1"
-      }
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true
     },
     "normalize-range": {
       "version": "0.1.2",
@@ -15492,17 +14878,6 @@
       "resolved": "https://registry.npmjs.org/normalize-selector/-/normalize-selector-0.2.0.tgz",
       "integrity": "sha1-0LFF62kRicY6eNIB3E/bEpPvDAM=",
       "dev": true
-    },
-    "normalize-url": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-2.0.1.tgz",
-      "integrity": "sha512-D6MUW4K/VzoJ4rJ01JFKxDrtY1v9wrgzCX5f2qj/lzH1m/lW6MhUZFKerVsnyjOhOsYzI9Kqqak+10l4LvLpMw==",
-      "dev": true,
-      "requires": {
-        "prepend-http": "^2.0.0",
-        "query-string": "^5.0.1",
-        "sort-keys": "^2.0.0"
-      }
     },
     "normalize.css": {
       "version": "4.2.0",
@@ -15617,14 +14992,6 @@
       "dev": true,
       "requires": {
         "isobject": "^3.0.0"
-      },
-      "dependencies": {
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
-        }
       }
     },
     "object.assign": {
@@ -15690,14 +15057,6 @@
       "dev": true,
       "requires": {
         "isobject": "^3.0.1"
-      },
-      "dependencies": {
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
-        }
       }
     },
     "object.values": {
@@ -15764,9 +15123,9 @@
       "dev": true
     },
     "opn": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/opn/-/opn-5.5.0.tgz",
-      "integrity": "sha512-PqHpggC9bLV0VeWcdKhkpxY+3JTzetLSqTCWL/z/tFIbI6G8JCjondXklT1JinczLz2Xib62sSp0T/gKT4KksA==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/opn/-/opn-5.2.0.tgz",
+      "integrity": "sha512-Jd/GpzPyHF4P2/aNOVmS3lfMSWV9J7cOhCG1s08XCEAsPkB7lp6ddiU0J7XzyQRDUh8BqJ7PchfINjR8jyofRQ==",
       "dev": true,
       "requires": {
         "is-wsl": "^1.1.0"
@@ -15780,14 +15139,6 @@
       "requires": {
         "minimist": "~0.0.1",
         "wordwrap": "~0.0.2"
-      },
-      "dependencies": {
-        "wordwrap": {
-          "version": "0.0.3",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
-          "dev": true
-        }
       }
     },
     "optionator": {
@@ -15802,6 +15153,14 @@
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2",
         "wordwrap": "~1.0.0"
+      },
+      "dependencies": {
+        "wordwrap": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+          "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+          "dev": true
+        }
       }
     },
     "original": {
@@ -15834,40 +15193,6 @@
         "execa": "^0.7.0",
         "lcid": "^1.0.0",
         "mem": "^1.1.0"
-      },
-      "dependencies": {
-        "cross-spawn": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^4.0.1",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
-          }
-        },
-        "execa": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-          "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
-          "dev": true,
-          "requires": {
-            "cross-spawn": "^5.0.1",
-            "get-stream": "^3.0.0",
-            "is-stream": "^1.1.0",
-            "npm-run-path": "^2.0.0",
-            "p-finally": "^1.0.0",
-            "signal-exit": "^3.0.0",
-            "strip-eof": "^1.0.0"
-          }
-        },
-        "get-stream": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-          "dev": true
-        }
       }
     },
     "os-name": {
@@ -15903,27 +15228,15 @@
       }
     },
     "p-cancelable": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
-      "integrity": "sha512-HNa1A8LvB1kie7cERyy21VNeHb2CWJJYqyyC2o3klWFfMGlFmWv2Z7sFgZH8ZiaYL95ydToKTFVXgMV/Os0bBQ==",
-      "dev": true
-    },
-    "p-defer": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
-      "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
+      "integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw==",
       "dev": true
     },
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
       "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-      "dev": true
-    },
-    "p-is-promise": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
-      "integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4=",
       "dev": true
     },
     "p-limit": {
@@ -15951,9 +15264,9 @@
       "dev": true
     },
     "p-timeout": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
-      "integrity": "sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-1.2.1.tgz",
+      "integrity": "sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=",
       "dev": true,
       "requires": {
         "p-finally": "^1.0.0"
@@ -15982,12 +15295,6 @@
         "readable-stream": "^2.1.5"
       }
     },
-    "paralleljs": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/paralleljs/-/paralleljs-0.2.1.tgz",
-      "integrity": "sha1-68p0XT4JwB4r68wUhYiR/0UQ6SY=",
-      "dev": true
-    },
     "parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -15995,6 +15302,14 @@
       "dev": true,
       "requires": {
         "callsites": "^3.0.0"
+      },
+      "dependencies": {
+        "callsites": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+          "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+          "dev": true
+        }
       }
     },
     "parse-asn1": {
@@ -16018,9 +15333,9 @@
       "dev": true
     },
     "parse-entities": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.2.2.tgz",
-      "integrity": "sha512-NzfpbxW/NPrzZ/yYSoQxyqUZMZXIdCfE0OIN4ESsnptHJECoUk3FZktxNuzQf4tjt5UEopnxpYJbvYuxIFDdsg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.2.1.tgz",
+      "integrity": "sha512-NBWYLQm1KSoDKk7GAHyioLTvCZ5QjdH/ASBBQTD3iLiAWJXS5bg1jEWI8nIJ+vgVvsceBVBcDGRWSo0KVQBvvg==",
       "dev": true,
       "requires": {
         "character-entities": "^1.0.0",
@@ -16058,15 +15373,33 @@
         "is-dotfile": "^1.0.0",
         "is-extglob": "^1.0.0",
         "is-glob": "^2.0.0"
+      },
+      "dependencies": {
+        "is-extglob": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "^1.0.0"
+          }
+        }
       }
     },
     "parse-json": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
       "dev": true,
       "requires": {
-        "error-ex": "^1.2.0"
+        "error-ex": "^1.3.1",
+        "json-parse-better-errors": "^1.0.1"
       }
     },
     "parse-link-header": {
@@ -16106,9 +15439,9 @@
       "dev": true
     },
     "path-browserify": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.1.tgz",
-      "integrity": "sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ==",
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
+      "integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo=",
       "dev": true
     },
     "path-dirname": {
@@ -16148,31 +15481,18 @@
       "dev": true
     },
     "path-to-regexp": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
-      "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
-      "dev": true,
-      "requires": {
-        "isarray": "0.0.1"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
-        }
-      }
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
+      "dev": true
     },
     "path-type": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+      "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
+        "pify": "^2.0.0"
       }
     },
     "pbkdf2": {
@@ -16271,9 +15591,9 @@
       }
     },
     "portfinder": {
-      "version": "1.0.21",
-      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.21.tgz",
-      "integrity": "sha512-ESabpDCzmBS3ekHbmpAIiESq3udRsCBGiBZLsC+HgBKv2ezb0R4oG+7RnYEVZ/ZCfhel5Tx3UzdNWA0Lox2QCA==",
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.20.tgz",
+      "integrity": "sha512-Yxe4mTyDzTd59PZJY4ojZR8F+E5e97iq2ZOHPz3HDgSvYC5siNad2tLooQ5y5QHyQhc3xVqvyk/eNA3wuoa7Sw==",
       "dev": true,
       "requires": {
         "async": "^1.5.2",
@@ -16296,25 +15616,14 @@
       "dev": true
     },
     "postcss": {
-      "version": "7.0.17",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.17.tgz",
-      "integrity": "sha512-546ZowA+KZ3OasvQZHsbuEpysvwTZNGJv9EfyCQdsIDltPSWHAeTQ5fQy/Npi2ZDtLI3zs7Ps/p6wThErhm9fQ==",
+      "version": "6.0.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+      "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
       "dev": true,
       "requires": {
-        "chalk": "^2.4.2",
+        "chalk": "^2.4.1",
         "source-map": "^0.6.1",
-        "supports-color": "^6.1.0"
-      },
-      "dependencies": {
-        "supports-color": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
+        "supports-color": "^5.4.0"
       }
     },
     "postcss-flexbugs-fixes": {
@@ -16324,6 +15633,28 @@
       "dev": true,
       "requires": {
         "postcss": "^7.0.0"
+      },
+      "dependencies": {
+        "postcss": {
+          "version": "7.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.4.2",
+            "source-map": "^0.6.1",
+            "supports-color": "^6.1.0"
+          }
+        },
+        "supports-color": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
       }
     },
     "postcss-html": {
@@ -16336,12 +15667,12 @@
       }
     },
     "postcss-jsx": {
-      "version": "0.36.2",
-      "resolved": "https://registry.npmjs.org/postcss-jsx/-/postcss-jsx-0.36.2.tgz",
-      "integrity": "sha512-7B8a8a6YDOQFqMQ9UmOo+IPPb2i14Z57Fvc9cOI11B3bWMSY2O6r2XJ3tlcQhUhv93TeN0ntxehTaSWJDQavlg==",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/postcss-jsx/-/postcss-jsx-0.36.0.tgz",
+      "integrity": "sha512-/lWOSXSX5jlITCKFkuYU2WLFdrncZmjSVyNpHAunEgirZXLwI8RjU556e3Uz4mv0WVHnJA9d3JWb36lK9Yx99g==",
       "dev": true,
       "requires": {
-        "@babel/core": ">=7.2.2"
+        "@babel/core": ">=7.1.0"
       }
     },
     "postcss-less": {
@@ -16351,15 +15682,37 @@
       "dev": true,
       "requires": {
         "postcss": "^7.0.14"
+      },
+      "dependencies": {
+        "postcss": {
+          "version": "7.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.4.2",
+            "source-map": "^0.6.1",
+            "supports-color": "^6.1.0"
+          }
+        },
+        "supports-color": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
       }
     },
     "postcss-load-config": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-2.1.0.tgz",
-      "integrity": "sha512-4pV3JJVPLd5+RueiVVB+gFOAa7GWc25XQcMp86Zexzke69mKf6Nx9LRcQywdz7yZI9n1udOxmLuAwTBypypF8Q==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-2.0.0.tgz",
+      "integrity": "sha512-V5JBLzw406BB8UIfsAWSK2KSwIJ5yoEIVFb4gVkXci0QdKgA24jLmHZ/ghe/GgX0lJ0/D1uUK1ejhzEY94MChQ==",
       "dev": true,
       "requires": {
-        "cosmiconfig": "^5.0.0",
+        "cosmiconfig": "^4.0.0",
         "import-cwd": "^2.0.0"
       }
     },
@@ -16375,6 +15728,17 @@
         "schema-utils": "^1.0.0"
       },
       "dependencies": {
+        "postcss": {
+          "version": "7.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.4.2",
+            "source-map": "^0.6.1",
+            "supports-color": "^6.1.0"
+          }
+        },
         "schema-utils": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
@@ -16384,6 +15748,15 @@
             "ajv": "^6.1.0",
             "ajv-errors": "^1.0.0",
             "ajv-keywords": "^3.1.0"
+          }
+        },
+        "supports-color": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -16411,19 +15784,6 @@
       "dev": true,
       "requires": {
         "postcss": "^6.0.1"
-      },
-      "dependencies": {
-        "postcss": {
-          "version": "6.0.23",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.4.1",
-            "source-map": "^0.6.1",
-            "supports-color": "^5.4.0"
-          }
-        }
       }
     },
     "postcss-modules-local-by-default": {
@@ -16434,19 +15794,6 @@
       "requires": {
         "css-selector-tokenizer": "^0.7.0",
         "postcss": "^6.0.1"
-      },
-      "dependencies": {
-        "postcss": {
-          "version": "6.0.23",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.4.1",
-            "source-map": "^0.6.1",
-            "supports-color": "^5.4.0"
-          }
-        }
       }
     },
     "postcss-modules-scope": {
@@ -16457,19 +15804,6 @@
       "requires": {
         "css-selector-tokenizer": "^0.7.0",
         "postcss": "^6.0.1"
-      },
-      "dependencies": {
-        "postcss": {
-          "version": "6.0.23",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.4.1",
-            "source-map": "^0.6.1",
-            "supports-color": "^5.4.0"
-          }
-        }
       }
     },
     "postcss-modules-values": {
@@ -16480,19 +15814,6 @@
       "requires": {
         "icss-replace-symbols": "^1.1.0",
         "postcss": "^6.0.1"
-      },
-      "dependencies": {
-        "postcss": {
-          "version": "6.0.23",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.4.1",
-            "source-map": "^0.6.1",
-            "supports-color": "^5.4.0"
-          }
-        }
       }
     },
     "postcss-reporter": {
@@ -16507,13 +15828,24 @@
         "postcss": "^7.0.7"
       },
       "dependencies": {
-        "log-symbols": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
-          "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+        "postcss": {
+          "version": "7.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
           "dev": true,
           "requires": {
-            "chalk": "^2.0.1"
+            "chalk": "^2.4.2",
+            "source-map": "^0.6.1",
+            "supports-color": "^6.1.0"
+          }
+        },
+        "supports-color": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -16531,6 +15863,28 @@
       "dev": true,
       "requires": {
         "postcss": "^7.0.0"
+      },
+      "dependencies": {
+        "postcss": {
+          "version": "7.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.4.2",
+            "source-map": "^0.6.1",
+            "supports-color": "^6.1.0"
+          }
+        },
+        "supports-color": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
       }
     },
     "postcss-sass": {
@@ -16541,6 +15895,28 @@
       "requires": {
         "gonzales-pe": "^4.2.3",
         "postcss": "^7.0.1"
+      },
+      "dependencies": {
+        "postcss": {
+          "version": "7.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.4.2",
+            "source-map": "^0.6.1",
+            "supports-color": "^6.1.0"
+          }
+        },
+        "supports-color": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
       }
     },
     "postcss-scss": {
@@ -16550,15 +15926,37 @@
       "dev": true,
       "requires": {
         "postcss": "^7.0.0"
+      },
+      "dependencies": {
+        "postcss": {
+          "version": "7.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.4.2",
+            "source-map": "^0.6.1",
+            "supports-color": "^6.1.0"
+          }
+        },
+        "supports-color": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
       }
     },
     "postcss-selector-parser": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
-      "integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz",
+      "integrity": "sha1-+UN3iGBsPJrO4W/+jYsWKX8nu5A=",
       "dev": true,
       "requires": {
-        "dot-prop": "^4.1.1",
+        "flatten": "^1.0.2",
         "indexes-of": "^1.0.1",
         "uniq": "^1.0.1"
       }
@@ -16571,19 +15969,6 @@
       "requires": {
         "lodash": "^4.17.4",
         "postcss": "^6.0.13"
-      },
-      "dependencies": {
-        "postcss": {
-          "version": "6.0.23",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.4.1",
-            "source-map": "^0.6.1",
-            "supports-color": "^5.4.0"
-          }
-        }
       }
     },
     "postcss-syntax": {
@@ -16593,9 +15978,9 @@
       "dev": true
     },
     "postcss-value-parser": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.0.0.tgz",
-      "integrity": "sha512-ESPktioptiSUchCKgggAkzdmkgzKfmp0EU8jXH+5kbIUB+unr0Y4CY9SRMvibuvYUBjNh1ACLbxqYNpdTQOteQ==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+      "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
       "dev": true
     },
     "prelude-ls": {
@@ -16605,9 +15990,9 @@
       "dev": true
     },
     "prepend-http": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
-      "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+      "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
       "dev": true
     },
     "preserve": {
@@ -16617,9 +16002,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.18.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.18.2.tgz",
-      "integrity": "sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.17.0.tgz",
+      "integrity": "sha512-sXe5lSt2WQlCbydGETgfm1YBShgOX4HxQkFPvbxkcwgDvGDeqVau8h+12+lmSVlP3rHPz0oavfddSZg/q+Szjw==",
       "dev": true
     },
     "prettier-linter-helpers": {
@@ -16655,16 +16040,10 @@
       "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
       "dev": true
     },
-    "process": {
-      "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
-      "dev": true
-    },
     "process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
       "dev": true
     },
     "progress": {
@@ -16747,9 +16126,9 @@
       "dev": true
     },
     "psl": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.2.0.tgz",
-      "integrity": "sha512-GEn74ZffufCmkDDLNcl3uuyF/aSD6exEyh1v/ZSdAomB82t6G9hzJVRx0jBmLDW+VfZqks3aScmMw9DszwUalA==",
+      "version": "1.1.31",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
+      "integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw==",
       "dev": true
     },
     "public-encrypt": {
@@ -16785,6 +16164,18 @@
         "duplexify": "^3.6.0",
         "inherits": "^2.0.3",
         "pump": "^2.0.0"
+      },
+      "dependencies": {
+        "pump": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+          "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+          "dev": true,
+          "requires": {
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
+          }
+        }
       }
     },
     "punycode": {
@@ -16798,23 +16189,6 @@
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
       "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
       "dev": true
-    },
-    "qs": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
-      "dev": true
-    },
-    "query-string": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
-      "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
-      "dev": true,
-      "requires": {
-        "decode-uri-component": "^0.2.0",
-        "object-assign": "^4.1.0",
-        "strict-uri-encode": "^1.0.0"
-      }
     },
     "querystring": {
       "version": "0.2.0",
@@ -16916,28 +16290,31 @@
       }
     },
     "range-parser": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+      "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=",
       "dev": true
     },
     "raw-body": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
-      "integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.3.tgz",
+      "integrity": "sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==",
       "dev": true,
       "requires": {
-        "bytes": "3.1.0",
-        "http-errors": "1.7.2",
-        "iconv-lite": "0.4.24",
+        "bytes": "3.0.0",
+        "http-errors": "1.6.3",
+        "iconv-lite": "0.4.23",
         "unpipe": "1.0.0"
       },
       "dependencies": {
-        "bytes": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
-          "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
-          "dev": true
+        "iconv-lite": {
+          "version": "0.4.23",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
+          "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+          "dev": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
         }
       }
     },
@@ -17035,6 +16412,12 @@
         "warning": "^3.0.0"
       },
       "dependencies": {
+        "hoist-non-react-statics": {
+          "version": "2.5.5",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
+          "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==",
+          "dev": true
+        },
         "recompose": {
           "version": "0.26.0",
           "resolved": "https://registry.npmjs.org/recompose/-/recompose-0.26.0.tgz",
@@ -17074,9 +16457,9 @@
       "dev": true
     },
     "react-markdown": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-4.1.0.tgz",
-      "integrity": "sha512-EOHsEAN+aoP8UVz7vTHx6Z63GJfhrO9KItKlfsiBtVVS9tmSWtUaBTw73+2SObrWiOiE2Cs9qUBL7ORsvVhOrA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-4.0.8.tgz",
+      "integrity": "sha512-Z6oa648rufvzyO0KwYJ/9p9AsdYGIluqK6OlpJ35ouJ8HPF0Ko1WDNdyymjDSHxNrkb7HDyEcIDJCQs8NlET5A==",
       "dev": true,
       "requires": {
         "html-to-react": "^1.3.4",
@@ -17114,6 +16497,27 @@
         "warning": "^4.0.1"
       },
       "dependencies": {
+        "hoist-non-react-statics": {
+          "version": "2.5.5",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
+          "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==",
+          "dev": true
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "path-to-regexp": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+          "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+          "dev": true,
+          "requires": {
+            "isarray": "0.0.1"
+          }
+        },
         "warning": {
           "version": "4.0.3",
           "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
@@ -17179,6 +16583,101 @@
         "lodash.clonedeep": "^4.5.0",
         "lodash.isplainobject": "^4.0.6",
         "svgo": "^1.2.2"
+      },
+      "dependencies": {
+        "@babel/core": {
+          "version": "7.4.5",
+          "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.4.5.tgz",
+          "integrity": "sha512-OvjIh6aqXtlsA8ujtGKfC7LYWksYSX8yQcM8Ay3LuvVeQ63lcOKgoZWVqcpFwkd29aYU9rVx7jxhfhiEDV9MZA==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@babel/generator": "^7.4.4",
+            "@babel/helpers": "^7.4.4",
+            "@babel/parser": "^7.4.5",
+            "@babel/template": "^7.4.4",
+            "@babel/traverse": "^7.4.5",
+            "@babel/types": "^7.4.4",
+            "convert-source-map": "^1.1.0",
+            "debug": "^4.1.0",
+            "json5": "^2.1.0",
+            "lodash": "^4.17.11",
+            "resolve": "^1.3.2",
+            "semver": "^5.4.1",
+            "source-map": "^0.5.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.4.5",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.5.tgz",
+          "integrity": "sha512-9mUqkL1FF5T7f0WDFfAoDdiMVPWsdD1gZYzSnaXsxUCUqzuch/8of9G3VUSNiZmMBoRxT3neyVsqeiL/ZPcjew==",
+          "dev": true
+        },
+        "@babel/traverse": {
+          "version": "7.4.5",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.5.tgz",
+          "integrity": "sha512-Vc+qjynwkjRmIFGxy0KYoPj4FdVDxLej89kMHFsWScq999uX+pwcX4v9mWRjW0KcAYTPAuVQl2LKP1wEVLsp+A==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@babel/generator": "^7.4.4",
+            "@babel/helper-function-name": "^7.1.0",
+            "@babel/helper-split-export-declaration": "^7.4.4",
+            "@babel/parser": "^7.4.5",
+            "@babel/types": "^7.4.4",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0",
+            "lodash": "^4.17.11"
+          }
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "globals": {
+          "version": "11.12.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+          "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+          "dev": true
+        },
+        "json5": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
+          "integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.0"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
       }
     },
     "react-svg-loader": {
@@ -17233,9 +16732,9 @@
       }
     },
     "react-window": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.5.tgz",
-      "integrity": "sha512-HeTwlNa37AFa8MDZFZOKcNEkuF2YflA0hpGPiTT9vR7OawEt+GZbfM6wqkBahD3D3pUjIabQYzsnY/BSJbgq6Q==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.1.tgz",
+      "integrity": "sha512-iNzekymggL9zAnil3QbmRG74RDMfIbO+plE/soP3M/zskicA1DwoLthC6/QA6xu9dr+A5UoawCTsEYcva2mfeA==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.0.0",
@@ -17261,45 +16760,24 @@
       }
     },
     "read-pkg": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+      "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
       "dev": true,
       "requires": {
-        "load-json-file": "^1.0.0",
+        "load-json-file": "^2.0.0",
         "normalize-package-data": "^2.3.2",
-        "path-type": "^1.0.0"
+        "path-type": "^2.0.0"
       }
     },
     "read-pkg-up": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+      "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
       "dev": true,
       "requires": {
-        "find-up": "^1.0.0",
-        "read-pkg": "^1.0.0"
-      },
-      "dependencies": {
-        "find-up": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-          "dev": true,
-          "requires": {
-            "path-exists": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
-          }
-        },
-        "path-exists": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-          "dev": true,
-          "requires": {
-            "pinkie-promise": "^2.0.0"
-          }
-        }
+        "find-up": "^2.0.0",
+        "read-pkg": "^2.0.0"
       }
     },
     "readable-stream": {
@@ -17326,313 +16804,6 @@
         "graceful-fs": "^4.1.11",
         "micromatch": "^3.1.10",
         "readable-stream": "^2.0.2"
-      },
-      "dependencies": {
-        "arr-diff": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
-          "dev": true
-        },
-        "array-unique": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-          "dev": true
-        },
-        "braces": {
-          "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-          "dev": true,
-          "requires": {
-            "arr-flatten": "^1.1.0",
-            "array-unique": "^0.3.2",
-            "extend-shallow": "^2.0.1",
-            "fill-range": "^4.0.0",
-            "isobject": "^3.0.1",
-            "repeat-element": "^1.1.2",
-            "snapdragon": "^0.8.1",
-            "snapdragon-node": "^2.0.1",
-            "split-string": "^3.0.2",
-            "to-regex": "^3.0.1"
-          },
-          "dependencies": {
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            }
-          }
-        },
-        "expand-brackets": {
-          "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
-          "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
-          "dev": true,
-          "requires": {
-            "debug": "^2.3.3",
-            "define-property": "^0.2.5",
-            "extend-shallow": "^2.0.1",
-            "posix-character-classes": "^0.1.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
-          },
-          "dependencies": {
-            "define-property": {
-              "version": "0.2.5",
-              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-              "dev": true,
-              "requires": {
-                "is-descriptor": "^0.1.0"
-              }
-            },
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            },
-            "is-accessor-descriptor": {
-              "version": "0.1.6",
-              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-              "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-              "dev": true,
-              "requires": {
-                "kind-of": "^3.0.2"
-              },
-              "dependencies": {
-                "kind-of": {
-                  "version": "3.2.2",
-                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                  "dev": true,
-                  "requires": {
-                    "is-buffer": "^1.1.5"
-                  }
-                }
-              }
-            },
-            "is-data-descriptor": {
-              "version": "0.1.4",
-              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-              "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-              "dev": true,
-              "requires": {
-                "kind-of": "^3.0.2"
-              },
-              "dependencies": {
-                "kind-of": {
-                  "version": "3.2.2",
-                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                  "dev": true,
-                  "requires": {
-                    "is-buffer": "^1.1.5"
-                  }
-                }
-              }
-            },
-            "is-descriptor": {
-              "version": "0.1.6",
-              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-              "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-              "dev": true,
-              "requires": {
-                "is-accessor-descriptor": "^0.1.6",
-                "is-data-descriptor": "^0.1.4",
-                "kind-of": "^5.0.0"
-              }
-            },
-            "kind-of": {
-              "version": "5.1.0",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-              "dev": true
-            }
-          }
-        },
-        "extend-shallow": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
-          "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
-          "dev": true,
-          "requires": {
-            "assign-symbols": "^1.0.0",
-            "is-extendable": "^1.0.1"
-          },
-          "dependencies": {
-            "is-extendable": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-              "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-              "dev": true,
-              "requires": {
-                "is-plain-object": "^2.0.4"
-              }
-            }
-          }
-        },
-        "extglob": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
-          "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
-          "dev": true,
-          "requires": {
-            "array-unique": "^0.3.2",
-            "define-property": "^1.0.0",
-            "expand-brackets": "^2.1.4",
-            "extend-shallow": "^2.0.1",
-            "fragment-cache": "^0.2.1",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
-          },
-          "dependencies": {
-            "define-property": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-              "dev": true,
-              "requires": {
-                "is-descriptor": "^1.0.0"
-              }
-            },
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            }
-          }
-        },
-        "fill-range": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-          "dev": true,
-          "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1",
-            "to-regex-range": "^2.1.0"
-          },
-          "dependencies": {
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            }
-          }
-        },
-        "is-accessor-descriptor": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-          "dev": true,
-          "requires": {
-            "kind-of": "^6.0.0"
-          }
-        },
-        "is-data-descriptor": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-          "dev": true,
-          "requires": {
-            "kind-of": "^6.0.0"
-          }
-        },
-        "is-descriptor": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-          "dev": true,
-          "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
-          }
-        },
-        "is-number": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "dev": true,
-          "requires": {
-            "kind-of": "^3.0.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "^1.1.5"
-              }
-            }
-          }
-        },
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
-        },
-        "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-          "dev": true
-        },
-        "micromatch": {
-          "version": "3.1.10",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-          "dev": true,
-          "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "braces": "^2.3.1",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "extglob": "^2.0.4",
-            "fragment-cache": "^0.2.1",
-            "kind-of": "^6.0.2",
-            "nanomatch": "^1.2.9",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.2"
-          }
-        },
-        "to-regex-range": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
-          "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
-          "dev": true,
-          "requires": {
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1"
-          }
-        }
       }
     },
     "readline-sync": {
@@ -17640,15 +16811,6 @@
       "resolved": "https://registry.npmjs.org/readline-sync/-/readline-sync-1.4.9.tgz",
       "integrity": "sha1-PtqOZfI80qF+YTAbHwADOWr17No=",
       "dev": true
-    },
-    "rechoir": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-      "dev": true,
-      "requires": {
-        "resolve": "^1.1.6"
-      }
     },
     "recompose": {
       "version": "0.30.0",
@@ -17662,6 +16824,14 @@
         "hoist-non-react-statics": "^2.3.1",
         "react-lifecycles-compat": "^3.0.2",
         "symbol-observable": "^1.0.4"
+      },
+      "dependencies": {
+        "hoist-non-react-statics": {
+          "version": "2.5.5",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
+          "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==",
+          "dev": true
+        }
       }
     },
     "redent": {
@@ -17731,27 +16901,6 @@
       "requires": {
         "extend-shallow": "^3.0.2",
         "safe-regex": "^1.1.0"
-      },
-      "dependencies": {
-        "extend-shallow": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
-          "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
-          "dev": true,
-          "requires": {
-            "assign-symbols": "^1.0.0",
-            "is-extendable": "^1.0.1"
-          }
-        },
-        "is-extendable": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-          "dev": true,
-          "requires": {
-            "is-plain-object": "^2.0.4"
-          }
-        }
       }
     },
     "regexpp": {
@@ -17761,9 +16910,9 @@
       "dev": true
     },
     "regexpu-core": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
-      "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
+      "integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
       "dev": true,
       "requires": {
         "regenerate": "^1.2.1",
@@ -17784,14 +16933,6 @@
       "dev": true,
       "requires": {
         "jsesc": "~0.5.0"
-      },
-      "dependencies": {
-        "jsesc": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-          "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
-          "dev": true
-        }
       }
     },
     "remark": {
@@ -17970,21 +17111,11 @@
         "uuid": "^3.3.2"
       },
       "dependencies": {
-        "punycode": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+        "qs": {
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
           "dev": true
-        },
-        "tough-cookie": {
-          "version": "2.4.3",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
-          "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
-          "dev": true,
-          "requires": {
-            "psl": "^1.1.24",
-            "punycode": "^1.4.1"
-          }
         }
       }
     },
@@ -18019,9 +17150,9 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz",
-      "integrity": "sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.1.tgz",
+      "integrity": "sha512-KuIe4mf++td/eFb6wkaPbMDnP6kObCaEtIDuHOUED6MNUo4K670KZUHuuvYPZDxNF0WVLw49n06M2m2dXphEzA==",
       "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
@@ -18034,20 +17165,12 @@
       "dev": true,
       "requires": {
         "resolve-from": "^3.0.0"
-      },
-      "dependencies": {
-        "resolve-from": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-          "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
-          "dev": true
-        }
       }
     },
     "resolve-from": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+      "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
       "dev": true
     },
     "resolve-pathname": {
@@ -18061,15 +17184,6 @@
       "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
       "dev": true
-    },
-    "responselike": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
-      "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
-      "dev": true,
-      "requires": {
-        "lowercase-keys": "^1.0.0"
-      }
     },
     "restore-cursor": {
       "version": "2.0.0",
@@ -18186,9 +17300,9 @@
       "dev": true
     },
     "rxjs": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.2.tgz",
-      "integrity": "sha512-HUb7j3kvb7p7eCUHE3FqjoDsC1xfZQ4AHFWfTKSpZ+sAhhz5X1WX0ZuUqWbzB2QhSLp3DoLUG+hMdEDKqWo2Zg==",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.1.tgz",
+      "integrity": "sha512-y0j31WJc83wPu31vS1VlAFW5JGrnGC+j+TtGAa1fRQphy48+fDYiDmX8tjGloToEsMkxnouOg/1IzXGKkJnZMg==",
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"
@@ -18232,316 +17346,11 @@
         "watch": "~0.18.0"
       },
       "dependencies": {
-        "arr-diff": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
-          "dev": true
-        },
-        "array-unique": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-          "dev": true
-        },
-        "braces": {
-          "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-          "dev": true,
-          "requires": {
-            "arr-flatten": "^1.1.0",
-            "array-unique": "^0.3.2",
-            "extend-shallow": "^2.0.1",
-            "fill-range": "^4.0.0",
-            "isobject": "^3.0.1",
-            "repeat-element": "^1.1.2",
-            "snapdragon": "^0.8.1",
-            "snapdragon-node": "^2.0.1",
-            "split-string": "^3.0.2",
-            "to-regex": "^3.0.1"
-          },
-          "dependencies": {
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            }
-          }
-        },
-        "expand-brackets": {
-          "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
-          "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
-          "dev": true,
-          "requires": {
-            "debug": "^2.3.3",
-            "define-property": "^0.2.5",
-            "extend-shallow": "^2.0.1",
-            "posix-character-classes": "^0.1.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
-          },
-          "dependencies": {
-            "define-property": {
-              "version": "0.2.5",
-              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-              "dev": true,
-              "requires": {
-                "is-descriptor": "^0.1.0"
-              }
-            },
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            },
-            "is-accessor-descriptor": {
-              "version": "0.1.6",
-              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-              "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-              "dev": true,
-              "requires": {
-                "kind-of": "^3.0.2"
-              },
-              "dependencies": {
-                "kind-of": {
-                  "version": "3.2.2",
-                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                  "dev": true,
-                  "requires": {
-                    "is-buffer": "^1.1.5"
-                  }
-                }
-              }
-            },
-            "is-data-descriptor": {
-              "version": "0.1.4",
-              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-              "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-              "dev": true,
-              "requires": {
-                "kind-of": "^3.0.2"
-              },
-              "dependencies": {
-                "kind-of": {
-                  "version": "3.2.2",
-                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                  "dev": true,
-                  "requires": {
-                    "is-buffer": "^1.1.5"
-                  }
-                }
-              }
-            },
-            "is-descriptor": {
-              "version": "0.1.6",
-              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-              "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-              "dev": true,
-              "requires": {
-                "is-accessor-descriptor": "^0.1.6",
-                "is-data-descriptor": "^0.1.4",
-                "kind-of": "^5.0.0"
-              }
-            },
-            "kind-of": {
-              "version": "5.1.0",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-              "dev": true
-            }
-          }
-        },
-        "extend-shallow": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
-          "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
-          "dev": true,
-          "requires": {
-            "assign-symbols": "^1.0.0",
-            "is-extendable": "^1.0.1"
-          },
-          "dependencies": {
-            "is-extendable": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-              "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-              "dev": true,
-              "requires": {
-                "is-plain-object": "^2.0.4"
-              }
-            }
-          }
-        },
-        "extglob": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
-          "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
-          "dev": true,
-          "requires": {
-            "array-unique": "^0.3.2",
-            "define-property": "^1.0.0",
-            "expand-brackets": "^2.1.4",
-            "extend-shallow": "^2.0.1",
-            "fragment-cache": "^0.2.1",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
-          },
-          "dependencies": {
-            "define-property": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-              "dev": true,
-              "requires": {
-                "is-descriptor": "^1.0.0"
-              }
-            },
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            }
-          }
-        },
-        "fill-range": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-          "dev": true,
-          "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1",
-            "to-regex-range": "^2.1.0"
-          },
-          "dependencies": {
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            }
-          }
-        },
-        "is-accessor-descriptor": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-          "dev": true,
-          "requires": {
-            "kind-of": "^6.0.0"
-          }
-        },
-        "is-data-descriptor": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-          "dev": true,
-          "requires": {
-            "kind-of": "^6.0.0"
-          }
-        },
-        "is-descriptor": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-          "dev": true,
-          "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
-          }
-        },
-        "is-number": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "dev": true,
-          "requires": {
-            "kind-of": "^3.0.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "^1.1.5"
-              }
-            }
-          }
-        },
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
-        },
-        "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-          "dev": true
-        },
-        "micromatch": {
-          "version": "3.1.10",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-          "dev": true,
-          "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "braces": "^2.3.1",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "extglob": "^2.0.4",
-            "fragment-cache": "^0.2.1",
-            "kind-of": "^6.0.2",
-            "nanomatch": "^1.2.9",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.2"
-          }
-        },
         "minimist": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
-        },
-        "to-regex-range": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
-          "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
-          "dev": true,
-          "requires": {
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1"
-          }
         }
       }
     },
@@ -18574,13 +17383,27 @@
             "wrap-ansi": "^2.0.0"
           }
         },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+        "find-up": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "dev": true,
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "load-json-file": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0",
+            "strip-bom": "^2.0.0"
           }
         },
         "os-locale": {
@@ -18592,27 +17415,69 @@
             "lcid": "^1.0.0"
           }
         },
-        "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+        "parse-json": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
           "dev": true,
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "error-ex": "^1.2.0"
+          }
+        },
+        "path-exists": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+          "dev": true,
+          "requires": {
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "path-type": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "read-pkg": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "^1.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^1.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+          "dev": true,
+          "requires": {
+            "find-up": "^1.0.0",
+            "read-pkg": "^1.0.0"
+          }
+        },
+        "strip-bom": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "dev": true,
+          "requires": {
+            "is-utf8": "^0.2.0"
           }
         },
         "which-module": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
           "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
-          "dev": true
-        },
-        "y18n": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
           "dev": true
         },
         "yargs": {
@@ -18681,41 +17546,6 @@
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
       "dev": true
     },
-    "schema-utils": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.3.0.tgz",
-      "integrity": "sha1-9YdyIs4+kx7a4DnxfrNxbnE3+M8=",
-      "dev": true,
-      "requires": {
-        "ajv": "^5.0.0"
-      },
-      "dependencies": {
-        "ajv": {
-          "version": "5.5.2",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
-          "dev": true,
-          "requires": {
-            "co": "^4.6.0",
-            "fast-deep-equal": "^1.0.0",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.3.0"
-          }
-        },
-        "fast-deep-equal": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-          "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
-          "dev": true
-        },
-        "json-schema-traverse": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-          "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
-          "dev": true
-        }
-      }
-    },
     "scriptjs": {
       "version": "2.5.9",
       "resolved": "https://registry.npmjs.org/scriptjs/-/scriptjs-2.5.9.tgz",
@@ -18765,9 +17595,9 @@
       }
     },
     "semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.0.0.tgz",
+      "integrity": "sha512-0UewU+9rFapKFnlbirLi3byoOuhrSsli/z/ihNnvM24vgF+8sNBiI1LZPBSH9wJKUwaUbw+s3hToDLCXkrghrQ==",
       "dev": true
     },
     "semver-compare": {
@@ -18777,9 +17607,9 @@
       "dev": true
     },
     "send": {
-      "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
-      "integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
+      "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
       "dev": true,
       "requires": {
         "debug": "2.6.9",
@@ -18789,20 +17619,12 @@
         "escape-html": "~1.0.3",
         "etag": "~1.8.1",
         "fresh": "0.5.2",
-        "http-errors": "~1.7.2",
-        "mime": "1.6.0",
-        "ms": "2.1.1",
+        "http-errors": "~1.6.2",
+        "mime": "1.4.1",
+        "ms": "2.0.0",
         "on-finished": "~2.3.0",
-        "range-parser": "~1.2.1",
-        "statuses": "~1.5.0"
-      },
-      "dependencies": {
-        "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-          "dev": true
-        }
+        "range-parser": "~1.2.0",
+        "statuses": "~1.4.0"
       }
     },
     "serialize-javascript": {
@@ -18824,44 +17646,18 @@
         "http-errors": "~1.6.2",
         "mime-types": "~2.1.17",
         "parseurl": "~1.3.2"
-      },
-      "dependencies": {
-        "http-errors": {
-          "version": "1.6.3",
-          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
-          "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
-          "dev": true,
-          "requires": {
-            "depd": "~1.1.2",
-            "inherits": "2.0.3",
-            "setprototypeof": "1.1.0",
-            "statuses": ">= 1.4.0 < 2"
-          }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
-        },
-        "setprototypeof": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-          "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
-          "dev": true
-        }
       }
     },
     "serve-static": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
-      "integrity": "sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
+      "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
       "dev": true,
       "requires": {
         "encodeurl": "~1.0.2",
         "escape-html": "~1.0.3",
-        "parseurl": "~1.3.3",
-        "send": "0.17.1"
+        "parseurl": "~1.3.2",
+        "send": "0.16.2"
       }
     },
     "set-blocking": {
@@ -18871,15 +17667,26 @@
       "dev": true
     },
     "set-value": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
-      "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
+      "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
       "dev": true,
       "requires": {
         "extend-shallow": "^2.0.1",
         "is-extendable": "^0.1.1",
         "is-plain-object": "^2.0.3",
         "split-string": "^3.0.1"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
       }
     },
     "setimmediate": {
@@ -18889,9 +17696,9 @@
       "dev": true
     },
     "setprototypeof": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
-      "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+      "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
       "dev": true
     },
     "sha.js": {
@@ -18924,9 +17731,9 @@
       }
     },
     "shallow-equal": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/shallow-equal/-/shallow-equal-1.2.0.tgz",
-      "integrity": "sha512-Z21pVxR4cXsfwpMKMhCEIO1PCi5sp7KEp+CmOpBQ+E8GpHwKOw2sEzk7sgblM3d/j4z4gakoWEoPcjK0VJQogA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shallow-equal/-/shallow-equal-1.1.0.tgz",
+      "integrity": "sha512-0SW1nWo1hnabO62SEeHsl8nmTVVEzguVWZCj5gaQrgWAxz/BaCja4OWdJBWLVPDxdtE/WU7c98uUCCXyPHSCvw==",
       "dev": true
     },
     "shallowequal": {
@@ -18949,17 +17756,6 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
-    },
-    "shelljs": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.3.tgz",
-      "integrity": "sha512-fc0BKlAWiLpwZljmOvAOTE/gXawtCoNrP5oaY7KIaQbbyHeQVg01pSEuEGvGh3HEdBU4baCD7wQBwADmM/7f7A==",
-      "dev": true,
-      "requires": {
-        "glob": "^7.0.0",
-        "interpret": "^1.0.0",
-        "rechoir": "^0.6.2"
-      }
     },
     "shellwords": {
       "version": "0.1.1",
@@ -19015,6 +17811,14 @@
         "ansi-styles": "^3.2.0",
         "astral-regex": "^1.0.0",
         "is-fullwidth-code-point": "^2.0.0"
+      },
+      "dependencies": {
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        }
       }
     },
     "snapdragon": {
@@ -19040,6 +17844,15 @@
           "dev": true,
           "requires": {
             "is-descriptor": "^0.1.0"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
           }
         },
         "source-map": {
@@ -19099,12 +17912,6 @@
             "kind-of": "^6.0.2"
           }
         },
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
-        },
         "kind-of": {
           "version": "6.0.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
@@ -19130,6 +17937,17 @@
       "requires": {
         "faye-websocket": "^0.10.0",
         "uuid": "^3.0.1"
+      },
+      "dependencies": {
+        "faye-websocket": {
+          "version": "0.10.0",
+          "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
+          "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
+          "dev": true,
+          "requires": {
+            "websocket-driver": ">=0.5.1"
+          }
+        }
       }
     },
     "sockjs-client": {
@@ -19144,26 +17962,6 @@
         "inherits": "^2.0.1",
         "json3": "^3.3.2",
         "url-parse": "^1.1.8"
-      },
-      "dependencies": {
-        "faye-websocket": {
-          "version": "0.11.3",
-          "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.3.tgz",
-          "integrity": "sha512-D2y4bovYpzziGgbHYtGCMjlJM36vAl/y+xUyn1C+FVx8szd1E+86KwVw6XvYSzOP8iMpm1X0I4xJD+QtUb36OA==",
-          "dev": true,
-          "requires": {
-            "websocket-driver": ">=0.5.1"
-          }
-        }
-      }
-    },
-    "sort-keys": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
-      "integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
-      "dev": true,
-      "requires": {
-        "is-plain-obj": "^1.0.0"
       }
     },
     "source-list-map": {
@@ -19251,9 +18049,9 @@
       }
     },
     "spdx-license-ids": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
-      "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.4.tgz",
+      "integrity": "sha512-7j8LYJLeY/Yb6ACbQ7F76qy5jHkp0U6jgBfJsk97bwWlVUnUWsAgpyaCvo17h0/RQGnQ036tVDomiwoI4pDkQA==",
       "dev": true
     },
     "spdy": {
@@ -19279,9 +18077,9 @@
           }
         },
         "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
           "dev": true
         }
       }
@@ -19310,15 +18108,15 @@
           }
         },
         "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
           "dev": true
         },
         "readable-stream": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
-          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.3.0.tgz",
+          "integrity": "sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==",
           "dev": true,
           "requires": {
             "inherits": "^2.0.3",
@@ -19341,27 +18139,6 @@
       "dev": true,
       "requires": {
         "extend-shallow": "^3.0.0"
-      },
-      "dependencies": {
-        "extend-shallow": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
-          "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
-          "dev": true,
-          "requires": {
-            "assign-symbols": "^1.0.0",
-            "is-extendable": "^1.0.1"
-          }
-        },
-        "is-extendable": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-          "dev": true,
-          "requires": {
-            "is-plain-object": "^2.0.4"
-          }
-        }
       }
     },
     "split2": {
@@ -19454,9 +18231,9 @@
       "dev": true
     },
     "state-toggle": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/state-toggle/-/state-toggle-1.0.2.tgz",
-      "integrity": "sha512-8LpelPGR0qQM4PnfLiplOQNJcIN1/r2Gy0xKB2zKnIW2YzPMt2sR4I/+gtPjhN7Svh9kw+zqEg2SFwpBO9iNiw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/state-toggle/-/state-toggle-1.0.1.tgz",
+      "integrity": "sha512-Qe8QntFrrpWTnHwvwj2FZTgv+PKIsp0B9VxLzLLbSpPXWOgRgc5LVj/aTiSfK1RqIeF9jeC1UeOH8Q8y60A7og==",
       "dev": true
     },
     "static-extend": {
@@ -19515,13 +18292,19 @@
             "lodash.reject": "^4.4.0",
             "lodash.some": "^4.4.0"
           }
+        },
+        "lodash.bind": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-4.2.1.tgz",
+          "integrity": "sha1-euMBfpOWIqwxt9fX3LGzTbFpDTU=",
+          "dev": true
         }
       }
     },
     "statuses": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+      "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
       "dev": true
     },
     "stdout-stream": {
@@ -19582,12 +18365,6 @@
       "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
       "dev": true
     },
-    "strict-uri-encode": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
-      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
-      "dev": true
-    },
     "string-argv": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.0.tgz",
@@ -19622,30 +18399,14 @@
       }
     },
     "string-width": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "dev": true,
       "requires": {
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^4.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^3.0.0"
-          }
-        }
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
       }
     },
     "string.prototype.trim": {
@@ -19701,13 +18462,10 @@
       }
     },
     "strip-bom": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-      "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-      "dev": true,
-      "requires": {
-        "is-utf8": "^0.2.0"
-      }
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "dev": true
     },
     "strip-eof": {
       "version": "1.0.0",
@@ -19877,17 +18635,6 @@
             "postcss": "^5.0.0"
           }
         },
-        "postcss-selector-parser": {
-          "version": "2.2.3",
-          "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz",
-          "integrity": "sha1-+UN3iGBsPJrO4W/+jYsWKX8nu5A=",
-          "dev": true,
-          "requires": {
-            "flatten": "^1.0.2",
-            "indexes-of": "^1.0.1",
-            "uniq": "^1.0.1"
-          }
-        },
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -19969,46 +18716,17 @@
           "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
           "dev": true
         },
-        "arr-diff": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+        "balanced-match": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
           "dev": true
         },
-        "array-unique": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
           "dev": true
-        },
-        "braces": {
-          "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-          "dev": true,
-          "requires": {
-            "arr-flatten": "^1.1.0",
-            "array-unique": "^0.3.2",
-            "extend-shallow": "^2.0.1",
-            "fill-range": "^4.0.0",
-            "isobject": "^3.0.1",
-            "repeat-element": "^1.1.2",
-            "snapdragon": "^0.8.1",
-            "snapdragon-node": "^2.0.1",
-            "split-string": "^3.0.2",
-            "to-regex": "^3.0.1"
-          },
-          "dependencies": {
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            }
-          }
         },
         "camelcase-keys": {
           "version": "4.2.0",
@@ -20021,6 +18739,18 @@
             "quick-lru": "^1.0.0"
           }
         },
+        "cosmiconfig": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.0.tgz",
+          "integrity": "sha512-nxt+Nfc3JAqf4WIWd0jXLjTJZmsPLrA9DDc4nRw2KFJQJK7DNooqSXrNI7tzLG50CF8axczly5UV929tBmh/7g==",
+          "dev": true,
+          "requires": {
+            "import-fresh": "^2.0.0",
+            "is-directory": "^0.3.1",
+            "js-yaml": "^3.13.0",
+            "parse-json": "^4.0.0"
+          }
+        },
         "debug": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -20028,170 +18758,6 @@
           "dev": true,
           "requires": {
             "ms": "^2.1.1"
-          }
-        },
-        "expand-brackets": {
-          "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
-          "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
-          "dev": true,
-          "requires": {
-            "debug": "^2.3.3",
-            "define-property": "^0.2.5",
-            "extend-shallow": "^2.0.1",
-            "posix-character-classes": "^0.1.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "2.6.9",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-              "dev": true,
-              "requires": {
-                "ms": "2.0.0"
-              }
-            },
-            "define-property": {
-              "version": "0.2.5",
-              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-              "dev": true,
-              "requires": {
-                "is-descriptor": "^0.1.0"
-              }
-            },
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            },
-            "is-accessor-descriptor": {
-              "version": "0.1.6",
-              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-              "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-              "dev": true,
-              "requires": {
-                "kind-of": "^3.0.2"
-              },
-              "dependencies": {
-                "kind-of": {
-                  "version": "3.2.2",
-                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                  "dev": true,
-                  "requires": {
-                    "is-buffer": "^1.1.5"
-                  }
-                }
-              }
-            },
-            "is-data-descriptor": {
-              "version": "0.1.4",
-              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-              "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-              "dev": true,
-              "requires": {
-                "kind-of": "^3.0.2"
-              },
-              "dependencies": {
-                "kind-of": {
-                  "version": "3.2.2",
-                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                  "dev": true,
-                  "requires": {
-                    "is-buffer": "^1.1.5"
-                  }
-                }
-              }
-            },
-            "is-descriptor": {
-              "version": "0.1.6",
-              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-              "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-              "dev": true,
-              "requires": {
-                "is-accessor-descriptor": "^0.1.6",
-                "is-data-descriptor": "^0.1.4",
-                "kind-of": "^5.0.0"
-              }
-            },
-            "kind-of": {
-              "version": "5.1.0",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-              "dev": true
-            },
-            "ms": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-              "dev": true
-            }
-          }
-        },
-        "extend-shallow": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
-          "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
-          "dev": true,
-          "requires": {
-            "assign-symbols": "^1.0.0",
-            "is-extendable": "^1.0.1"
-          },
-          "dependencies": {
-            "is-extendable": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-              "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-              "dev": true,
-              "requires": {
-                "is-plain-object": "^2.0.4"
-              }
-            }
-          }
-        },
-        "extglob": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
-          "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
-          "dev": true,
-          "requires": {
-            "array-unique": "^0.3.2",
-            "define-property": "^1.0.0",
-            "expand-brackets": "^2.1.4",
-            "extend-shallow": "^2.0.1",
-            "fragment-cache": "^0.2.1",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
-          },
-          "dependencies": {
-            "define-property": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-              "dev": true,
-              "requires": {
-                "is-descriptor": "^1.0.0"
-              }
-            },
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            }
           }
         },
         "fast-glob": {
@@ -20217,48 +18783,24 @@
             "flat-cache": "^2.0.1"
           }
         },
-        "fill-range": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+        "global-modules": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
+          "integrity": "sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==",
           "dev": true,
           "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1",
-            "to-regex-range": "^2.1.0"
-          },
-          "dependencies": {
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            }
+            "global-prefix": "^3.0.0"
           }
         },
-        "glob-parent": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
-          "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+        "global-prefix": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
+          "integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
           "dev": true,
           "requires": {
-            "is-glob": "^3.1.0",
-            "path-dirname": "^1.0.0"
-          },
-          "dependencies": {
-            "is-glob": {
-              "version": "3.1.0",
-              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-              "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-              "dev": true,
-              "requires": {
-                "is-extglob": "^2.1.0"
-              }
-            }
+            "ini": "^1.3.5",
+            "kind-of": "^6.0.2",
+            "which": "^1.3.1"
           }
         },
         "globby": {
@@ -20286,79 +18828,21 @@
           }
         },
         "ignore": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.2.tgz",
-          "integrity": "sha512-vdqWBp7MyzdmHkkRWV5nY+PfGRbYbahfuvsBCh277tq+w9zyNi7h5CYJCK0kmzti9kU+O/cB7sE8HvKv6aXAKQ==",
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.1.tgz",
+          "integrity": "sha512-DWjnQIFLenVrwyRCKZT+7a7/U4Cqgar4WG8V++K3hw+lrW1hc/SIwdiGmtxKCVACmHULTuGeBbHJmbwW7/sAvA==",
           "dev": true
         },
-        "is-accessor-descriptor": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-          "dev": true,
-          "requires": {
-            "kind-of": "^6.0.0"
-          }
-        },
-        "is-data-descriptor": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-          "dev": true,
-          "requires": {
-            "kind-of": "^6.0.0"
-          }
-        },
-        "is-descriptor": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-          "dev": true,
-          "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
-          }
-        },
-        "is-extglob": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+        "import-lazy": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-3.1.0.tgz",
+          "integrity": "sha512-8/gvXvX2JMn0F+CDlSC4l6kOmVaLOO3XLkksI7CI3Ud95KDYJuYur2b9P/PUt/i/pDAMd/DulQsNbbbmRRsDIQ==",
           "dev": true
         },
-        "is-glob": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
-          "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
-          "dev": true,
-          "requires": {
-            "is-extglob": "^2.1.1"
-          }
-        },
-        "is-number": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "dev": true,
-          "requires": {
-            "kind-of": "^3.0.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "^1.1.5"
-              }
-            }
-          }
-        },
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
         "kind-of": {
@@ -20387,15 +18871,6 @@
             }
           }
         },
-        "log-symbols": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
-          "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.0.1"
-          }
-        },
         "map-obj": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
@@ -20419,42 +18894,11 @@
             "yargs-parser": "^10.0.0"
           }
         },
-        "micromatch": {
-          "version": "3.1.10",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-          "dev": true,
-          "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "braces": "^2.3.1",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "extglob": "^2.0.4",
-            "fragment-cache": "^0.2.1",
-            "kind-of": "^6.0.2",
-            "nanomatch": "^1.2.9",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.2"
-          }
-        },
         "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
           "dev": true
-        },
-        "parse-json": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-          "dev": true,
-          "requires": {
-            "error-ex": "^1.3.1",
-            "json-parse-better-errors": "^1.0.1"
-          }
         },
         "path-type": {
           "version": "3.0.0",
@@ -20479,11 +18923,27 @@
           "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
           "dev": true
         },
-        "postcss-value-parser": {
-          "version": "3.3.1",
-          "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-          "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
-          "dev": true
+        "postcss": {
+          "version": "7.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.4.2",
+            "source-map": "^0.6.1",
+            "supports-color": "^6.1.0"
+          }
+        },
+        "postcss-selector-parser": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
+          "integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
+          "dev": true,
+          "requires": {
+            "dot-prop": "^4.1.1",
+            "indexes-of": "^1.0.1",
+            "uniq": "^1.0.1"
+          }
         },
         "read-pkg": {
           "version": "3.0.0",
@@ -20516,6 +18976,12 @@
             "strip-indent": "^2.0.0"
           }
         },
+        "resolve-from": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+          "dev": true
+        },
         "slash": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
@@ -20542,26 +19008,19 @@
             "ansi-regex": "^4.1.0"
           }
         },
-        "strip-bom": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-          "dev": true
-        },
         "strip-indent": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
           "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
           "dev": true
         },
-        "to-regex-range": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
-          "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+        "supports-color": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "dev": true,
           "requires": {
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1"
+            "has-flag": "^3.0.0"
           }
         },
         "trim-newlines": {
@@ -20617,10 +19076,31 @@
         "stylelint": "^7.6.0"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
         "ansi-styles": {
           "version": "2.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
           "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "arr-diff": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+          "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "^1.0.1"
+          }
+        },
+        "array-unique": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+          "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
           "dev": true
         },
         "autoprefixer": {
@@ -20637,11 +19117,16 @@
             "postcss-value-parser": "^3.2.3"
           }
         },
-        "balanced-match": {
-          "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-          "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
-          "dev": true
+        "braces": {
+          "version": "1.8.5",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+          "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+          "dev": true,
+          "requires": {
+            "expand-range": "^1.8.1",
+            "preserve": "^0.2.0",
+            "repeat-element": "^1.1.2"
+          }
         },
         "browserslist": {
           "version": "1.7.7",
@@ -20666,6 +19151,24 @@
             "os-homedir": "^1.0.1",
             "parse-json": "^2.2.0",
             "require-from-string": "^1.1.0"
+          }
+        },
+        "expand-brackets": {
+          "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+          "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+          "dev": true,
+          "requires": {
+            "is-posix-bracket": "^0.1.0"
+          }
+        },
+        "extglob": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+          "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "^1.0.0"
           }
         },
         "file-entry-cache": {
@@ -20715,6 +19218,27 @@
           "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
           "dev": true
         },
+        "is-extglob": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "^1.0.0"
+          }
+        },
         "known-css-properties": {
           "version": "0.2.0",
           "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.2.0.tgz",
@@ -20751,11 +19275,50 @@
             }
           }
         },
+        "micromatch": {
+          "version": "2.3.11",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+          "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+          "dev": true,
+          "requires": {
+            "arr-diff": "^2.0.0",
+            "array-unique": "^0.2.1",
+            "braces": "^1.8.2",
+            "expand-brackets": "^0.1.4",
+            "extglob": "^0.3.1",
+            "filename-regex": "^2.0.0",
+            "is-extglob": "^1.0.0",
+            "is-glob": "^2.0.1",
+            "kind-of": "^3.0.2",
+            "normalize-path": "^2.0.1",
+            "object.omit": "^2.0.0",
+            "parse-glob": "^3.0.4",
+            "regex-cache": "^0.4.2"
+          }
+        },
         "minimist": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
+        },
+        "normalize-path": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+          "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+          "dev": true,
+          "requires": {
+            "remove-trailing-separator": "^1.0.1"
+          }
+        },
+        "parse-json": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.2.0"
+          }
         },
         "postcss": {
           "version": "5.2.18",
@@ -20843,33 +19406,10 @@
             "postcss": "^5.2.13"
           }
         },
-        "postcss-selector-parser": {
-          "version": "2.2.3",
-          "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz",
-          "integrity": "sha1-+UN3iGBsPJrO4W/+jYsWKX8nu5A=",
-          "dev": true,
-          "requires": {
-            "flatten": "^1.0.2",
-            "indexes-of": "^1.0.1",
-            "uniq": "^1.0.1"
-          }
-        },
-        "postcss-value-parser": {
-          "version": "3.3.1",
-          "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-          "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
-          "dev": true
-        },
         "require-from-string": {
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-1.2.1.tgz",
           "integrity": "sha1-UpyczvJzgK3+yaL5ZbZJu+5jZBg=",
-          "dev": true
-        },
-        "resolve-from": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-          "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
           "dev": true
         },
         "slice-ansi": {
@@ -20892,6 +19432,27 @@
           "resolved": "https://registry.npmjs.org/specificity/-/specificity-0.3.2.tgz",
           "integrity": "sha512-Nc/QN/A425Qog7j9aHmwOrlwX2e7pNI47ciwxwy4jOlvbbMHkNNJchit+FX+UjF3IAdiaaV5BKeWuDUnws6G1A==",
           "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          },
+          "dependencies": {
+            "strip-ansi": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            }
+          }
         },
         "stylelint": {
           "version": "7.13.0",
@@ -20992,19 +19553,6 @@
         "lodash": "^4.17.4",
         "postcss": "^6.0.14",
         "postcss-sorting": "^3.1.0"
-      },
-      "dependencies": {
-        "postcss": {
-          "version": "6.0.23",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.4.1",
-            "source-map": "^0.6.1",
-            "supports-color": "^5.4.0"
-          }
-        }
       }
     },
     "stylelint-scss": {
@@ -21020,11 +19568,16 @@
         "postcss-value-parser": "^3.3.0"
       },
       "dependencies": {
-        "postcss-value-parser": {
-          "version": "3.3.1",
-          "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-          "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
-          "dev": true
+        "postcss-selector-parser": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
+          "integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
+          "dev": true,
+          "requires": {
+            "dot-prop": "^4.1.1",
+            "indexes-of": "^1.0.1",
+            "uniq": "^1.0.1"
+          }
         }
       }
     },
@@ -21035,6 +19588,28 @@
       "dev": true,
       "requires": {
         "postcss": "^7.0.2"
+      },
+      "dependencies": {
+        "postcss": {
+          "version": "7.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.4.2",
+            "source-map": "^0.6.1",
+            "supports-color": "^6.1.0"
+          }
+        },
+        "supports-color": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
       }
     },
     "supports-color": {
@@ -21071,16 +19646,17 @@
       "dev": true
     },
     "svgo": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-1.3.0.tgz",
-      "integrity": "sha512-MLfUA6O+qauLDbym+mMZgtXCGRfIxyQoeH6IKVcFslyODEe/ElJNwr0FohQ3xG4C6HK6bk3KYPPXwHVJk3V5NQ==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-1.2.2.tgz",
+      "integrity": "sha512-rAfulcwp2D9jjdGu+0CuqlrAUin6bBWrpoqXWwKDZZZJfXcUXQSxLJOFJCQCSA0x0pP2U0TxSlJu2ROq5Bq6qA==",
       "dev": true,
       "requires": {
         "chalk": "^2.4.1",
         "coa": "^2.0.2",
         "css-select": "^2.0.0",
         "css-select-base-adapter": "^0.1.1",
-        "css-tree": "1.0.0-alpha.33",
+        "css-tree": "1.0.0-alpha.28",
+        "css-url-regex": "^1.1.0",
         "csso": "^3.5.1",
         "js-yaml": "^3.13.1",
         "mkdirp": "~0.5.1",
@@ -21122,9 +19698,9 @@
       "dev": true
     },
     "symbol-tree": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
-      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
+      "integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=",
       "dev": true
     },
     "synesthesia": {
@@ -21134,6 +19710,14 @@
       "dev": true,
       "requires": {
         "css-color-names": "0.0.3"
+      },
+      "dependencies": {
+        "css-color-names": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.3.tgz",
+          "integrity": "sha1-3gzvFvTYqoIioyDVttfpu62nufY=",
+          "dev": true
+        }
       }
     },
     "tabbable": {
@@ -21143,13 +19727,13 @@
       "dev": true
     },
     "table": {
-      "version": "5.4.4",
-      "resolved": "https://registry.npmjs.org/table/-/table-5.4.4.tgz",
-      "integrity": "sha512-IIfEAUx5QlODLblLrGTTLJA7Tk0iLSGBvgY8essPRVNGHAzThujww1YqHLs6h3HfTg55h++RzLHH5Xw/rfv+mg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/table/-/table-5.2.3.tgz",
+      "integrity": "sha512-N2RsDAMvDLvYwFcwbPyF3VmVSSkuF+G1e+8inhBLtHpvwXGw4QRPEZhihQNeEN0i1up6/f6ObCJXNdlRG3YVyQ==",
       "dev": true,
       "requires": {
-        "ajv": "^6.10.2",
-        "lodash": "^4.17.14",
+        "ajv": "^6.9.1",
+        "lodash": "^4.17.11",
         "slice-ansi": "^2.1.0",
         "string-width": "^3.0.0"
       },
@@ -21158,6 +19742,12 @@
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
           "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
         "string-width": {
@@ -21189,13 +19779,13 @@
       "dev": true
     },
     "tar": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
-      "integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+      "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
       "dev": true,
       "requires": {
         "block-stream": "*",
-        "fstream": "^1.0.12",
+        "fstream": "^1.0.2",
         "inherits": "2"
       }
     },
@@ -21210,6 +19800,179 @@
         "object-assign": "^4.1.0",
         "read-pkg-up": "^1.0.1",
         "require-main-filename": "^1.0.1"
+      },
+      "dependencies": {
+        "arr-diff": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+          "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "^1.0.1"
+          }
+        },
+        "array-unique": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+          "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+          "dev": true
+        },
+        "braces": {
+          "version": "1.8.5",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+          "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+          "dev": true,
+          "requires": {
+            "expand-range": "^1.8.1",
+            "preserve": "^0.2.0",
+            "repeat-element": "^1.1.2"
+          }
+        },
+        "expand-brackets": {
+          "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+          "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+          "dev": true,
+          "requires": {
+            "is-posix-bracket": "^0.1.0"
+          }
+        },
+        "extglob": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+          "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "^1.0.0"
+          }
+        },
+        "find-up": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+          "dev": true,
+          "requires": {
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "is-extglob": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "^1.0.0"
+          }
+        },
+        "load-json-file": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0",
+            "strip-bom": "^2.0.0"
+          }
+        },
+        "micromatch": {
+          "version": "2.3.11",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+          "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+          "dev": true,
+          "requires": {
+            "arr-diff": "^2.0.0",
+            "array-unique": "^0.2.1",
+            "braces": "^1.8.2",
+            "expand-brackets": "^0.1.4",
+            "extglob": "^0.3.1",
+            "filename-regex": "^2.0.0",
+            "is-extglob": "^1.0.0",
+            "is-glob": "^2.0.1",
+            "kind-of": "^3.0.2",
+            "normalize-path": "^2.0.1",
+            "object.omit": "^2.0.0",
+            "parse-glob": "^3.0.4",
+            "regex-cache": "^0.4.2"
+          }
+        },
+        "normalize-path": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+          "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+          "dev": true,
+          "requires": {
+            "remove-trailing-separator": "^1.0.1"
+          }
+        },
+        "parse-json": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.2.0"
+          }
+        },
+        "path-exists": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+          "dev": true,
+          "requires": {
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "path-type": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "read-pkg": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "^1.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^1.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+          "dev": true,
+          "requires": {
+            "find-up": "^1.0.0",
+            "read-pkg": "^1.0.0"
+          }
+        },
+        "strip-bom": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "dev": true,
+          "requires": {
+            "is-utf8": "^0.2.0"
+          }
+        }
       }
     },
     "text-table": {
@@ -21268,15 +20031,15 @@
       }
     },
     "tiny-invariant": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.0.6.tgz",
-      "integrity": "sha512-FOyLWWVjG+aC0UqG76V53yAWdXfH8bO6FNmyZOuUrzDzK8DI3/JRY25UD7+g49JWM1LXwymsKERB+DzI0dTEQA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.0.4.tgz",
+      "integrity": "sha512-lMhRd/djQJ3MoaHEBrw8e2/uM4rs9YMNk0iOr8rHQ0QdbM7D4l0gFl3szKdeixrlyfm9Zqi4dxHCM2qVG8ND5g==",
       "dev": true
     },
     "tiny-warning": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
-      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.2.tgz",
+      "integrity": "sha512-rru86D9CpQRLvsFG5XFdy0KdLAvjdQDyZCsRcuu60WtzFylDM3eAWSxEVz5kzL2Gp544XiUvPbVKtOA/txLi9Q==",
       "dev": true
     },
     "tinycolor2": {
@@ -21331,60 +20094,34 @@
         "extend-shallow": "^3.0.2",
         "regex-not": "^1.0.2",
         "safe-regex": "^1.1.0"
-      },
-      "dependencies": {
-        "extend-shallow": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
-          "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
-          "dev": true,
-          "requires": {
-            "assign-symbols": "^1.0.0",
-            "is-extendable": "^1.0.1"
-          }
-        },
-        "is-extendable": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-          "dev": true,
-          "requires": {
-            "is-plain-object": "^2.0.4"
-          }
-        }
       }
     },
     "to-regex-range": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+      "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
       "dev": true,
       "requires": {
-        "is-number": "^7.0.0"
-      },
-      "dependencies": {
-        "is-number": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-          "dev": true
-        }
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1"
       }
     },
-    "toidentifier": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
-      "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
-      "dev": true
-    },
     "tough-cookie": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+      "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
       "dev": true,
       "requires": {
-        "psl": "^1.1.28",
-        "punycode": "^2.1.1"
+        "psl": "^1.1.24",
+        "punycode": "^1.4.1"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+          "dev": true
+        }
       }
     },
     "tr46": {
@@ -21418,15 +20155,15 @@
       "dev": true
     },
     "trim-trailing-lines": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.2.tgz",
-      "integrity": "sha512-MUjYItdrqqj2zpcHFTkMa9WAv4JHTI6gnRQGPFLrt5L9a6tRMiDnIqYl8JBvu2d2Tc3lWJKQwlGCp0K8AvCM+Q==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.1.tgz",
+      "integrity": "sha512-bWLv9BbWbbd7mlqqs2oQYnLD/U/ZqeJeJwbO0FG2zA1aTq+HTvxfHNKFa/HGCVyJpDiioUYaBhfiT6rgk+l4mg==",
       "dev": true
     },
     "trough": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.4.tgz",
-      "integrity": "sha512-tdzBRDGWcI1OpPVmChbdSKhvSVurznZ8X36AYURAcl+0o2ldlCY2XPzyXNNxwJwwyIU+rIglTCG4kxtNKBQH7Q==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.3.tgz",
+      "integrity": "sha512-fwkLWH+DimvA4YCy+/nvJd61nWQQ2liO/nF/RjkTpiOGi+zxZzVkhb1mvbHIIW4b/8nDsYI8uTmAlc0nNkRMOw==",
       "dev": true
     },
     "true-case-path": {
@@ -21439,9 +20176,9 @@
       }
     },
     "tslib": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
       "dev": true
     },
     "tty-browserify": {
@@ -21465,12 +20202,6 @@
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "dev": true
     },
-    "type": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/type/-/type-1.0.1.tgz",
-      "integrity": "sha512-MAM5dBMJCJNKs9E7JXo4CXRAansRfG0nlJxW7Wf6GZzSOvH31zClSaHdIMWLehe/EGMBkqeC55rrkaOr5Oo7Nw==",
-      "dev": true
-    },
     "type-check": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
@@ -21481,9 +20212,9 @@
       }
     },
     "type-fest": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
-      "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.4.1.tgz",
+      "integrity": "sha512-IwzA/LSfD2vC1/YDYMv/zHP4rDF1usCwllsDpbolT3D4fUepIO7f9K70jjmUewU/LmGUKJcwcVtDCpnKk4BPMw==",
       "dev": true
     },
     "type-is": {
@@ -21502,32 +20233,41 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
-    "typescript": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
-      "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
-      "dev": true
-    },
-    "typescript-compiler": {
-      "version": "1.4.1-2",
-      "resolved": "https://registry.npmjs.org/typescript-compiler/-/typescript-compiler-1.4.1-2.tgz",
-      "integrity": "sha1-uk99si2RU0oZKdkACdzhYety/T8=",
-      "dev": true
-    },
     "ua-parser-js": {
-      "version": "0.7.20",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.20.tgz",
-      "integrity": "sha512-8OaIKfzL5cpx8eCMAhhvTlft8GYF8b2eQr6JkCyVdrgjcytyOmPCXrqXFcUnhonRpLlh5yxEZVohm6mzaowUOw==",
+      "version": "0.7.19",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.19.tgz",
+      "integrity": "sha512-T3PVJ6uz8i0HzPxOF9SWzWAlfN/DavlpQqepn22xgve/5QecC+XMCAtmUNnY7C9StehaV6exjUCI801lOI7QlQ==",
       "dev": true
     },
     "uglify-js": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.0.tgz",
-      "integrity": "sha512-W+jrUHJr3DXKhrsS7NUVxn3zqMOFn0hL/Ei6v0anCIMoKC93TjcflTagwIHLW7SfMFfiQuktQyFVCFHGUE0+yg==",
+      "version": "2.8.29",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+      "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
       "dev": true,
       "requires": {
-        "commander": "~2.20.0",
-        "source-map": "~0.6.1"
+        "source-map": "~0.5.1",
+        "uglify-to-browserify": "~1.0.0",
+        "yargs": "~3.10.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        },
+        "yargs": {
+          "version": "3.10.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+          "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+          "dev": true,
+          "requires": {
+            "camelcase": "^1.0.2",
+            "cliui": "^2.1.0",
+            "decamelize": "^1.0.0",
+            "window-size": "0.1.0"
+          }
+        }
       }
     },
     "uglify-loader": {
@@ -21546,6 +20286,24 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
           "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
           "dev": true
+        },
+        "uglify-js": {
+          "version": "3.5.10",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.10.tgz",
+          "integrity": "sha512-/GTF0nosyPLbdJBd+AwYiZ+Hu5z8KXWnO0WCGt1BQ/u9Iamhejykqmz5o1OHJ53+VAk6xVxychonnApDjuqGsw==",
+          "dev": true,
+          "requires": {
+            "commander": "~2.20.0",
+            "source-map": "~0.6.1"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.6.1",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+              "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+              "dev": true
+            }
+          }
         }
       }
     },
@@ -21556,81 +20314,10 @@
       "dev": true,
       "optional": true
     },
-    "uglifyjs-webpack-plugin": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-0.4.6.tgz",
-      "integrity": "sha1-uVH0q7a9YX5m9j64kUmOORdj4wk=",
-      "dev": true,
-      "requires": {
-        "source-map": "^0.5.6",
-        "uglify-js": "^2.8.29",
-        "webpack-sources": "^1.0.1"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
-          "dev": true
-        },
-        "cliui": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-          "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-          "dev": true,
-          "requires": {
-            "center-align": "^0.1.1",
-            "right-align": "^0.1.1",
-            "wordwrap": "0.0.2"
-          }
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
-        },
-        "uglify-js": {
-          "version": "2.8.29",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-          "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
-          "dev": true,
-          "requires": {
-            "source-map": "~0.5.1",
-            "uglify-to-browserify": "~1.0.0",
-            "yargs": "~3.10.0"
-          }
-        },
-        "window-size": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-          "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
-          "dev": true
-        },
-        "wordwrap": {
-          "version": "0.0.2",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
-          "dev": true
-        },
-        "yargs": {
-          "version": "3.10.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-          "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-          "dev": true,
-          "requires": {
-            "camelcase": "^1.0.2",
-            "cliui": "^2.1.0",
-            "decamelize": "^1.0.0",
-            "window-size": "0.1.0"
-          }
-        }
-      }
-    },
     "unherit": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.2.tgz",
-      "integrity": "sha512-W3tMnpaMG7ZY6xe/moK04U9fBhi6wEiCYHUW5Mop/wQHf12+79EQGwxYejNdhEz2mkqkBlGwm7pxmgBKMVUj0w==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.1.tgz",
+      "integrity": "sha512-+XZuV691Cn4zHsK0vkKYwBEwB74T3IZIcxrgn2E4rKwTfFyI1zCh7X7grwh9Re08fdPlarIdyWgI8aVB3F5A5g==",
       "dev": true,
       "requires": {
         "inherits": "^2.0.1",
@@ -21652,15 +20339,38 @@
       }
     },
     "union-value": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
-      "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
+      "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
       "dev": true,
       "requires": {
         "arr-union": "^3.1.0",
         "get-value": "^2.0.6",
         "is-extendable": "^0.1.1",
-        "set-value": "^2.0.1"
+        "set-value": "^0.4.3"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "set-value": {
+          "version": "0.4.3",
+          "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
+          "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
+          "dev": true,
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-extendable": "^0.1.1",
+            "is-plain-object": "^2.0.1",
+            "to-object-path": "^0.3.0"
+          }
+        }
       }
     },
     "uniq": {
@@ -21685,33 +20395,33 @@
       }
     },
     "unique-slug": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
-      "integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.1.tgz",
+      "integrity": "sha512-n9cU6+gITaVu7VGj1Z8feKMmfAjEAQGhwD9fE3zvpRRa0wEIx8ODYkVGfSc94M2OX00tUFV8wH3zYbm1I8mxFg==",
       "dev": true,
       "requires": {
         "imurmurhash": "^0.1.4"
       }
     },
     "unist-util-find-all-after": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/unist-util-find-all-after/-/unist-util-find-all-after-1.0.4.tgz",
-      "integrity": "sha512-CaxvMjTd+yF93BKLJvZnEfqdM7fgEACsIpQqz8vIj9CJnUb9VpyymFS3tg6TCtgrF7vfCJBF5jbT2Ox9CBRYRQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-find-all-after/-/unist-util-find-all-after-1.0.2.tgz",
+      "integrity": "sha512-nDl79mKpffXojLpCimVXnxhlH/jjaTnDuScznU9J4jjsaUtBdDbxmlc109XtcqxY4SDO0SwzngsxxW8DIISt1w==",
       "dev": true,
       "requires": {
-        "unist-util-is": "^3.0.0"
+        "unist-util-is": "^2.0.0"
       }
     },
     "unist-util-is": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-3.0.0.tgz",
-      "integrity": "sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-2.1.2.tgz",
+      "integrity": "sha512-YkXBK/H9raAmG7KXck+UUpnKiNmUdB+aBGrknfQ4EreE1banuzrKABx3jP6Z5Z3fMSPMQQmeXBlKpCbMwBkxVw==",
       "dev": true
     },
     "unist-util-remove-position": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-1.1.3.tgz",
-      "integrity": "sha512-CtszTlOjP2sBGYc2zcKA/CvNdTdEs3ozbiJ63IPBxh8iZg42SCCb8m04f8z2+V1aSk5a7BxbZKEdoDjadmBkWA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-1.1.2.tgz",
+      "integrity": "sha512-XxoNOBvq1WXRKXxgnSYbtCF76TJrRoe5++pD4cCBsssSiWSnPEktyFrFLE8LTk3JW5mt9hB0Sk5zn4x/JeWY7Q==",
       "dev": true,
       "requires": {
         "unist-util-visit": "^1.1.0"
@@ -21724,21 +20434,21 @@
       "dev": true
     },
     "unist-util-visit": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
-      "integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.0.tgz",
+      "integrity": "sha512-FiGu34ziNsZA3ZUteZxSFaczIjGmksfSgdKqBfOejrrfzyUy5b7YrlzT1Bcvi+djkYDituJDy2XB7tGTeBieKw==",
       "dev": true,
       "requires": {
         "unist-util-visit-parents": "^2.0.0"
       },
       "dependencies": {
         "unist-util-visit-parents": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz",
-          "integrity": "sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==",
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.0.1.tgz",
+          "integrity": "sha512-6B0UTiMfdWql4cQ03gDTCSns+64Zkfo2OCbK31Ov0uMizEz+CJeAp0cgZVb5Fhmcd7Bct2iRNywejT0orpbqUA==",
           "dev": true,
           "requires": {
-            "unist-util-is": "^3.0.0"
+            "unist-util-is": "^2.1.2"
           }
         }
       }
@@ -21750,9 +20460,9 @@
       "dev": true
     },
     "universal-user-agent": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-2.1.0.tgz",
-      "integrity": "sha512-8itiX7G05Tu3mGDTdNY2fB4KJ8MgZLS54RdG6PkkfwMAavrXu1mV/lls/GABx9O3Rw4PnTtasxrvbMQoBYY92Q==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-2.0.3.tgz",
+      "integrity": "sha512-eRHEHhChCBHrZsA4WEhdgiOKgdvgrMIHwnwnqD0r5C6AO8kwKcG7qSku3iXdhvHL3YvsS9ZkSGN8h/hIpoFC8g==",
       "dev": true,
       "requires": {
         "os-name": "^3.0.0"
@@ -21813,19 +20523,13 @@
           "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
           "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
           "dev": true
-        },
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
         }
       }
     },
     "unzipper": {
-      "version": "0.9.15",
-      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.9.15.tgz",
-      "integrity": "sha512-2aaUvO4RAeHDvOCuEtth7jrHFaCKTSXPqUkXwADaLBzGbgZGzUDccoEdJ5lW+3RmfpOZYNx0Rw6F6PUzM6caIA==",
+      "version": "0.8.14",
+      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.8.14.tgz",
+      "integrity": "sha512-8rFtE7EP5ssOwGpN2dt1Q4njl0N1hUXJ7sSPz0leU2hRdq6+pra57z4YPBlVqm40vcgv6ooKZEAx48fMTv9x4w==",
       "dev": true,
       "requires": {
         "big-integer": "^1.6.17",
@@ -21833,9 +20537,9 @@
         "bluebird": "~3.4.1",
         "buffer-indexof-polyfill": "~1.0.0",
         "duplexer2": "~0.1.4",
-        "fstream": "^1.0.12",
+        "fstream": "~1.0.10",
         "listenercount": "~1.0.1",
-        "readable-stream": "~2.3.6",
+        "readable-stream": "~2.1.5",
         "setimmediate": "~1.0.4"
       },
       "dependencies": {
@@ -21843,6 +20547,33 @@
           "version": "3.4.7",
           "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
           "integrity": "sha1-9y12C+Cbf3bQjtj66Ysomo0F+rM=",
+          "dev": true
+        },
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.1.5",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
+          "integrity": "sha1-ZvqLcg4UOLNkaB8q0aY8YYRIydA=",
+          "dev": true,
+          "requires": {
+            "buffer-shims": "^1.0.0",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~1.0.6",
+            "string_decoder": "~0.10.x",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "dev": true
         }
       }
@@ -21897,12 +20628,12 @@
       }
     },
     "url-parse-lax": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
-      "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+      "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
       "dev": true,
       "requires": {
-        "prepend-http": "^2.0.0"
+        "prepend-http": "^1.0.1"
       }
     },
     "url-template": {
@@ -21930,14 +20661,6 @@
       "dev": true,
       "requires": {
         "inherits": "2.0.3"
-      },
-      "dependencies": {
-        "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
-        }
       }
     },
     "util-deprecate": {
@@ -21974,6 +20697,12 @@
           "version": "0.9.2",
           "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
           "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
+          "dev": true
+        },
+        "deep-equal": {
+          "version": "0.2.2",
+          "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.2.tgz",
+          "integrity": "sha1-hLdFiW80xoTpjyzg5Cq69Du6AX0=",
           "dev": true
         }
       }
@@ -22036,9 +20765,9 @@
       }
     },
     "vfile-location": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-2.0.5.tgz",
-      "integrity": "sha512-Pa1ey0OzYBkLPxPZI3d9E+S4BmvfVwNAAXrrqGbwTVXWaX2p9kM1zZ+n35UtVM06shmWKH4RPRN8KI80qE3wNQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-2.0.4.tgz",
+      "integrity": "sha512-KRL5uXQPoUKu+NGvQVL4XLORw45W62v4U4gxJ3vRlDfI9QsT4ZN1PNXn/zQpKUulqGDpYuT0XDfp5q9O87/y/w==",
       "dev": true
     },
     "vfile-message": {
@@ -22051,15 +20780,18 @@
       }
     },
     "vm-browserify": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.0.tgz",
-      "integrity": "sha512-iq+S7vZJE60yejDYM0ek6zg308+UZsdtPExWP9VZoCFCz1zkJoXFnAX7aZfd/ZwrkidzdUZL0C/ryW+JwAiIGw==",
-      "dev": true
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
+      "integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
+      "dev": true,
+      "requires": {
+        "indexof": "0.0.1"
+      }
     },
     "vm2": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.8.2.tgz",
-      "integrity": "sha512-FE9slf0o4YoD2Jf7VEjytHTac2SMt2J4ahf9Tw9YLLVqJm0DQiMpmN+I0+RsnOZ0kb7PyeR1rLxathXZWJ23kg==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.8.1.tgz",
+      "integrity": "sha512-ecR1+KFuP7KK2hpo8ItamW0F9pq4dJOd4o+r6OWvAsx2eXGPshP6uKE24qepGshT8v+TF0jpnzugFJak42LuZQ==",
       "dev": true
     },
     "voca": {
@@ -22160,103 +20892,16 @@
         "yargs": "^8.0.2"
       },
       "dependencies": {
-        "acorn": {
-          "version": "5.7.3",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
-          "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
-          "dev": true
-        },
-        "cliui": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-          "dev": true,
-          "requires": {
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wrap-ansi": "^2.0.0"
-          },
-          "dependencies": {
-            "string-width": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-              "dev": true,
-              "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
-              }
-            }
-          }
-        },
         "has-flag": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
           "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
           "dev": true
         },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true,
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
-        "load-json-file": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-          "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^2.2.0",
-            "pify": "^2.0.0",
-            "strip-bom": "^3.0.0"
-          }
-        },
-        "path-type": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
-          "dev": true,
-          "requires": {
-            "pify": "^2.0.0"
-          }
-        },
-        "read-pkg": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-          "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
-          "dev": true,
-          "requires": {
-            "load-json-file": "^2.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^2.0.0"
-          }
-        },
-        "read-pkg-up": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-          "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
-          "dev": true,
-          "requires": {
-            "find-up": "^2.0.0",
-            "read-pkg": "^2.0.0"
-          }
-        },
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
-        },
-        "strip-bom": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
           "dev": true
         },
         "supports-color": {
@@ -22268,40 +20913,15 @@
             "has-flag": "^2.0.0"
           }
         },
-        "y18n": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
-          "dev": true
-        },
-        "yargs": {
-          "version": "8.0.2",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
-          "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
+        "uglifyjs-webpack-plugin": {
+          "version": "0.4.6",
+          "resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-0.4.6.tgz",
+          "integrity": "sha1-uVH0q7a9YX5m9j64kUmOORdj4wk=",
           "dev": true,
           "requires": {
-            "camelcase": "^4.1.0",
-            "cliui": "^3.2.0",
-            "decamelize": "^1.1.1",
-            "get-caller-file": "^1.0.1",
-            "os-locale": "^2.0.0",
-            "read-pkg-up": "^2.0.0",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
-            "set-blocking": "^2.0.0",
-            "string-width": "^2.0.0",
-            "which-module": "^2.0.0",
-            "y18n": "^3.2.1",
-            "yargs-parser": "^7.0.0"
-          }
-        },
-        "yargs-parser": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
-          "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
-          "dev": true,
-          "requires": {
-            "camelcase": "^4.1.0"
+            "source-map": "^0.5.6",
+            "uglify-js": "^2.8.29",
+            "webpack-sources": "^1.0.1"
           }
         }
       }
@@ -22317,6 +20937,14 @@
         "path-is-absolute": "^1.0.0",
         "range-parser": "^1.0.3",
         "time-stamp": "^2.0.0"
+      },
+      "dependencies": {
+        "mime": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+          "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+          "dev": true
+        }
       }
     },
     "webpack-dev-server": {
@@ -22394,6 +21022,16 @@
             "rimraf": "^2.2.8"
           }
         },
+        "find-up": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+          "dev": true,
+          "requires": {
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          }
+        },
         "globby": {
           "version": "6.1.0",
           "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
@@ -22413,15 +21051,6 @@
               "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
               "dev": true
             }
-          }
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true,
-          "requires": {
-            "number-is-nan": "^1.0.0"
           }
         },
         "is-path-cwd": {
@@ -22448,10 +21077,31 @@
             "path-is-inside": "^1.0.1"
           }
         },
+        "load-json-file": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0",
+            "strip-bom": "^2.0.0"
+          },
+          "dependencies": {
+            "pify": {
+              "version": "2.3.0",
+              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+              "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+              "dev": true
+            }
+          }
+        },
         "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
           "dev": true
         },
         "os-locale": {
@@ -22469,33 +21119,83 @@
           "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
           "dev": true
         },
+        "parse-json": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.2.0"
+          }
+        },
+        "path-exists": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+          "dev": true,
+          "requires": {
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "path-type": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          },
+          "dependencies": {
+            "pify": {
+              "version": "2.3.0",
+              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+              "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+              "dev": true
+            }
+          }
+        },
         "pify": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
           "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
           "dev": true
         },
-        "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+        "read-pkg": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
           "dev": true,
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "load-json-file": "^1.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^1.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+          "dev": true,
+          "requires": {
+            "find-up": "^1.0.0",
+            "read-pkg": "^1.0.0"
+          }
+        },
+        "strip-bom": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "dev": true,
+          "requires": {
+            "is-utf8": "^0.2.0"
           }
         },
         "which-module": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
           "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
-          "dev": true
-        },
-        "y18n": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
           "dev": true
         },
         "yargs": {
@@ -22541,13 +21241,12 @@
       }
     },
     "websocket-driver": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.3.tgz",
-      "integrity": "sha512-bpxWlvbbB459Mlipc5GBzzZwhoZgGEZLuqPaR0INBGnPAY1vdBX6hPnoFXiw+3yWxDuHyQjO2oXTMyS8A5haFg==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.0.tgz",
+      "integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
       "dev": true,
       "requires": {
-        "http-parser-js": ">=0.4.0 <0.4.11",
-        "safe-buffer": ">=5.1.0",
+        "http-parser-js": ">=0.4.0",
         "websocket-extensions": ">=0.1.1"
       }
     },
@@ -22615,9 +21314,9 @@
       }
     },
     "window-size": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
-      "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY=",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+      "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
       "dev": true
     },
     "windows-release": {
@@ -22627,6 +21326,61 @@
       "dev": true,
       "requires": {
         "execa": "^1.0.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "dev": true,
+          "requires": {
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "execa": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+          "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^6.0.0",
+            "get-stream": "^4.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          }
+        },
+        "get-stream": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "pump": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+          "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+          "dev": true,
+          "requires": {
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
+          }
+        },
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+          "dev": true
+        }
       }
     },
     "winston": {
@@ -22665,9 +21419,9 @@
       }
     },
     "wordwrap": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+      "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
       "dev": true
     },
     "worker-farm": {
@@ -22687,28 +21441,6 @@
       "requires": {
         "string-width": "^1.0.1",
         "strip-ansi": "^3.0.1"
-      },
-      "dependencies": {
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true,
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "dev": true,
-          "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
-          }
-        }
       }
     },
     "wrapper-webpack-plugin": {
@@ -22736,9 +21468,9 @@
       }
     },
     "write-file-atomic": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
-      "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.1.tgz",
+      "integrity": "sha512-TGHFeZEZMnv+gBFRfjAcxL5bPHrsGKtnb4qsFAws7/vlh+QfwAaySIw4AXP9ZskTTh5GWu3FLuJhsWVdiJPGvg==",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.11",
@@ -22765,15 +21497,15 @@
       "dev": true
     },
     "xtend": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
       "dev": true
     },
     "y18n": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
       "dev": true
     },
     "yallist": {
@@ -22783,40 +21515,106 @@
       "dev": true
     },
     "yargs": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
-      "integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
+      "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
       "dev": true,
       "requires": {
-        "cliui": "^4.0.0",
+        "camelcase": "^4.1.0",
+        "cliui": "^3.2.0",
         "decamelize": "^1.1.1",
-        "find-up": "^2.1.0",
         "get-caller-file": "^1.0.1",
         "os-locale": "^2.0.0",
+        "read-pkg-up": "^2.0.0",
         "require-directory": "^2.1.1",
         "require-main-filename": "^1.0.1",
         "set-blocking": "^2.0.0",
         "string-width": "^2.0.0",
         "which-module": "^2.0.0",
         "y18n": "^3.2.1",
-        "yargs-parser": "^9.0.2"
+        "yargs-parser": "^7.0.0"
       },
       "dependencies": {
-        "y18n": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
+        },
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+          "dev": true
+        },
+        "cliui": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+          "dev": true,
+          "requires": {
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wrap-ansi": "^2.0.0"
+          },
+          "dependencies": {
+            "string-width": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+              "dev": true,
+              "requires": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+              }
+            }
+          }
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          },
+          "dependencies": {
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+              "dev": true
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            }
+          }
         }
       }
     },
     "yargs-parser": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
-      "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
+      "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
       "dev": true,
       "requires": {
         "camelcase": "^4.1.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+          "dev": true
+        }
       }
     },
     "zip-it-loader": {


### PR DESCRIPTION
This changes all Backpack dependencies in the lockfile to be bundled. From what I can tell from reading npm docs, this is what we want. 

I think the file got messed up when people did `npm install` **before cloning submodules**, as it then reverts to the registry or something I guess?

## How to test

Clone this repo, **with submodules**:

```
git clone --recursive git@github.com:Skyscanner/backpack-docs.git
```

Install deps:

```
npm i
```

If all is well, run the site:

```
npm start
```

If everything is 👌you'll see the docs site after a while. 