### PR TITLE
Colour updates

### DIFF
--- a/docs/src/layouts/DefaultLayout/default-layout.scss
+++ b/docs/src/layouts/DefaultLayout/default-layout.scss
@@ -20,11 +20,11 @@
 
 .bpkdocs-default-layout {
   &__container {
-    background-color: $bpk-color-sky-gray-tint-06;
+    background-color: $bpk-color-sky-gray-tint-07;
   }
 
   &__footer-container {
-    @include bpk-border-top-sm($bpk-color-sky-gray-tint-06);
+    @include bpk-border-top-sm($bpk-color-sky-gray-tint-07);
   }
 
   &__footer-row {

--- a/docs/src/layouts/SideNavLayout/NavList.scss
+++ b/docs/src/layouts/SideNavLayout/NavList.scss
@@ -52,7 +52,7 @@
     @include bpk-themeable-property(
       background-color,
       --bpk-docs-sidebar-background,
-      $bpk-color-sky-blue-shade-02
+      $bpk-color-sky-blue-shade-03
     );
   }
 
@@ -108,7 +108,7 @@
     @include bpk-themeable-property(
       fill,
       --bpk-docs-sidebar-selected-arrow-color,
-      $bpk-color-panjin
+      $bpk-color-monteverde
     );
 
     @include bpk-rtl {
@@ -132,9 +132,9 @@
     display: block;
     padding: $bpk-spacing-md 0;
 
-    @include bpk-border-bottom-sm($bpk-color-sky-gray-tint-01);
+    @include bpk-border-bottom-sm($bpk-color-sky-gray-tint-02);
     @include bpk-border-bottom-sm(
-      var(--bpk-docs-sidebar-link-border, $bpk-color-sky-gray-tint-07)
+      var(--bpk-docs-sidebar-link-border, $bpk-color-sky-gray-tint-02)
     );
 
     *:last-child > & {

--- a/docs/src/layouts/SideNavLayout/SectionsList.scss
+++ b/docs/src/layouts/SideNavLayout/SectionsList.scss
@@ -96,9 +96,9 @@ $bpk-heading-button-padding: $bpk-spacing-md;
     background: none;
     text-align: left;
 
-    @include bpk-border-bottom-sm($bpk-color-sky-gray-tint-07);
+    @include bpk-border-bottom-sm($bpk-color-sky-gray-tint-02);
     @include bpk-border-bottom-sm(
-      var(--bpk-docs-sidebar-link-border, $bpk-color-sky-gray-tint-07)
+      var(--bpk-docs-sidebar-link-border, $bpk-color-sky-gray-tint-02)
     );
     @include nav-link;
     @include nav-link--enabled;

--- a/docs/src/layouts/SideNavLayout/Sidebar.scss
+++ b/docs/src/layouts/SideNavLayout/Sidebar.scss
@@ -25,7 +25,7 @@
   @include bpk-themeable-property(
     background-color,
     --bpk-docs-sidebar-background,
-    $bpk-color-sky-blue-shade-02
+    $bpk-color-sky-blue-shade-03
   );
 
   @include bpk-breakpoint-tablet {

--- a/docs/src/layouts/SideNavLayout/_common.scss
+++ b/docs/src/layouts/SideNavLayout/_common.scss
@@ -26,7 +26,7 @@ $bpk-first-column-size: $bpk-spacing-xs * 10;
   @include bpk-themeable-property(
     color,
     --bpk-docs-sidebar-link,
-    $bpk-color-sky-gray-tint-07
+    $bpk-color-sky-gray-tint-02
   );
   @include bpk-text;
   @include bpk-text-base;


### PR DESCRIPTION
This aligns colours on the homepage and sidebar to match the new designs as seen below

Homepage background colour:
![Screenshot 2019-10-31 at 11 51 09](https://user-images.githubusercontent.com/8831547/67944623-c350c600-fbd4-11e9-99f9-1487d3026199.png)

Navigation sidebar:

Before:
![Before_Sidebar](https://user-images.githubusercontent.com/8831547/67944644-cea3f180-fbd4-11e9-97a5-8f49038dd2f4.gif)

After:
![After_Sidebar](https://user-images.githubusercontent.com/8831547/67944653-d368a580-fbd4-11e9-9cdd-2d507f352f58.gif)

