### PR TITLE
[BPK-3453]: Add Android DM screenshots

### DIFF
--- a/docs/src/pages/AndroidBadgePage/AndroidBadgePage.js
+++ b/docs/src/pages/AndroidBadgePage/AndroidBadgePage.js
@@ -20,6 +20,7 @@ import React from 'react';
 
 import readme from '../../../../backpack-android/docs/Badge/README.md';
 import screenshotAll from '../../../../backpack-android/docs/Badge/screenshots/all.png';
+import screenshotAllDm from '../../../../backpack-android/docs/Badge/screenshots/all_dm.png';
 import DocsPageBuilder from '../../components/DocsPageBuilder';
 
 const components = [
@@ -33,6 +34,13 @@ const components = [
         src: `/${screenshotAll}`,
         altText: 'Android badges',
         subText: '(Google Pixel emulator)',
+      },
+      {
+        width: 1080,
+        height: 1920,
+        src: `/${screenshotAllDm}`,
+        altText: 'Android badges',
+        subText: '(Google Pixel emulator - dark mode)',
       },
     ],
   },

--- a/docs/src/pages/AndroidButtonPage/AndroidButtonPage.js
+++ b/docs/src/pages/AndroidButtonPage/AndroidButtonPage.js
@@ -20,10 +20,15 @@ import React from 'react';
 
 import readme from '../../../../backpack-android/docs/Button/README.md';
 import screenshotPrimary from '../../../../backpack-android/docs/Button/screenshots/primary.png';
+import screenshotPrimaryDm from '../../../../backpack-android/docs/Button/screenshots/primary_dm.png';
 import screenshotSecondary from '../../../../backpack-android/docs/Button/screenshots/secondary.png';
+import screenshotSecondaryDm from '../../../../backpack-android/docs/Button/screenshots/secondary_dm.png';
 import screenshotDestructive from '../../../../backpack-android/docs/Button/screenshots/destructive.png';
+import screenshotDestructiveDm from '../../../../backpack-android/docs/Button/screenshots/destructive_dm.png';
 import screenshotOutline from '../../../../backpack-android/docs/Button/screenshots/outline.png';
+import screenshotOutlineDm from '../../../../backpack-android/docs/Button/screenshots/outline_dm.png';
 import screenshotFeatured from '../../../../backpack-android/docs/Button/screenshots/featured.png';
+import screenshotFeaturedDm from '../../../../backpack-android/docs/Button/screenshots/featured_dm.png';
 import DocsPageBuilder from '../../components/DocsPageBuilder';
 
 const components = [
@@ -38,6 +43,13 @@ const components = [
         altText: 'Android primary button',
         subText: '(Google Pixel emulator)',
       },
+      {
+        width: 1080,
+        height: 1920,
+        src: `/${screenshotPrimaryDm}`,
+        altText: 'Android primary button',
+        subText: '(Google Pixel emulator - dark mode)',
+      },
     ],
   },
   {
@@ -50,6 +62,13 @@ const components = [
         src: `/${screenshotSecondary}`,
         altText: 'Android secondary button',
         subText: '(Google Pixel emulator)',
+      },
+      {
+        width: 1080,
+        height: 1920,
+        src: `/${screenshotSecondaryDm}`,
+        altText: 'Android secondary button',
+        subText: '(Google Pixel emulator - dark mode)',
       },
     ],
   },
@@ -64,6 +83,13 @@ const components = [
         altText: 'Android destructive button',
         subText: '(Google Pixel emulator)',
       },
+      {
+        width: 1080,
+        height: 1920,
+        src: `/${screenshotDestructiveDm}`,
+        altText: 'Android destructive button',
+        subText: '(Google Pixel emulator - dark mode)',
+      },
     ],
   },
   {
@@ -77,6 +103,13 @@ const components = [
         altText: 'Android featured button',
         subText: '(Google Pixel emulator)',
       },
+      {
+        width: 1080,
+        height: 1920,
+        src: `/${screenshotFeaturedDm}`,
+        altText: 'Android featured button',
+        subText: '(Google Pixel emulator - dark mode)',
+      },
     ],
   },
   {
@@ -89,6 +122,13 @@ const components = [
         src: `/${screenshotOutline}`,
         altText: 'Android outline button',
         subText: '(Google Pixel emulator)',
+      },
+      {
+        width: 1080,
+        height: 1920,
+        src: `/${screenshotOutlineDm}`,
+        altText: 'Android outline button',
+        subText: '(Google Pixel emulator - dark mode)',
       },
     ],
   },

--- a/docs/src/pages/AndroidCalendarPage/AndroidCalendarPage.js
+++ b/docs/src/pages/AndroidCalendarPage/AndroidCalendarPage.js
@@ -20,6 +20,7 @@ import React from 'react';
 
 import readme from '../../../../backpack-android/docs/Calendar/README.md';
 import screenshotAll from '../../../../backpack-android/docs/Calendar/screenshots/range.png';
+import screenshotAllDm from '../../../../backpack-android/docs/Calendar/screenshots/range_dm.png';
 import DocsPageBuilder from '../../components/DocsPageBuilder';
 
 const components = [
@@ -33,6 +34,13 @@ const components = [
         src: `/${screenshotAll}`,
         altText: 'Calendar with a range of dates',
         subText: '(Google Pixel emulator)',
+      },
+      {
+        width: 1080,
+        height: 1920,
+        src: `/${screenshotAllDm}`,
+        altText: 'Calendar with a range of dates',
+        subText: '(Google Pixel emulator - dark mode)',
       },
     ],
   },

--- a/docs/src/pages/AndroidCardPage/AndroidCardPage.js
+++ b/docs/src/pages/AndroidCardPage/AndroidCardPage.js
@@ -20,13 +20,21 @@ import React from 'react';
 
 import readme from '../../../../backpack-android/docs/Card/README.md';
 import screenshotDefault from '../../../../backpack-android/docs/Card/screenshots/default.png';
+import screenshotDefaultDm from '../../../../backpack-android/docs/Card/screenshots/default_dm.png';
 import screenshotCornerStyleLarge from '../../../../backpack-android/docs/Card/screenshots/corner-style-large.png';
+import screenshotCornerStyleLargeDm from '../../../../backpack-android/docs/Card/screenshots/corner-style-large_dm.png';
 import screenshotSelected from '../../../../backpack-android/docs/Card/screenshots/selected.png';
+import screenshotSelectedDm from '../../../../backpack-android/docs/Card/screenshots/selected_dm.png';
 import screenshotWithoutPadding from '../../../../backpack-android/docs/Card/screenshots/without-padding.png';
+import screenshotWithoutPaddingDm from '../../../../backpack-android/docs/Card/screenshots/without-padding_dm.png';
 import screenshotWithDivider from '../../../../backpack-android/docs/Card/screenshots/with-divider.png';
+import screenshotWithDividerDm from '../../../../backpack-android/docs/Card/screenshots/with-divider_dm.png';
 import screenshotWithDividerArrangedVertically from '../../../../backpack-android/docs/Card/screenshots/with-divider-arranged-vertically.png';
+import screenshotWithDividerArrangedVerticallyDm from '../../../../backpack-android/docs/Card/screenshots/with-divider-arranged-vertically_dm.png';
 import screenshotWithDividerCornerStyleLarge from '../../../../backpack-android/docs/Card/screenshots/with-divider-and-corner-style-large.png';
+import screenshotWithDividerCornerStyleLargeDm from '../../../../backpack-android/docs/Card/screenshots/with-divider-and-corner-style-large_dm.png';
 import screenshotWithDividerWithoutPadding from '../../../../backpack-android/docs/Card/screenshots/with-divider-without-padding.png';
+import screenshotWithDividerWithoutPaddingDm from '../../../../backpack-android/docs/Card/screenshots/with-divider-without-padding_dm.png';
 import DocsPageBuilder from '../../components/DocsPageBuilder';
 
 const components = [
@@ -41,6 +49,13 @@ const components = [
         altText: 'Default card component',
         subText: '(Google Pixel emulator)',
       },
+      {
+        width: 1080,
+        height: 1920,
+        src: `/${screenshotDefaultDm}`,
+        altText: 'Default card component',
+        subText: '(Google Pixel emulator - dark mode)',
+      },
     ],
   },
   {
@@ -53,6 +68,13 @@ const components = [
         src: `/${screenshotSelected}`,
         altText: 'Selected card component',
         subText: '(Google Pixel emulator)',
+      },
+      {
+        width: 1080,
+        height: 1920,
+        src: `/${screenshotSelectedDm}`,
+        altText: 'Selected card component',
+        subText: '(Google Pixel emulator - dark mode)',
       },
     ],
   },
@@ -67,6 +89,13 @@ const components = [
         altText: 'Card component with large corner style',
         subText: '(Google Pixel emulator)',
       },
+      {
+        width: 1080,
+        height: 1920,
+        src: `/${screenshotCornerStyleLargeDm}`,
+        altText: 'Card component with large corner style',
+        subText: '(Google Pixel emulator - dark mode)',
+      },
     ],
   },
   {
@@ -79,6 +108,13 @@ const components = [
         src: `/${screenshotWithoutPadding}`,
         altText: 'Card component without padding',
         subText: '(Google Pixel emulator)',
+      },
+      {
+        width: 1080,
+        height: 1920,
+        src: `/${screenshotWithoutPaddingDm}`,
+        altText: 'Card component without padding',
+        subText: '(Google Pixel emulator - dark mode)',
       },
     ],
   },
@@ -93,6 +129,13 @@ const components = [
         altText: 'Card component with divider',
         subText: '(Google Pixel emulator)',
       },
+      {
+        width: 1080,
+        height: 1920,
+        src: `/${screenshotWithDividerDm}`,
+        altText: 'Card component with divider',
+        subText: '(Google Pixel emulator - dark mode)',
+      },
     ],
   },
   {
@@ -105,6 +148,13 @@ const components = [
         src: `/${screenshotWithDividerArrangedVertically}`,
         altText: 'Card component with divider arranged vertically',
         subText: '(Google Pixel emulator)',
+      },
+      {
+        width: 1080,
+        height: 1920,
+        src: `/${screenshotWithDividerArrangedVerticallyDm}`,
+        altText: 'Card component with divider arranged vertically',
+        subText: '(Google Pixel emulator - dark mode)',
       },
     ],
   },
@@ -119,6 +169,13 @@ const components = [
         altText: 'Card component with divider and without padding',
         subText: '(Google Pixel emulator)',
       },
+      {
+        width: 1080,
+        height: 1920,
+        src: `/${screenshotWithDividerWithoutPaddingDm}`,
+        altText: 'Card component with divider and without padding',
+        subText: '(Google Pixel emulator - dark mode)',
+      },
     ],
   },
   {
@@ -131,6 +188,13 @@ const components = [
         src: `/${screenshotWithDividerCornerStyleLarge}`,
         altText: 'Card component with divider and large corner style',
         subText: '(Google Pixel emulator)',
+      },
+      {
+        width: 1080,
+        height: 1920,
+        src: `/${screenshotWithDividerCornerStyleLargeDm}`,
+        altText: 'Card component with divider and large corner style',
+        subText: '(Google Pixel emulator - dark mode)',
       },
     ],
   },

--- a/docs/src/pages/AndroidCheckboxPage/AndroidCheckboxPage.js
+++ b/docs/src/pages/AndroidCheckboxPage/AndroidCheckboxPage.js
@@ -20,6 +20,7 @@ import React from 'react';
 
 import readme from '../../../../backpack-android/docs/Checkbox/README.md';
 import screenshotDefault from '../../../../backpack-android/docs/Checkbox/screenshots/default.png';
+import screenshotDefaultDm from '../../../../backpack-android/docs/Checkbox/screenshots/default_dm.png';
 import DocsPageBuilder from '../../components/DocsPageBuilder';
 
 const components = [
@@ -34,6 +35,14 @@ const components = [
         src: `/${screenshotDefault}`,
         altText: 'Android Checkbox Component',
         subText: '(Google Pixel emulator)',
+      },
+      {
+        title: 'Android',
+        width: 1080,
+        height: 1920,
+        src: `/${screenshotDefaultDm}`,
+        altText: 'Android Checkbox Component',
+        subText: '(Google Pixel emulator - dark mode)',
       },
     ],
   },

--- a/docs/src/pages/AndroidChipPage/AndroidChipPage.js
+++ b/docs/src/pages/AndroidChipPage/AndroidChipPage.js
@@ -20,6 +20,7 @@ import React from 'react';
 
 import readme from '../../../../backpack-android/docs/Chip/README.md';
 import screenshotAll from '../../../../backpack-android/docs/Chip/screenshots/all.png';
+import screenshotAllDm from '../../../../backpack-android/docs/Chip/screenshots/all_dm.png';
 import DocsPageBuilder from '../../components/DocsPageBuilder';
 
 const components = [
@@ -33,6 +34,13 @@ const components = [
         src: `/${screenshotAll}`,
         altText: 'Chip component',
         subText: '(Google Pixel emulator)',
+      },
+      {
+        width: 1080,
+        height: 1920,
+        src: `/${screenshotAllDm}`,
+        altText: 'Chip component',
+        subText: '(Google Pixel emulator - dark mode)',
       },
     ],
   },

--- a/docs/src/pages/AndroidDialogPage/AndroidDialogPage.js
+++ b/docs/src/pages/AndroidDialogPage/AndroidDialogPage.js
@@ -20,7 +20,9 @@ import React from 'react';
 
 import readme from '../../../../backpack-android/docs/Dialog/README.md';
 import screenshotAlert from '../../../../backpack-android/docs/Dialog/screenshots/with-cta.png';
+import screenshotAlertDm from '../../../../backpack-android/docs/Dialog/screenshots/with-cta_dm.png';
 import screenshotBottomSheet from '../../../../backpack-android/docs/Dialog/screenshots/delete-confirmation.png';
+import screenshotBottomSheetDm from '../../../../backpack-android/docs/Dialog/screenshots/delete-confirmation_dm.png';
 import DocsPageBuilder from '../../components/DocsPageBuilder';
 
 const components = [
@@ -38,6 +40,14 @@ const components = [
         altText: 'Alert dialog with a call to action.',
         subText: '(Google Pixel emulator)',
       },
+      {
+        title: 'Used as a call to action.',
+        width: 1080,
+        height: 1920,
+        src: `/${screenshotAlertDm}`,
+        altText: 'Alert dialog with a call to action.',
+        subText: '(Google Pixel emulator - dark mode)',
+      },
     ],
   },
   {
@@ -53,6 +63,14 @@ const components = [
         src: `/${screenshotBottomSheet}`,
         altText: 'Bottom sheet dialog used for confirmation.',
         subText: '(Google Pixel emulator)',
+      },
+      {
+        title: 'Used for confirmation.',
+        width: 1080,
+        height: 1920,
+        src: `/${screenshotBottomSheetDm}`,
+        altText: 'Bottom sheet dialog used for confirmation.',
+        subText: '(Google Pixel emulator - dark mode)',
       },
     ],
   },

--- a/docs/src/pages/AndroidFlarePage/AndroidFlarePage.js
+++ b/docs/src/pages/AndroidFlarePage/AndroidFlarePage.js
@@ -20,9 +20,13 @@ import React from 'react';
 
 import readme from '../../../../backpack-android/docs/Flare/README.md';
 import screenshotDefault from '../../../../backpack-android/docs/Flare/screenshots/default.png';
+import screenshotDefaultDm from '../../../../backpack-android/docs/Flare/screenshots/default_dm.png';
 import screenshotRounded from '../../../../backpack-android/docs/Flare/screenshots/rounded.png';
+import screenshotRoundedDm from '../../../../backpack-android/docs/Flare/screenshots/rounded_dm.png';
 import screenshotPointerOffset from '../../../../backpack-android/docs/Flare/screenshots/pointer-offset.png';
+import screenshotPointerOffsetDm from '../../../../backpack-android/docs/Flare/screenshots/pointer-offset_dm.png';
 import screenshotInsetPadding from '../../../../backpack-android/docs/Flare/screenshots/inset-padding.png';
+import screenshotInsetPaddingDm from '../../../../backpack-android/docs/Flare/screenshots/inset-padding_dm.png';
 import DocsPageBuilder from '../../components/DocsPageBuilder';
 
 const components = [
@@ -37,6 +41,13 @@ const components = [
         altText: 'Flare component',
         subText: '(Google Pixel emulator)',
       },
+      {
+        width: 1080,
+        height: 1920,
+        src: `/${screenshotDefaultDm}`,
+        altText: 'Flare component',
+        subText: '(Google Pixel emulator - dark mode)',
+      },
     ],
   },
   {
@@ -49,6 +60,13 @@ const components = [
         src: `/${screenshotRounded}`,
         altText: 'Flare component with rounded corners',
         subText: '(Google Pixel emulator)',
+      },
+      {
+        width: 1080,
+        height: 1920,
+        src: `/${screenshotRoundedDm}`,
+        altText: 'Flare component with rounded corners',
+        subText: '(Google Pixel emulator - dark mode)',
       },
     ],
   },
@@ -63,6 +81,13 @@ const components = [
         altText: 'Flare component with offset pointer',
         subText: '(Google Pixel emulator)',
       },
+      {
+        width: 1080,
+        height: 1920,
+        src: `/${screenshotPointerOffsetDm}`,
+        altText: 'Flare component with offset pointer',
+        subText: '(Google Pixel emulator - dark mode)',
+      },
     ],
   },
   {
@@ -75,6 +100,13 @@ const components = [
         src: `/${screenshotInsetPadding}`,
         altText: 'Flare component with padding',
         subText: '(Google Pixel emulator)',
+      },
+      {
+        width: 1080,
+        height: 1920,
+        src: `/${screenshotInsetPaddingDm}`,
+        altText: 'Flare component with padding',
+        subText: '(Google Pixel emulator - dark mode)',
       },
     ],
   },

--- a/docs/src/pages/AndroidFloatingActionButtonPage/AndroidFloatingActionButtonPage.js
+++ b/docs/src/pages/AndroidFloatingActionButtonPage/AndroidFloatingActionButtonPage.js
@@ -20,6 +20,7 @@ import React from 'react';
 
 import readme from '../../../../backpack-android/docs/FloatingActionButton/README.md';
 import screenshotDefault from '../../../../backpack-android/docs/FloatingActionButton/screenshots/default.png';
+import screenshotDefaultDm from '../../../../backpack-android/docs/FloatingActionButton/screenshots/default_dm.png';
 import DocsPageBuilder from '../../components/DocsPageBuilder';
 
 const components = [
@@ -34,6 +35,14 @@ const components = [
         src: `/${screenshotDefault}`,
         altText: 'Android Floating Action Button Component',
         subText: '(Google Pixel emulator)',
+      },
+      {
+        title: 'Android',
+        width: 1080,
+        height: 1920,
+        src: `/${screenshotDefaultDm}`,
+        altText: 'Android Floating Action Button Component',
+        subText: '(Google Pixel emulator - dark mode)',
       },
     ],
   },

--- a/docs/src/pages/AndroidHorizontalNavPage/AndroidHorizontalNavPage.js
+++ b/docs/src/pages/AndroidHorizontalNavPage/AndroidHorizontalNavPage.js
@@ -20,6 +20,7 @@ import React from 'react';
 
 import readme from '../../../../backpack-android/docs/HorizontalNav/README.md';
 import screenshotDefault from '../../../../backpack-android/docs/HorizontalNav/screenshots/default.png';
+import screenshotDefaultDm from '../../../../backpack-android/docs/HorizontalNav/screenshots/default_dm.png';
 import DocsPageBuilder from '../../components/DocsPageBuilder';
 
 const components = [
@@ -34,6 +35,14 @@ const components = [
         src: `/${screenshotDefault}`,
         altText: 'Android HorizontalNav Component',
         subText: '(Google Pixel emulator)',
+      },
+      {
+        title: 'Android',
+        width: 1080,
+        height: 1920,
+        src: `/${screenshotDefaultDm}`,
+        altText: 'Android HorizontalNav Component',
+        subText: '(Google Pixel emulator - dark mode)',
       },
     ],
   },

--- a/docs/src/pages/AndroidIconPage/AndroidIconPage.js
+++ b/docs/src/pages/AndroidIconPage/AndroidIconPage.js
@@ -20,6 +20,7 @@ import React from 'react';
 
 import readme from '../../../../backpack-android/docs/Icon/README.md';
 import screenshotAll from '../../../../backpack-android/docs/Icon/screenshots/all.png';
+import screenshotAllDm from '../../../../backpack-android/docs/Icon/screenshots/all_dm.png';
 import DocsPageBuilder from '../../components/DocsPageBuilder';
 
 const components = [
@@ -33,6 +34,13 @@ const components = [
         src: `/${screenshotAll}`,
         altText: 'Icons for Android.',
         subText: '(Google Pixel Emulator)',
+      },
+      {
+        width: 750,
+        height: 1334,
+        src: `/${screenshotAllDm}`,
+        altText: 'Icons for Android.',
+        subText: '(Google Pixel Emulator - dark mode)',
       },
     ],
   },

--- a/docs/src/pages/AndroidLinkPage/AndroidLinkPage.js
+++ b/docs/src/pages/AndroidLinkPage/AndroidLinkPage.js
@@ -20,6 +20,7 @@ import React from 'react';
 
 import readme from '../../../../backpack-android/docs/ButtonLink/README.md';
 import screenshotDefault from '../../../../backpack-android/docs/ButtonLink/screenshots/default.png';
+import screenshotDefaultDm from '../../../../backpack-android/docs/ButtonLink/screenshots/default_dm.png';
 import DocsPageBuilder from '../../components/DocsPageBuilder';
 
 const components = [
@@ -34,6 +35,14 @@ const components = [
         src: `/${screenshotDefault}`,
         altText: 'Android Button link Component',
         subText: '(Google Pixel emulator)',
+      },
+      {
+        title: 'Android',
+        width: 1080,
+        height: 1920,
+        src: `/${screenshotDefaultDm}`,
+        altText: 'Android Button link Component',
+        subText: '(Google Pixel emulator - dark mode)',
       },
     ],
   },

--- a/docs/src/pages/AndroidNavBarPage/AndroidNavBarPage.js
+++ b/docs/src/pages/AndroidNavBarPage/AndroidNavBarPage.js
@@ -20,8 +20,11 @@ import React from 'react';
 
 import readme from '../../../../backpack-android/docs/NavBar/README.md';
 import screenshotCollapsed from '../../../../backpack-android/docs/NavBar/screenshots/collapsed.png';
+import screenshotCollapsedDm from '../../../../backpack-android/docs/NavBar/screenshots/collapsed_dm.png';
 import screenshotExpanded from '../../../../backpack-android/docs/NavBar/screenshots/expanded.png';
+import screenshotExpandedDm from '../../../../backpack-android/docs/NavBar/screenshots/expanded_dm.png';
 import screenshotNavigation from '../../../../backpack-android/docs/NavBar/screenshots/navigation.png';
+import screenshotNavigationDm from '../../../../backpack-android/docs/NavBar/screenshots/navigation_dm.png';
 import DocsPageBuilder from '../../components/DocsPageBuilder';
 
 const components = [
@@ -36,6 +39,13 @@ const components = [
         altText: 'Navigation bar component when expanded',
         subText: '(Google Pixel emulator)',
       },
+      {
+        width: 1080,
+        height: 1920,
+        src: `/${screenshotExpandedDm}`,
+        altText: 'Navigation bar component when expanded',
+        subText: '(Google Pixel emulator - dark mode)',
+      },
     ],
   },
   {
@@ -49,6 +59,13 @@ const components = [
         altText: 'Navigation bar component when collapsed',
         subText: '(Google Pixel emulator)',
       },
+      {
+        width: 1080,
+        height: 1920,
+        src: `/${screenshotCollapsedDm}`,
+        altText: 'Navigation bar component when collapsed',
+        subText: '(Google Pixel emulator - dark mode)',
+      },
     ],
   },
   {
@@ -61,6 +78,13 @@ const components = [
         src: `/${screenshotNavigation}`,
         altText: 'Navigation bar component with navigation elements',
         subText: '(Google Pixel emulator)',
+      },
+      {
+        width: 1080,
+        height: 1920,
+        src: `/${screenshotNavigationDm}`,
+        altText: 'Navigation bar component with navigation elements',
+        subText: '(Google Pixel emulator - dark mode)',
       },
     ],
   },

--- a/docs/src/pages/AndroidPanelPage/AndroidPanelPage.js
+++ b/docs/src/pages/AndroidPanelPage/AndroidPanelPage.js
@@ -20,6 +20,7 @@ import React from 'react';
 
 import readme from '../../../../backpack-android/docs/Panel/README.md';
 import screenshotDefault from '../../../../backpack-android/docs/Panel/screenshots/all.png';
+import screenshotDefaultDm from '../../../../backpack-android/docs/Panel/screenshots/all_dm.png';
 import DocsPageBuilder from '../../components/DocsPageBuilder';
 
 const components = [
@@ -33,6 +34,13 @@ const components = [
         src: `/${screenshotDefault}`,
         altText: 'Panel component',
         subText: '(Google Pixel emulator)',
+      },
+      {
+        width: 1080,
+        height: 1920,
+        src: `/${screenshotDefaultDm}`,
+        altText: 'Panel component',
+        subText: '(Google Pixel emulator - dark mode)',
       },
     ],
   },

--- a/docs/src/pages/AndroidRatingPage/AndroidRatingPage.js
+++ b/docs/src/pages/AndroidRatingPage/AndroidRatingPage.js
@@ -20,8 +20,11 @@ import React from 'react';
 
 import readme from '../../../../backpack-android/docs/Rating/README.md';
 import screenshotDefault from '../../../../backpack-android/docs/Rating/screenshots/default.png';
+import screenshotDefaultDm from '../../../../backpack-android/docs/Rating/screenshots/default_dm.png';
 import screenshotSizes from '../../../../backpack-android/docs/Rating/screenshots/sizes.png';
+import screenshotSizesDm from '../../../../backpack-android/docs/Rating/screenshots/sizes_dm.png';
 import screenshotVertical from '../../../../backpack-android/docs/Rating/screenshots/vertical.png';
+import screenshotVerticalDm from '../../../../backpack-android/docs/Rating/screenshots/vertical_dm.png';
 import DocsPageBuilder from '../../components/DocsPageBuilder';
 
 const components = [
@@ -37,6 +40,14 @@ const components = [
         altText: 'Android Rating Component',
         subText: '(Google Pixel emulator)',
       },
+      {
+        title: 'Android',
+        width: 1080,
+        height: 1920,
+        src: `/${screenshotDefaultDm}`,
+        altText: 'Android Rating Component',
+        subText: '(Google Pixel emulator - dark mode)',
+      },
     ],
   },
   {
@@ -51,6 +62,14 @@ const components = [
         altText: 'Different sizes of the Rating component',
         subText: '(Google Pixel emulator)',
       },
+      {
+        title: 'Sizes',
+        width: 1080,
+        height: 1920,
+        src: `/${screenshotSizesDm}`,
+        altText: 'Different sizes of the Rating component',
+        subText: '(Google Pixel emulator - dark mode)',
+      },
     ],
   },
   {
@@ -64,6 +83,14 @@ const components = [
         src: `/${screenshotVertical}`,
         altText: 'Vertical orientation of the Rating component',
         subText: '(Google Pixel emulator)',
+      },
+      {
+        title: 'Vertical',
+        width: 1080,
+        height: 1920,
+        src: `/${screenshotVerticalDm}`,
+        altText: 'Vertical orientation of the Rating component',
+        subText: '(Google Pixel emulator - dark mode)',
       },
     ],
   },

--- a/docs/src/pages/AndroidSnackbarPage/AndroidSnackbarPage.js
+++ b/docs/src/pages/AndroidSnackbarPage/AndroidSnackbarPage.js
@@ -20,6 +20,7 @@ import React from 'react';
 
 import readme from '../../../../backpack-android/docs/Snackbar/README.md';
 import screenshotDefault from '../../../../backpack-android/docs/Snackbar/screenshots/default.png';
+import screenshotDefaultDm from '../../../../backpack-android/docs/Snackbar/screenshots/default_dm.png';
 import DocsPageBuilder from '../../components/DocsPageBuilder';
 
 const components = [
@@ -34,6 +35,14 @@ const components = [
         src: `/${screenshotDefault}`,
         altText: 'Android Snackbar Component',
         subText: '(Google Pixel emulator)',
+      },
+      {
+        title: 'Android',
+        width: 1080,
+        height: 1920,
+        src: `/${screenshotDefaultDm}`,
+        altText: 'Android Snackbar Component',
+        subText: '(Google Pixel emulator - dark mode)',
       },
     ],
   },

--- a/docs/src/pages/AndroidSpinnerPage/AndroidSpinnerPage.js
+++ b/docs/src/pages/AndroidSpinnerPage/AndroidSpinnerPage.js
@@ -20,7 +20,9 @@ import React from 'react';
 
 import readme from '../../../../backpack-android/docs/Spinner/README.md';
 import screenshotDefault from '../../../../backpack-android/docs/Spinner/screenshots/default.png';
+import screenshotDefaultDm from '../../../../backpack-android/docs/Spinner/screenshots/default_dm.png';
 import screenshotSmall from '../../../../backpack-android/docs/Spinner/screenshots/small.png';
+import screenshotSmallDm from '../../../../backpack-android/docs/Spinner/screenshots/small_dm.png';
 import DocsPageBuilder from '../../components/DocsPageBuilder';
 
 const components = [
@@ -35,6 +37,13 @@ const components = [
         altText: 'Spinner component',
         subText: '(Google Pixel emulator)',
       },
+      {
+        width: 1080,
+        height: 1920,
+        src: `/${screenshotDefaultDm}`,
+        altText: 'Spinner component',
+        subText: '(Google Pixel emulator - dark mode)',
+      },
     ],
   },
   {
@@ -47,6 +56,13 @@ const components = [
         src: `/${screenshotSmall}`,
         altText: 'Small spinner component',
         subText: '(Google Pixel emulator)',
+      },
+      {
+        width: 1080,
+        height: 1920,
+        src: `/${screenshotSmallDm}`,
+        altText: 'Small spinner component',
+        subText: '(Google Pixel emulator - dark mode)',
       },
     ],
   },

--- a/docs/src/pages/AndroidStarRatingInteractivePage/AndroidStarRatingInteractivePage.js
+++ b/docs/src/pages/AndroidStarRatingInteractivePage/AndroidStarRatingInteractivePage.js
@@ -21,6 +21,7 @@ import BpkLink from 'bpk-component-link';
 
 import readme from '../../../../backpack-android/docs/InteractiveStarRating/README.md';
 import screenshotDefault from '../../../../backpack-android/docs/InteractiveStarRating/screenshots/default.png';
+import screenshotDefaultDm from '../../../../backpack-android/docs/InteractiveStarRating/screenshots/default_dm.png';
 import DocsPageBuilder from '../../components/DocsPageBuilder';
 import Paragraph from '../../components/Paragraph';
 import * as ROUTES from '../../constants/routes';
@@ -44,6 +45,14 @@ const components = [
         src: `/${screenshotDefault}`,
         altText: 'Android Interactive Star Rating Component',
         subText: '(Google Pixel emulator)',
+      },
+      {
+        title: 'Android',
+        width: 1080,
+        height: 1920,
+        src: `/${screenshotDefaultDm}`,
+        altText: 'Android Interactive Star Rating Component',
+        subText: '(Google Pixel emulator - dark mode)',
       },
     ],
   },

--- a/docs/src/pages/AndroidStarRatingPage/AndroidStarRatingPage.js
+++ b/docs/src/pages/AndroidStarRatingPage/AndroidStarRatingPage.js
@@ -20,6 +20,7 @@ import React from 'react';
 
 import readme from '../../../../backpack-android/docs/StarRating/README.md';
 import screenshotDefault from '../../../../backpack-android/docs/StarRating/screenshots/default.png';
+import screenshotDefaultDm from '../../../../backpack-android/docs/StarRating/screenshots/default_dm.png';
 import DocsPageBuilder from '../../components/DocsPageBuilder';
 
 const components = [
@@ -36,6 +37,14 @@ const components = [
         src: `/${screenshotDefault}`,
         altText: 'Android Star Rating Component',
         subText: '(Google Pixel emulator)',
+      },
+      {
+        title: 'Android',
+        width: 1080,
+        height: 1920,
+        src: `/${screenshotDefaultDm}`,
+        altText: 'Android Star Rating Component',
+        subText: '(Google Pixel emulator - dark mode)',
       },
     ],
   },

--- a/docs/src/pages/AndroidSwitchPage/AndroidSwitchPage.js
+++ b/docs/src/pages/AndroidSwitchPage/AndroidSwitchPage.js
@@ -20,6 +20,7 @@ import React from 'react';
 
 import readme from '../../../../backpack-android/docs/Switch/README.md';
 import screenshotDefault from '../../../../backpack-android/docs/Switch/screenshots/default.png';
+import screenshotDefaultDm from '../../../../backpack-android/docs/Switch/screenshots/default_dm.png';
 import DocsPageBuilder from '../../components/DocsPageBuilder';
 
 const components = [
@@ -33,6 +34,13 @@ const components = [
         src: `/${screenshotDefault}`,
         altText: 'Switch component',
         subText: '(Google Pixel emulator)',
+      },
+      {
+        width: 1080,
+        height: 1920,
+        src: `/${screenshotDefaultDm}`,
+        altText: 'Switch component',
+        subText: '(Google Pixel emulator - dark mode)',
       },
     ],
   },

--- a/docs/src/pages/AndroidTextFieldPage/AndroidTextFieldPage.js
+++ b/docs/src/pages/AndroidTextFieldPage/AndroidTextFieldPage.js
@@ -20,6 +20,7 @@ import React from 'react';
 
 import readme from '../../../../backpack-android/docs/TextField/README.md';
 import screenshotDefault from '../../../../backpack-android/docs/TextField/screenshots/default.png';
+import screenshotDefaultDm from '../../../../backpack-android/docs/TextField/screenshots/default_dm.png';
 import DocsPageBuilder from '../../components/DocsPageBuilder';
 
 const components = [
@@ -34,6 +35,14 @@ const components = [
         src: `/${screenshotDefault}`,
         altText: 'Android Text Field Component',
         subText: '(Google Pixel emulator)',
+      },
+      {
+        title: 'Android',
+        width: 1080,
+        height: 1920,
+        src: `/${screenshotDefaultDm}`,
+        altText: 'Android Text Field Component',
+        subText: '(Google Pixel emulator - dark mode)',
       },
     ],
   },

--- a/docs/src/pages/AndroidTextPage/AndroidTextPage.js
+++ b/docs/src/pages/AndroidTextPage/AndroidTextPage.js
@@ -20,8 +20,11 @@ import React from 'react';
 
 import readme from '../../../../backpack-android/docs/Text/README.md';
 import screenshotDefault from '../../../../backpack-android/docs/Text/screenshots/default.png';
+import screenshotDefaultDm from '../../../../backpack-android/docs/Text/screenshots/default_dm.png';
 import screenshotEmphasized from '../../../../backpack-android/docs/Text/screenshots/emphasized.png';
+import screenshotEmphasizedDm from '../../../../backpack-android/docs/Text/screenshots/emphasized_dm.png';
 import screenshotHeavy from '../../../../backpack-android/docs/Text/screenshots/heavy.png';
+import screenshotHeavyDm from '../../../../backpack-android/docs/Text/screenshots/heavy_dm.png';
 import DocsPageBuilder from '../../components/DocsPageBuilder';
 
 const components = [
@@ -36,6 +39,13 @@ const components = [
         altText: 'Default text component',
         subText: '(Google Pixel emulator)',
       },
+      {
+        width: 1080,
+        height: 1920,
+        src: `/${screenshotDefaultDm}`,
+        altText: 'Default text component',
+        subText: '(Google Pixel emulator - dark mode)',
+      },
     ],
   },
   {
@@ -49,6 +59,13 @@ const components = [
         altText: 'Emphasized text component',
         subText: '(Google Pixel emulator)',
       },
+      {
+        width: 1080,
+        height: 1920,
+        src: `/${screenshotEmphasizedDm}`,
+        altText: 'Emphasized text component',
+        subText: '(Google Pixel emulator - dark mode)',
+      },
     ],
   },
   {
@@ -61,6 +78,13 @@ const components = [
         src: `/${screenshotHeavy}`,
         altText: 'Heavy text component',
         subText: '(Google Pixel emulator)',
+      },
+      {
+        width: 1080,
+        height: 1920,
+        src: `/${screenshotHeavyDm}`,
+        altText: 'Heavy text component',
+        subText: '(Google Pixel emulator - dark mode)',
       },
     ],
   },

--- a/docs/src/pages/AndroidTextSpansPage/AndroidTextSpansPage.js
+++ b/docs/src/pages/AndroidTextSpansPage/AndroidTextSpansPage.js
@@ -20,6 +20,7 @@ import React from 'react';
 
 import readme from '../../../../backpack-android/docs/TextSpans/README.md';
 import screenshotDefault from '../../../../backpack-android/docs/TextSpans/screenshots/default.png';
+import screenshotDefaultDm from '../../../../backpack-android/docs/TextSpans/screenshots/default_dm.png';
 import DocsPageBuilder from '../../components/DocsPageBuilder';
 
 const components = [
@@ -34,6 +35,14 @@ const components = [
         src: `/${screenshotDefault}`,
         altText: 'Android Text Spans Component',
         subText: '(Google Pixel emulator)',
+      },
+      {
+        title: 'Android',
+        width: 1080,
+        height: 1920,
+        src: `/${screenshotDefaultDm}`,
+        altText: 'Android Text Spans Component',
+        subText: '(Google Pixel emulator - dark mode)',
       },
     ],
   },

--- a/docs/src/pages/AndroidToastPage/AndroidToastPage.js
+++ b/docs/src/pages/AndroidToastPage/AndroidToastPage.js
@@ -20,6 +20,7 @@ import React from 'react';
 
 import readme from '../../../../backpack-android/docs/Toast/README.md';
 import screenshotDefault from '../../../../backpack-android/docs/Toast/screenshots/default.png';
+import screenshotDefaultDm from '../../../../backpack-android/docs/Toast/screenshots/default_dm.png';
 import DocsPageBuilder from '../../components/DocsPageBuilder';
 
 const components = [
@@ -34,6 +35,14 @@ const components = [
         src: `/${screenshotDefault}`,
         altText: 'Android Toast Component',
         subText: '(Google Pixel emulator)',
+      },
+      {
+        title: 'Android',
+        width: 1080,
+        height: 1920,
+        src: `/${screenshotDefaultDm}`,
+        altText: 'Android Toast Component',
+        subText: '(Google Pixel emulator - dark mode)',
       },
     ],
   },


### PR DESCRIPTION
This PR adds the screenshots for Android Dark mode introduced here: https://github.com/Skyscanner/backpack-android/pull/400

This PR cannot be merged until the above PR is merged and the submodule for Android updated