### PR TITLE
[BPK-2933] Update docs to show non-shadow iOS Chip

### DIFF
--- a/docs/src/pages/IOSChipPage/IOSChipPage.js
+++ b/docs/src/pages/IOSChipPage/IOSChipPage.js
@@ -19,7 +19,8 @@
 import React from 'react';
 
 import readme from '../../../../backpack-ios/Backpack/Chip/README.md';
-import screenshotAll from '../../../../backpack-ios/screenshots/Chip/all.png';
+import screenshotDefault from '../../../../backpack-ios/screenshots/Chip/default.png';
+import screenshotWithoutShadow from '../../../../backpack-ios/screenshots/Chip/without-shadow.png';
 import DocsPageBuilder from '../../components/DocsPageBuilder';
 
 const components = [
@@ -30,7 +31,20 @@ const components = [
       {
         width: 750,
         height: 1334,
-        src: `/${screenshotAll}`,
+        src: `/${screenshotDefault}`,
+        altText: 'Chips for iOS.',
+        subText: '(iPhone 8 simulator)',
+      },
+    ],
+  },
+  {
+    id: 'withoutShadow',
+    title: 'Without shadow',
+    screenshots: [
+      {
+        width: 750,
+        height: 1334,
+        src: `/${screenshotWithoutShadow}`,
         altText: 'Chips for iOS.',
         subText: '(iPhone 8 simulator)',
       },


### PR DESCRIPTION
Waiting on https://github.com/Skyscanner/backpack-ios/pull/411 

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack/blob/master/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] [Links platform metadata](https://github.com/Skyscanner/backpack-docs/blob/master/docs/src/layouts/links.js)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
