### PR TITLE
Fixing guidelines icon size to be smaller

### DIFF
--- a/docs/src/pages/HomePage/HomePage.js
+++ b/docs/src/pages/HomePage/HomePage.js
@@ -59,7 +59,6 @@ const CARD_CONTENTS = [
     href: ROUTES.GUIDELINES,
     image: GuidelinesImage,
     icon: GuidelinesIcon,
-    iconWidth: '7.5rem',
   },
   {
     key: 'components',


### PR DESCRIPTION
The icon was pointed out by Will to be bigger than the design, so we remove the `iconWidth` property to make it sized down to the correct size. 

This property was left over from the previous icon and implementation in the old site

Before 
<img width="555" alt="Screenshot 2019-10-25 at 22 25 14" src="https://user-images.githubusercontent.com/8831547/67605731-1959df80-f777-11e9-9af0-7daa157ebe84.png">

After
<img width="554" alt="Screenshot 2019-10-25 at 22 28 21" src="https://user-images.githubusercontent.com/8831547/67605742-224ab100-f777-11e9-9cb3-99061ad51b56.png">