### PR TITLE
[No JIRA] New screenshot name convention for iOS

### DIFF
--- a/docs/src/pages/IOSBadgePage/IOSBadgePage.js
+++ b/docs/src/pages/IOSBadgePage/IOSBadgePage.js
@@ -19,8 +19,8 @@
 import React from 'react';
 
 import readme from '../../../../backpack-ios/Backpack/Badge/README.md';
-import screenshotAll from '../../../../backpack-ios/screenshots/Badge/all.png';
-import screenshotAllDm from '../../../../backpack-ios/screenshots/Badge/all_dm.png';
+import screenshotAll from '../../../../backpack-ios/screenshots/iPhone 8-badge___all_lm.png';
+import screenshotAllDm from '../../../../backpack-ios/screenshots/iPhone 8-badge___all_dm.png';
 import DocsPageBuilder from '../../components/DocsPageBuilder';
 
 const components = [

--- a/docs/src/pages/IOSBottomSheetPage/IOSBottomSheetPage.js
+++ b/docs/src/pages/IOSBottomSheetPage/IOSBottomSheetPage.js
@@ -19,8 +19,8 @@
 import React from 'react';
 
 import readme from '../../../../backpack-ios/Backpack/BottomSheet/README.md';
-import screenshotAll from '../../../../backpack-ios/screenshots/BottomSheet/with-bottom-section.png';
-import screenshotAllDm from '../../../../backpack-ios/screenshots/BottomSheet/with-bottom-section_dm.png';
+import screenshotAll from '../../../../backpack-ios/screenshots/iPhone 8-bottom-sheet___with-bottom-section_lm.png';
+import screenshotAllDm from '../../../../backpack-ios/screenshots/iPhone 8-bottom-sheet___with-bottom-section_dm.png';
 import DocsPageBuilder from '../../components/DocsPageBuilder';
 
 const components = [

--- a/docs/src/pages/IOSButtonPage/IOSButtonPage.js
+++ b/docs/src/pages/IOSButtonPage/IOSButtonPage.js
@@ -19,18 +19,18 @@
 import React from 'react';
 
 import readme from '../../../../backpack-ios/Backpack/Button/README.md';
-import screenshotPrimary from '../../../../backpack-ios/screenshots/Button/primary.png';
-import screenshotSecondary from '../../../../backpack-ios/screenshots/Button/secondary.png';
-import screenshotDestructive from '../../../../backpack-ios/screenshots/Button/destructive.png';
-import screenshotFeatured from '../../../../backpack-ios/screenshots/Button/featured.png';
-import screenshotLink from '../../../../backpack-ios/screenshots/Button/link.png';
-import screenshotOutline from '../../../../backpack-ios/screenshots/Button/outline.png';
-import screenshotPrimaryDm from '../../../../backpack-ios/screenshots/Button/primary_dm.png';
-import screenshotSecondaryDm from '../../../../backpack-ios/screenshots/Button/secondary_dm.png';
-import screenshotDestructiveDm from '../../../../backpack-ios/screenshots/Button/destructive_dm.png';
-import screenshotFeaturedDm from '../../../../backpack-ios/screenshots/Button/featured_dm.png';
-import screenshotLinkDm from '../../../../backpack-ios/screenshots/Button/link_dm.png';
-import screenshotOutlineDm from '../../../../backpack-ios/screenshots/Button/outline_dm.png';
+import screenshotPrimary from '../../../../backpack-ios/screenshots/iPhone 8-button___primary_lm.png';
+import screenshotSecondary from '../../../../backpack-ios/screenshots/iPhone 8-button___secondary_lm.png';
+import screenshotDestructive from '../../../../backpack-ios/screenshots/iPhone 8-button___destructive_lm.png';
+import screenshotFeatured from '../../../../backpack-ios/screenshots/iPhone 8-button___featured_lm.png';
+import screenshotLink from '../../../../backpack-ios/screenshots/iPhone 8-button___link_lm.png';
+import screenshotOutline from '../../../../backpack-ios/screenshots/iPhone 8-button___outline_lm.png';
+import screenshotPrimaryDm from '../../../../backpack-ios/screenshots/iPhone 8-button___primary_dm.png';
+import screenshotSecondaryDm from '../../../../backpack-ios/screenshots/iPhone 8-button___secondary_dm.png';
+import screenshotDestructiveDm from '../../../../backpack-ios/screenshots/iPhone 8-button___destructive_dm.png';
+import screenshotFeaturedDm from '../../../../backpack-ios/screenshots/iPhone 8-button___featured_dm.png';
+import screenshotLinkDm from '../../../../backpack-ios/screenshots/iPhone 8-button___link_dm.png';
+import screenshotOutlineDm from '../../../../backpack-ios/screenshots/iPhone 8-button___outline_dm.png';
 import DocsPageBuilder from '../../components/DocsPageBuilder';
 
 const components = [

--- a/docs/src/pages/IOSCalendarPage/IOSCalendarPage.js
+++ b/docs/src/pages/IOSCalendarPage/IOSCalendarPage.js
@@ -19,14 +19,14 @@
 import React from 'react';
 
 import readme from '../../../../backpack-ios/Backpack/Calendar/README.md';
-import screenshotSingle from '../../../../backpack-ios/screenshots/Calendar/single.png';
-import screenshotRange from '../../../../backpack-ios/screenshots/Calendar/range.png';
-import screenshotMultiple from '../../../../backpack-ios/screenshots/Calendar/multiple.png';
-import screenshotPill from '../../../../backpack-ios/screenshots/Calendar/pill.png';
-import screenshotSingleDm from '../../../../backpack-ios/screenshots/Calendar/single_dm.png';
-import screenshotRangeDm from '../../../../backpack-ios/screenshots/Calendar/range_dm.png';
-import screenshotMultipleDm from '../../../../backpack-ios/screenshots/Calendar/multiple_dm.png';
-import screenshotPillDm from '../../../../backpack-ios/screenshots/Calendar/pill_dm.png';
+import screenshotSingle from '../../../../backpack-ios/screenshots/iPhone 8-calendar___single_lm.png';
+import screenshotRange from '../../../../backpack-ios/screenshots/iPhone 8-calendar___range_lm.png';
+import screenshotMultiple from '../../../../backpack-ios/screenshots/iPhone 8-calendar___multiple_lm.png';
+import screenshotPill from '../../../../backpack-ios/screenshots/iPhone 8-calendar___pill_lm.png';
+import screenshotSingleDm from '../../../../backpack-ios/screenshots/iPhone 8-calendar___single_dm.png';
+import screenshotRangeDm from '../../../../backpack-ios/screenshots/iPhone 8-calendar___range_dm.png';
+import screenshotMultipleDm from '../../../../backpack-ios/screenshots/iPhone 8-calendar___multiple_dm.png';
+import screenshotPillDm from '../../../../backpack-ios/screenshots/iPhone 8-calendar___pill_dm.png';
 import DocsPageBuilder from '../../components/DocsPageBuilder';
 
 const components = [

--- a/docs/src/pages/IOSCardPage/IOSCardPage.js
+++ b/docs/src/pages/IOSCardPage/IOSCardPage.js
@@ -19,22 +19,22 @@
 import React from 'react';
 
 import readme from '../../../../backpack-ios/Backpack/Card/README.md';
-import screenshotDefault from '../../../../backpack-ios/screenshots/Card/default.png';
-import screenshotSelected from '../../../../backpack-ios/screenshots/Card/selected.png';
-import screenshotCornerStyleLarge from '../../../../backpack-ios/screenshots/Card/corner-style-large.png';
-import screenshotWithoutPadding from '../../../../backpack-ios/screenshots/Card/without-padding.png';
-import screenshotWithDivider from '../../../../backpack-ios/screenshots/Card/with-divider.png';
-import screenshotWithDividerWithoutPadding from '../../../../backpack-ios/screenshots/Card/with-divider-without-padding.png';
-import screenshotWithDividerCornerStyleLarge from '../../../../backpack-ios/screenshots/Card/with-divider-and-corner-style-large.png';
-import screenshotWithDividerArrangedVertically from '../../../../backpack-ios/screenshots/Card/with-divider-arranged-vertically.png';
-import screenshotDefaultDm from '../../../../backpack-ios/screenshots/Card/default_dm.png';
-import screenshotSelectedDm from '../../../../backpack-ios/screenshots/Card/selected_dm.png';
-import screenshotCornerStyleLargeDm from '../../../../backpack-ios/screenshots/Card/corner-style-large_dm.png';
-import screenshotWithoutPaddingDm from '../../../../backpack-ios/screenshots/Card/without-padding_dm.png';
-import screenshotWithDividerDm from '../../../../backpack-ios/screenshots/Card/with-divider_dm.png';
-import screenshotWithDividerWithoutPaddingDm from '../../../../backpack-ios/screenshots/Card/with-divider-without-padding_dm.png';
-import screenshotWithDividerCornerStyleLargeDm from '../../../../backpack-ios/screenshots/Card/with-divider-and-corner-style-large_dm.png';
-import screenshotWithDividerArrangedVerticallyDm from '../../../../backpack-ios/screenshots/Card/with-divider-arranged-vertically_dm.png';
+import screenshotDefault from '../../../../backpack-ios/screenshots/iPhone 8-card___default_lm.png';
+import screenshotSelected from '../../../../backpack-ios/screenshots/iPhone 8-card___selected_lm.png';
+import screenshotCornerStyleLarge from '../../../../backpack-ios/screenshots/iPhone 8-card___corner-style-large_lm.png';
+import screenshotWithoutPadding from '../../../../backpack-ios/screenshots/iPhone 8-card___without-padding_lm.png';
+import screenshotWithDivider from '../../../../backpack-ios/screenshots/iPhone 8-card___with-divider_lm.png';
+import screenshotWithDividerWithoutPadding from '../../../../backpack-ios/screenshots/iPhone 8-card___with-divider-without-padding_lm.png';
+import screenshotWithDividerCornerStyleLarge from '../../../../backpack-ios/screenshots/iPhone 8-card___with-divider-and-corner-style-large_lm.png';
+import screenshotWithDividerArrangedVertically from '../../../../backpack-ios/screenshots/iPhone 8-card___with-divider-arranged-vertically_lm.png';
+import screenshotDefaultDm from '../../../../backpack-ios/screenshots/iPhone 8-card___default_dm.png';
+import screenshotSelectedDm from '../../../../backpack-ios/screenshots/iPhone 8-card___selected_dm.png';
+import screenshotCornerStyleLargeDm from '../../../../backpack-ios/screenshots/iPhone 8-card___corner-style-large_dm.png';
+import screenshotWithoutPaddingDm from '../../../../backpack-ios/screenshots/iPhone 8-card___without-padding_dm.png';
+import screenshotWithDividerDm from '../../../../backpack-ios/screenshots/iPhone 8-card___with-divider_dm.png';
+import screenshotWithDividerWithoutPaddingDm from '../../../../backpack-ios/screenshots/iPhone 8-card___with-divider-without-padding_dm.png';
+import screenshotWithDividerCornerStyleLargeDm from '../../../../backpack-ios/screenshots/iPhone 8-card___with-divider-and-corner-style-large_dm.png';
+import screenshotWithDividerArrangedVerticallyDm from '../../../../backpack-ios/screenshots/iPhone 8-card___with-divider-arranged-vertically_dm.png';
 import DocsPageBuilder from '../../components/DocsPageBuilder';
 
 const components = [

--- a/docs/src/pages/IOSChipPage/IOSChipPage.js
+++ b/docs/src/pages/IOSChipPage/IOSChipPage.js
@@ -19,12 +19,12 @@
 import React from 'react';
 
 import readme from '../../../../backpack-ios/Backpack/Chip/README.md';
-import screenshotDefault from '../../../../backpack-ios/screenshots/Chip/default.png';
-import screenshotWithoutShadow from '../../../../backpack-ios/screenshots/Chip/without-shadow.png';
-import screenshotWithBackgroundColor from '../../../../backpack-ios/screenshots/Chip/background-color.png';
-import screenshotDefaultDm from '../../../../backpack-ios/screenshots/Chip/default_dm.png';
-import screenshotWithoutShadowDm from '../../../../backpack-ios/screenshots/Chip/without-shadow_dm.png';
-import screenshotWithBackgroundColorDm from '../../../../backpack-ios/screenshots/Chip/background-color_dm.png';
+import screenshotDefault from '../../../../backpack-ios/screenshots/iPhone 8-chip___default_lm.png';
+import screenshotWithoutShadow from '../../../../backpack-ios/screenshots/iPhone 8-chip___without-shadow_lm.png';
+import screenshotWithBackgroundColor from '../../../../backpack-ios/screenshots/iPhone 8-chip___background-color_lm.png';
+import screenshotDefaultDm from '../../../../backpack-ios/screenshots/iPhone 8-chip___default_dm.png';
+import screenshotWithoutShadowDm from '../../../../backpack-ios/screenshots/iPhone 8-chip___without-shadow_dm.png';
+import screenshotWithBackgroundColorDm from '../../../../backpack-ios/screenshots/iPhone 8-chip___background-color_dm.png';
 import DocsPageBuilder from '../../components/DocsPageBuilder';
 
 const components = [

--- a/docs/src/pages/IOSDialogPage/IOSDialogPage.js
+++ b/docs/src/pages/IOSDialogPage/IOSDialogPage.js
@@ -19,12 +19,12 @@
 import React from 'react';
 
 import readme from '../../../../backpack-ios/Backpack/Dialog/README.md';
-import screenshotAlert from '../../../../backpack-ios/screenshots/Dialog/with-cta.png';
-import screenshotBottomSheet from '../../../../backpack-ios/screenshots/Dialog/delete-confirmation.png';
-import screenshotAlertDm from '../../../../backpack-ios/screenshots/Dialog/with-cta_dm.png';
-import screenshotBottomSheetDm from '../../../../backpack-ios/screenshots/Dialog/delete-confirmation_dm.png';
-import screenshotWithFlare from '../../../../backpack-ios/screenshots/Dialog/in-app-messaging.png';
-import screenshotWithFlareDm from '../../../../backpack-ios/screenshots/Dialog/in-app-messaging_dm.png';
+import screenshotAlert from '../../../../backpack-ios/screenshots/iPhone 8-dialog___with-cta_lm.png';
+import screenshotBottomSheet from '../../../../backpack-ios/screenshots/iPhone 8-dialog___delete-confirmation_lm.png';
+import screenshotWithFlare from '../../../../backpack-ios/screenshots/iPhone 8-dialog___in-app-messaging_lm.png';
+import screenshotAlertDm from '../../../../backpack-ios/screenshots/iPhone 8-dialog___with-cta_dm.png';
+import screenshotBottomSheetDm from '../../../../backpack-ios/screenshots/iPhone 8-dialog___delete-confirmation_dm.png';
+import screenshotWithFlareDm from '../../../../backpack-ios/screenshots/iPhone 8-dialog___in-app-messaging_dm.png';
 import DocsPageBuilder from '../../components/DocsPageBuilder';
 
 const components = [

--- a/docs/src/pages/IOSFlarePage/IOSFlarePage.js
+++ b/docs/src/pages/IOSFlarePage/IOSFlarePage.js
@@ -19,10 +19,10 @@
 import React from 'react';
 
 import readme from '../../../../backpack-ios/Backpack/FlareView/README.md';
-import screenshotDefault from '../../../../backpack-ios/screenshots/FlareView/default.png';
-import screenshotWithBackgroundColor from '../../../../backpack-ios/screenshots/FlareView/background-image.png';
-import screenshotDefaultDm from '../../../../backpack-ios/screenshots/FlareView/default_dm.png';
-import screenshotWithBackgroundColorDm from '../../../../backpack-ios/screenshots/FlareView/background-image_dm.png';
+import screenshotDefault from '../../../../backpack-ios/screenshots/iPhone 8-flare-view___default_lm.png';
+import screenshotWithBackgroundColor from '../../../../backpack-ios/screenshots/iPhone 8-flare-view___background-image_lm.png';
+import screenshotDefaultDm from '../../../../backpack-ios/screenshots/iPhone 8-flare-view___default_dm.png';
+import screenshotWithBackgroundColorDm from '../../../../backpack-ios/screenshots/iPhone 8-flare-view___background-image_dm.png';
 import DocsPageBuilder from '../../components/DocsPageBuilder';
 
 const components = [

--- a/docs/src/pages/IOSHorizontalNavPage/IOSHorizontalNavPage.js
+++ b/docs/src/pages/IOSHorizontalNavPage/IOSHorizontalNavPage.js
@@ -19,14 +19,14 @@
 import React from 'react';
 
 import readme from '../../../../backpack-ios/Backpack/HorizontalNavigation/README.md';
-import screenshotDefault from '../../../../backpack-ios/screenshots/HorizontalNavigation/default.png';
-import screenshotSmall from '../../../../backpack-ios/screenshots/HorizontalNavigation/small.png';
-import screenshotWithIcons from '../../../../backpack-ios/screenshots/HorizontalNavigation/with-icons.png';
-import screenshotNoUnderline from '../../../../backpack-ios/screenshots/HorizontalNavigation/without-underline.png';
-import screenshotDefaultDm from '../../../../backpack-ios/screenshots/HorizontalNavigation/default_dm.png';
-import screenshotSmallDm from '../../../../backpack-ios/screenshots/HorizontalNavigation/small_dm.png';
-import screenshotWithIconsDm from '../../../../backpack-ios/screenshots/HorizontalNavigation/with-icons_dm.png';
-import screenshotNoUnderlineDm from '../../../../backpack-ios/screenshots/HorizontalNavigation/without-underline_dm.png';
+import screenshotDefault from '../../../../backpack-ios/screenshots/iPhone 8-horizontal-navigation___default_lm.png';
+import screenshotSmall from '../../../../backpack-ios/screenshots/iPhone 8-horizontal-navigation___small_lm.png';
+import screenshotWithIcons from '../../../../backpack-ios/screenshots/iPhone 8-horizontal-navigation___with-icons_lm.png';
+import screenshotNoUnderline from '../../../../backpack-ios/screenshots/iPhone 8-horizontal-navigation___without-underline_lm.png';
+import screenshotDefaultDm from '../../../../backpack-ios/screenshots/iPhone 8-horizontal-navigation___default_dm.png';
+import screenshotSmallDm from '../../../../backpack-ios/screenshots/iPhone 8-horizontal-navigation___small_dm.png';
+import screenshotWithIconsDm from '../../../../backpack-ios/screenshots/iPhone 8-horizontal-navigation___with-icons_dm.png';
+import screenshotNoUnderlineDm from '../../../../backpack-ios/screenshots/iPhone 8-horizontal-navigation___without-underline_dm.png';
 import DocsPageBuilder from '../../components/DocsPageBuilder';
 
 const components = [

--- a/docs/src/pages/IOSIconPage/IOSIconPage.js
+++ b/docs/src/pages/IOSIconPage/IOSIconPage.js
@@ -19,8 +19,8 @@
 import React from 'react';
 
 import readme from '../../../../backpack-ios/Backpack/Icon/README.md';
-import screenshotAll from '../../../../backpack-ios/screenshots/Icon/all.png';
-import screenshotAllDm from '../../../../backpack-ios/screenshots/Icon/all_dm.png';
+import screenshotAll from '../../../../backpack-ios/screenshots/iPhone 8-icon___all_lm.png';
+import screenshotAllDm from '../../../../backpack-ios/screenshots/iPhone 8-icon___all_dm.png';
 import DocsPageBuilder from '../../components/DocsPageBuilder';
 
 const components = [

--- a/docs/src/pages/IOSNavigationBarPage/IOSNavigationBarPage.js
+++ b/docs/src/pages/IOSNavigationBarPage/IOSNavigationBarPage.js
@@ -19,12 +19,12 @@
 import React from 'react';
 
 import readme from '../../../../backpack-ios/Backpack/NavigationBar/README.md';
-import screenshotLarge from '../../../../backpack-ios/screenshots/NavigationBar/full-height.png';
-import screenshotCollapsed from '../../../../backpack-ios/screenshots/NavigationBar/collapsed.png';
-import screenshotLargeWithButtons from '../../../../backpack-ios/screenshots/NavigationBar/full-height-with-buttons.png';
-import screenshotLargeDm from '../../../../backpack-ios/screenshots/NavigationBar/full-height_dm.png';
-import screenshotCollapsedDm from '../../../../backpack-ios/screenshots/NavigationBar/collapsed_dm.png';
-import screenshotLargeWithButtonsDm from '../../../../backpack-ios/screenshots/NavigationBar/full-height-with-buttons_dm.png';
+import screenshotLarge from '../../../../backpack-ios/screenshots/iPhone 8-navigation-bar___full-height_lm.png';
+import screenshotCollapsed from '../../../../backpack-ios/screenshots/iPhone 8-navigation-bar___collapsed_lm.png';
+import screenshotLargeWithButtons from '../../../../backpack-ios/screenshots/iPhone 8-navigation-bar___full-height-with-buttons_lm.png';
+import screenshotLargeDm from '../../../../backpack-ios/screenshots/iPhone 8-navigation-bar___full-height_dm.png';
+import screenshotCollapsedDm from '../../../../backpack-ios/screenshots/iPhone 8-navigation-bar___collapsed_dm.png';
+import screenshotLargeWithButtonsDm from '../../../../backpack-ios/screenshots/iPhone 8-navigation-bar___full-height-with-buttons_dm.png';
 import DocsPageBuilder from '../../components/DocsPageBuilder';
 
 const components = [

--- a/docs/src/pages/IOSPanelPage/IOSPanelPage.js
+++ b/docs/src/pages/IOSPanelPage/IOSPanelPage.js
@@ -19,12 +19,12 @@
 import React from 'react';
 
 import readme from '../../../../backpack-ios/Backpack/Panel/README.md';
-import screenshotDefault from '../../../../backpack-ios/screenshots/Panel/default.png';
-import screenshotWithoutPadding from '../../../../backpack-ios/screenshots/Panel/without-padding.png';
-import screenshotElevated from '../../../../backpack-ios/screenshots/Panel/elevated.png';
-import screenshotDefaultDm from '../../../../backpack-ios/screenshots/Panel/default_dm.png';
-import screenshotWithoutPaddingDm from '../../../../backpack-ios/screenshots/Panel/without-padding_dm.png';
-import screenshotElevatedDm from '../../../../backpack-ios/screenshots/Panel/elevated_dm.png';
+import screenshotDefault from '../../../../backpack-ios/screenshots/iPhone 8-panel___default_lm.png';
+import screenshotWithoutPadding from '../../../../backpack-ios/screenshots/iPhone 8-panel___without-padding_lm.png';
+import screenshotElevated from '../../../../backpack-ios/screenshots/iPhone 8-panel___elevated_lm.png';
+import screenshotDefaultDm from '../../../../backpack-ios/screenshots/iPhone 8-panel___default_dm.png';
+import screenshotWithoutPaddingDm from '../../../../backpack-ios/screenshots/iPhone 8-panel___without-padding_dm.png';
+import screenshotElevatedDm from '../../../../backpack-ios/screenshots/iPhone 8-panel___elevated_dm.png';
 import DocsPageBuilder from '../../components/DocsPageBuilder';
 
 const components = [

--- a/docs/src/pages/IOSProgressBarPage/IOSProgressBarPage.js
+++ b/docs/src/pages/IOSProgressBarPage/IOSProgressBarPage.js
@@ -19,8 +19,8 @@
 import React from 'react';
 
 import readme from '../../../../backpack-ios/Backpack/ProgressBar/README.md';
-import screenshotDefault from '../../../../backpack-ios/screenshots/ProgressBar/default.png';
-import screenshotDefaultDm from '../../../../backpack-ios/screenshots/ProgressBar/default_dm.png';
+import screenshotDefault from '../../../../backpack-ios/screenshots/iPhone 8-progress-bar___default_lm.png';
+import screenshotDefaultDm from '../../../../backpack-ios/screenshots/iPhone 8-progress-bar___default_dm.png';
 import DocsPageBuilder from '../../components/DocsPageBuilder';
 
 const components = [

--- a/docs/src/pages/IOSRatingPage/IOSRatingPage.js
+++ b/docs/src/pages/IOSRatingPage/IOSRatingPage.js
@@ -19,12 +19,12 @@
 import React from 'react';
 
 import readme from '../../../../backpack-ios/Backpack/Rating/README.md';
-import screenshotDefault from '../../../../backpack-ios/screenshots/Rating/default.png';
-import screenshotSubtitle from '../../../../backpack-ios/screenshots/Rating/subtitles.png';
-import screenshotSizes from '../../../../backpack-ios/screenshots/Rating/sizes.png';
-import screenshotDefaultDm from '../../../../backpack-ios/screenshots/Rating/default_dm.png';
-import screenshotSubtitleDm from '../../../../backpack-ios/screenshots/Rating/subtitles_dm.png';
-import screenshotSizesDm from '../../../../backpack-ios/screenshots/Rating/sizes_dm.png';
+import screenshotDefault from '../../../../backpack-ios/screenshots/iPhone 8-rating___default_lm.png';
+import screenshotSubtitle from '../../../../backpack-ios/screenshots/iPhone 8-rating___subtitles_lm.png';
+import screenshotSizes from '../../../../backpack-ios/screenshots/iPhone 8-rating___sizes_lm.png';
+import screenshotDefaultDm from '../../../../backpack-ios/screenshots/iPhone 8-rating___default_dm.png';
+import screenshotSubtitleDm from '../../../../backpack-ios/screenshots/iPhone 8-rating___subtitles_dm.png';
+import screenshotSizesDm from '../../../../backpack-ios/screenshots/iPhone 8-rating___sizes_dm.png';
 import DocsPageBuilder from '../../components/DocsPageBuilder';
 
 const components = [

--- a/docs/src/pages/IOSSpinnerPage/IOSSpinnerPage.js
+++ b/docs/src/pages/IOSSpinnerPage/IOSSpinnerPage.js
@@ -19,8 +19,8 @@
 import React from 'react';
 
 import readme from '../../../../backpack-ios/Backpack/Spinner/README.md';
-import screenshotAll from '../../../../backpack-ios/screenshots/Spinner/all.png';
-import screenshotAllDm from '../../../../backpack-ios/screenshots/Spinner/all_dm.png';
+import screenshotAll from '../../../../backpack-ios/screenshots/iPhone 8-spinner___all_lm.png';
+import screenshotAllDm from '../../../../backpack-ios/screenshots/iPhone 8-spinner___all_dm.png';
 import DocsPageBuilder from '../../components/DocsPageBuilder';
 
 const components = [

--- a/docs/src/pages/IOSStarRatingPage/IOSStarRatingPage.js
+++ b/docs/src/pages/IOSStarRatingPage/IOSStarRatingPage.js
@@ -19,8 +19,8 @@
 import React from 'react';
 
 import readme from '../../../../backpack-ios/Backpack/StarRating/README.md';
-import screenshotAll from '../../../../backpack-ios/screenshots/StarRating/docs.png';
-import screenshotAllDm from '../../../../backpack-ios/screenshots/StarRating/docs_dm.png';
+import screenshotAll from '../../../../backpack-ios/screenshots/iPhone 8-star-rating___docs_lm.png';
+import screenshotAllDm from '../../../../backpack-ios/screenshots/iPhone 8-star-rating___docs_dm.png';
 import DocsPageBuilder from '../../components/DocsPageBuilder';
 
 const components = [

--- a/docs/src/pages/IOSSwitchPage/IOSSwitchPage.js
+++ b/docs/src/pages/IOSSwitchPage/IOSSwitchPage.js
@@ -19,8 +19,8 @@
 import React from 'react';
 
 import readme from '../../../../backpack-ios/Backpack/Switch/README.md';
-import screenshotDefault from '../../../../backpack-ios/screenshots/Switch/default.png';
-import screenshotDefaultDm from '../../../../backpack-ios/screenshots/Switch/default_dm.png';
+import screenshotDefault from '../../../../backpack-ios/screenshots/iPhone 8-switch___default_lm.png';
+import screenshotDefaultDm from '../../../../backpack-ios/screenshots/iPhone 8-switch___default_dm.png';
 import DocsPageBuilder from '../../components/DocsPageBuilder';
 
 const components = [

--- a/docs/src/pages/IOSTappableLinkLabelPage/IOSTappableLinkLabelPage.js
+++ b/docs/src/pages/IOSTappableLinkLabelPage/IOSTappableLinkLabelPage.js
@@ -19,10 +19,10 @@
 import React from 'react';
 
 import readme from '../../../../backpack-ios/Backpack/TappableLinkLabel/README.md';
-import screenshotMultiple from '../../../../backpack-ios/screenshots/TappableLinkLabel/multiple.png';
-import screenshotAlternate from '../../../../backpack-ios/screenshots/TappableLinkLabel/alternate-style.png';
-import screenshotMultipleDm from '../../../../backpack-ios/screenshots/TappableLinkLabel/multiple_dm.png';
-import screenshotAlternateDm from '../../../../backpack-ios/screenshots/TappableLinkLabel/alternate-style_dm.png';
+import screenshotMultiple from '../../../../backpack-ios/screenshots/iPhone 8-tappable-link-label___multiple_lm.png';
+import screenshotAlternate from '../../../../backpack-ios/screenshots/iPhone 8-tappable-link-label___alternate-style_lm.png';
+import screenshotMultipleDm from '../../../../backpack-ios/screenshots/iPhone 8-tappable-link-label___multiple_dm.png';
+import screenshotAlternateDm from '../../../../backpack-ios/screenshots/iPhone 8-tappable-link-label___alternate-style_dm.png';
 import DocsPageBuilder from '../../components/DocsPageBuilder';
 
 const components = [

--- a/docs/src/pages/IOSTextInputPage/IOSTextInputPage.js
+++ b/docs/src/pages/IOSTextInputPage/IOSTextInputPage.js
@@ -19,8 +19,8 @@
 import React from 'react';
 
 import readme from '../../../../backpack-ios/Backpack/TextField/README.md';
-import screenshotDefault from '../../../../backpack-ios/screenshots/TextField/default.png';
-import screenshotDefaultDm from '../../../../backpack-ios/screenshots/TextField/default_dm.png';
+import screenshotDefault from '../../../../backpack-ios/screenshots/iPhone 8-text-field___default_lm.png';
+import screenshotDefaultDm from '../../../../backpack-ios/screenshots/iPhone 8-text-field___default_dm.png';
 import DocsPageBuilder from '../../components/DocsPageBuilder';
 
 const components = [

--- a/docs/src/pages/IOSTextPage/IOSTextPage.js
+++ b/docs/src/pages/IOSTextPage/IOSTextPage.js
@@ -19,14 +19,14 @@
 import React from 'react';
 
 import readme from '../../../../backpack-ios/Backpack/Label/README.md';
-import screenshotDefault from '../../../../backpack-ios/screenshots/Label/default.png';
-import screenshotEmphasized from '../../../../backpack-ios/screenshots/Label/emphasized.png';
-import screenshotHeavy from '../../../../backpack-ios/screenshots/Label/heavy.png';
-import screenshotMultipleFontStyles from '../../../../backpack-ios/screenshots/Label/multiple-font-styles.png';
-import screenshotDefaultDm from '../../../../backpack-ios/screenshots/Label/default_dm.png';
-import screenshotEmphasizedDm from '../../../../backpack-ios/screenshots/Label/emphasized_dm.png';
-import screenshotHeavyDm from '../../../../backpack-ios/screenshots/Label/heavy_dm.png';
-import screenshotMultipleFontStylesDm from '../../../../backpack-ios/screenshots/Label/multiple-font-styles_dm.png';
+import screenshotDefault from '../../../../backpack-ios/screenshots/iPhone 8-label___default_lm.png';
+import screenshotEmphasized from '../../../../backpack-ios/screenshots/iPhone 8-label___emphasized_lm.png';
+import screenshotHeavy from '../../../../backpack-ios/screenshots/iPhone 8-label___heavy_lm.png';
+import screenshotMultipleFontStyles from '../../../../backpack-ios/screenshots/iPhone 8-label___multiple-font-styles_lm.png';
+import screenshotDefaultDm from '../../../../backpack-ios/screenshots/iPhone 8-label___default_dm.png';
+import screenshotEmphasizedDm from '../../../../backpack-ios/screenshots/iPhone 8-label___emphasized_dm.png';
+import screenshotHeavyDm from '../../../../backpack-ios/screenshots/iPhone 8-label___heavy_dm.png';
+import screenshotMultipleFontStylesDm from '../../../../backpack-ios/screenshots/iPhone 8-label___multiple-font-styles_dm.png';
 import DocsPageBuilder from '../../components/DocsPageBuilder';
 
 const components = [

--- a/docs/src/pages/IOSTextViewPage/IOSTextViewPage.js
+++ b/docs/src/pages/IOSTextViewPage/IOSTextViewPage.js
@@ -19,8 +19,8 @@
 import React from 'react';
 
 import readme from '../../../../backpack-ios/Backpack/TextView/README.md';
-import screenshotDefault from '../../../../backpack-ios/screenshots/TextView/default.png';
-import screenshotDefaultDm from '../../../../backpack-ios/screenshots/TextView/default_dm.png';
+import screenshotDefault from '../../../../backpack-ios/screenshots/iPhone 8-text-view___default_lm.png';
+import screenshotDefaultDm from '../../../../backpack-ios/screenshots/iPhone 8-text-view___default_dm.png';
 import DocsPageBuilder from '../../components/DocsPageBuilder';
 
 const components = [

--- a/docs/src/pages/IOSToastPage/IOSToastPage.js
+++ b/docs/src/pages/IOSToastPage/IOSToastPage.js
@@ -19,8 +19,8 @@
 import React from 'react';
 
 import readme from '../../../../backpack-ios/Backpack/Toast/README.md';
-import screenshotDefault from '../../../../backpack-ios/screenshots/Toast/default.png';
-import screenshotDefaultDm from '../../../../backpack-ios/screenshots/Toast/default_dm.png';
+import screenshotDefault from '../../../../backpack-ios/screenshots/iPhone 8-toast___default_lm.png';
+import screenshotDefaultDm from '../../../../backpack-ios/screenshots/iPhone 8-toast___default_dm.png';
 import DocsPageBuilder from '../../components/DocsPageBuilder';
 
 const components = [


### PR DESCRIPTION
Note that https://github.com/Skyscanner/backpack-ios/pull/563/ needs to
be merged before this PR.

To run locally uncomment the submodeule update in the `docs` script and
then run `npm run docs`. You might also have to run `git submodules
update --recursive`.


+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack/blob/master/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] [Links platform metadata](https://github.com/Skyscanner/backpack-docs/blob/master/docs/src/layouts/links.js)