### PR TITLE
[BPK-2693] Split out text-area page

### DIFF
--- a/docs/src/layouts/links.js
+++ b/docs/src/layouts/links.js
@@ -352,7 +352,7 @@ const ComponentsLinks = [
         id: 'NATIVE_TEXT_VIEW',
         route: routes.TEXT_VIEW,
         children: 'Text view',
-        tags: ['ios'],
+        tags: ['ios', 'web'],
       },
       {
         id: 'TAPPABLE_LINK_LABEL',

--- a/docs/src/pages/FormsPage/FormsPage.js
+++ b/docs/src/pages/FormsPage/FormsPage.js
@@ -27,7 +27,6 @@ import BpkInput from 'bpk-component-input';
 import BpkFormValidation from 'bpk-component-form-validation';
 import { cssModules } from 'bpk-react-utils';
 import labelReadme from 'bpk-component-label/README.md';
-import textareaReadme from 'bpk-component-textarea/README.md';
 import validationReadme from 'bpk-component-form-validation/README.md';
 
 import * as ROUTES from '../../constants/routes';
@@ -40,11 +39,6 @@ import InputContainer from './InputContainer';
 import STYLES from './forms-page.scss';
 
 const getClassName = cssModules(STYLES);
-const loremIpsum = 'Lorem ipsum dolor sit amet, consectetur adipisicing elit.';
-
-const loremIpsumLong = `Lorem ipsum dolor sit amet, consectetur adipisicing elit. Voluptate repellat assumenda
-necessitatibus reiciendis, porro temporibus expedita excepturi! Nostrum pariatur odit porro, dolorem dignissimos
-laudantium quis, tempore iste non, nam magnam.`;
 
 const formClassName = getClassName('bpkdocs-forms-page__form');
 
@@ -91,64 +85,11 @@ const components = [
     title: 'Textareas',
     blurb: [
       <BpkParagraph>
-        Textareas look almost identical to{' '}
-        <BpkLink href="#inputs">inputs</BpkLink> except they allow long text to
-        wrap across multiple lines.
+        <BpkLink href={ROUTES.TEXT_VIEW}>
+          Text areas have been moved to their own page.
+        </BpkLink>
       </BpkParagraph>,
     ],
-    examples: [
-      <form className={formClassName}>
-        <BpkLabel htmlFor="textarea">Textarea</BpkLabel>
-        <InputContainer
-          FormComponent={BpkTextarea}
-          id="textarea"
-          name="textarea"
-          value={loremIpsumLong}
-          placeholder={loremIpsumLong}
-          onChange={() => null}
-        />
-      </form>,
-      <form className={formClassName}>
-        <BpkLabel htmlFor="textarea_invalid">Invalid Textarea</BpkLabel>
-        <InputContainer
-          FormComponent={BpkTextarea}
-          id="textarea_invalid"
-          name="textarea_invalid"
-          value="@ 123 {\ hi"
-          placeholder="@ 123 {\ hi"
-          onChange={() => null}
-          valid={false}
-        />
-      </form>,
-      <form className={formClassName}>
-        <BpkLabel htmlFor="textarea_placeholder">
-          Textarea (placeholder)
-        </BpkLabel>
-        <InputContainer
-          FormComponent={BpkTextarea}
-          id="textarea_placeholder"
-          name="textarea_placeholder"
-          value=""
-          placeholder={loremIpsum}
-          onChange={() => null}
-        />
-      </form>,
-      <form className={formClassName}>
-        <BpkLabel htmlFor="textarea_disabled" disabled>
-          Disabled textarea
-        </BpkLabel>
-        <InputContainer
-          FormComponent={BpkTextarea}
-          id="textarea_disabled"
-          name="textarea_disabled"
-          value=""
-          placeholder={loremIpsum}
-          onChange={() => null}
-          disabled
-        />
-      </form>,
-    ],
-    readme: textareaReadme,
   },
   {
     id: 'checkboxes',

--- a/docs/src/pages/TextViewPage/TextViewPage.js
+++ b/docs/src/pages/TextViewPage/TextViewPage.js
@@ -22,6 +22,7 @@ import BpkRouterLink from 'bpk-component-router-link';
 import IntroBlurb from '../../components/IntroBlurb';
 import DocsPageWrapper from '../../components/DocsPageWrapper';
 import IOS from '../IOSTextViewPage';
+import Web from '../WebTextAreaPage';
 import Paragraph from '../../components/Paragraph';
 import { TEXT_INPUT } from '../../constants/routes';
 
@@ -39,6 +40,7 @@ const TextViewPage = () => (
     title="Text views"
     blurb={blurb}
     iosSubpage={<IOS wrapped />}
+    webSubpage={<Web wrapped />}
   />
 );
 

--- a/docs/src/pages/WebTextAreaPage/WebTextAreaPage.js
+++ b/docs/src/pages/WebTextAreaPage/WebTextAreaPage.js
@@ -1,0 +1,141 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2016-2019 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import BpkLink from 'bpk-component-link';
+import BpkLabel from 'bpk-component-label';
+import BpkTextarea from 'bpk-component-textarea';
+import { cssModules } from 'bpk-react-utils';
+import readme from 'bpk-component-textarea/README.md';
+
+import * as ROUTES from '../../constants/routes';
+import InputContainer from '../FormsPage/InputContainer';
+import DocsPageBuilder from '../../components/DocsPageBuilder';
+import BpkParagraph from '../../components/Paragraph';
+import STYLES from '../FormsPage/forms-page.scss';
+
+const getClassName = cssModules(STYLES);
+
+const formClassName = getClassName('bpkdocs-forms-page__form');
+
+const loremIpsum = 'Lorem ipsum dolor sit amet, consectetur adipisicing elit.';
+
+const loremIpsumLong = `Lorem ipsum dolor sit amet, consectetur adipisicing elit. Voluptate repellat assumenda
+necessitatibus reiciendis, porro temporibus expedita excepturi! Nostrum pariatur odit porro, dolorem dignissimos
+laudantium quis, tempore iste non, nam magnam.`;
+
+const components = [
+  {
+    id: 'default',
+    title: 'Default',
+    examples: [
+      <form className={formClassName}>
+        <BpkLabel htmlFor="textarea">Textarea</BpkLabel>
+        <InputContainer
+          FormComponent={BpkTextarea}
+          id="textarea"
+          name="textarea"
+          value={loremIpsumLong}
+          placeholder={loremIpsumLong}
+          onChange={() => null}
+        />
+      </form>,
+    ],
+  },
+  {
+    id: 'empty',
+    title: 'Empty',
+    examples: [
+      <form className={formClassName}>
+        <BpkLabel htmlFor="textarea_placeholder">
+          Textarea (placeholder)
+        </BpkLabel>
+        <InputContainer
+          FormComponent={BpkTextarea}
+          id="textarea_placeholder"
+          name="textarea_placeholder"
+          value=""
+          placeholder={loremIpsum}
+          onChange={() => null}
+        />
+      </form>,
+    ],
+  },
+  {
+    id: 'disabled',
+    title: 'Disabled',
+    examples: [
+      <form className={formClassName}>
+        <BpkLabel disabled htmlFor="textarea_disabled">
+          Disabled textarea
+        </BpkLabel>
+        <InputContainer
+          FormComponent={BpkTextarea}
+          id="textarea_disabled"
+          name="textarea_disabled"
+          value=""
+          placeholder={loremIpsum}
+          onChange={() => null}
+          disabled
+        />
+      </form>,
+    ],
+  },
+  {
+    id: 'invalid',
+    title: 'Invalid',
+    examples: [
+      <form className={formClassName}>
+        <BpkLabel valid={false} htmlFor="textarea_invalid">
+          Invalid Textarea
+        </BpkLabel>
+        <InputContainer
+          FormComponent={BpkTextarea}
+          id="textarea_invalid"
+          name="textarea_invalid"
+          value="@ 123 {\ hi"
+          placeholder="@ 123 {\ hi"
+          onChange={() => null}
+          valid={false}
+        />
+      </form>,
+    ],
+  },
+];
+
+const blurb = [
+  <BpkParagraph>
+    Textareas look almost identical to{' '}
+    <BpkLink href={ROUTES.TEXT_INPUT}>inputs</BpkLink> except they allow long
+    text to wrap across multiple lines.
+  </BpkParagraph>,
+];
+
+const WebTextAreaPage = ({ ...rest }) => (
+  <DocsPageBuilder
+    title="Text area"
+    sassdocId="forms-mixin-bpk-text-area"
+    blurb={blurb}
+    components={components}
+    readme={readme}
+    showMenu={false}
+    {...rest}
+  />
+);
+
+export default WebTextAreaPage;

--- a/docs/src/pages/WebTextAreaPage/index.js
+++ b/docs/src/pages/WebTextAreaPage/index.js
@@ -1,0 +1,21 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2016-2019 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import page from './WebTextAreaPage';
+
+export default page;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/30267516/64858304-e4f2ef80-d61e-11e9-9253-178e109d31ee.png)

![image](https://user-images.githubusercontent.com/30267516/64858310-e8867680-d61e-11e9-8b65-a22f28aca956.png)

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack/blob/master/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] [Links platform metadata](https://github.com/Skyscanner/backpack-docs/blob/master/docs/src/layouts/links.js)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
