### PR TITLE
[NO-JIRA] Make colouor pairing headers less misleading

### DIFF
--- a/docs/src/pages/ColorsPage/ColorChart.js
+++ b/docs/src/pages/ColorsPage/ColorChart.js
@@ -91,7 +91,7 @@ class ColorChart extends Component<{}, State> {
     });
     chartColors.forEach(c1 => {
       colHeadings.push({
-        c1: 'white',
+        c1,
         c2: c1,
         show: true,
       });


### PR DESCRIPTION
The current heading style can be misinterpreted as saying that all colours are accessibile on white. Hopefully this makes it clearer.
![image](https://user-images.githubusercontent.com/30267516/72985069-135ab580-3ddd-11ea-8203-5e8dd47de1d5.png)

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack/blob/master/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] [Links platform metadata](https://github.com/Skyscanner/backpack-docs/blob/master/docs/src/layouts/links.js)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
