### PR TITLE
Updating greenkeeper badges

### DIFF
--- a/docs/src/pages/StatusPage/content/androidStatus.md
+++ b/docs/src/pages/StatusPage/content/androidStatus.md
@@ -1,5 +1,5 @@
 [![CI Status](https://img.shields.io/travis/Skyscanner/backpack-android.svg?style=flat)](https://travis-ci.org/Skyscanner/backpack-android)
-[![Greenkeeper badge](https://badges.greenkeeper.io/Skyscanner/backpack-android.svg)](https://greenkeeper.io/)
+[![Snyk](https://snyk.io/test/github/skyscanner/backpack-android/badge.svg)](https://snyk.io/test/github/skyscanner/backpack-android)
 [![Release](https://jitpack.io/v/skyscanner/backpack-android.svg)](https://jitpack.io/#skyscanner/backpack-android)
 [![Platform](https://img.shields.io/badge/platform-android-green.svg)](https://jitpack.io/#skyscanner/backpack-android)
 [![License](https://img.shields.io/github/license/Skyscanner/backpack-android.svg)](https://github.com/Skyscanner/backpack-android/blob/master/LICENSE.txt)

--- a/docs/src/pages/StatusPage/content/backpackNodeSassStatus.md
+++ b/docs/src/pages/StatusPage/content/backpackNodeSassStatus.md
@@ -1,5 +1,5 @@
 [![Build Status](https://travis-ci.org/Skyscanner/backpack-node-sass.svg?branch=master)](https://travis-ci.org/Skyscanner/backpack-node-sass)
-[![Greenkeeper badge](https://badges.greenkeeper.io/Skyscanner/backpack-node-sass.svg)](https://greenkeeper.io/)
+[![Snyk](https://snyk.io/test/github/skyscanner/backpack-node-sass/badge.svg)](https://snyk.io/test/github/skyscanner/backpack-node-sass)
 [![License](https://img.shields.io/github/license/Skyscanner/backpack-node-sass.svg)](https://github.com/Skyscanner/backpack-node-sass/blob/master/LICENSE.txt)
 
 [Changelog](https://github.com/Skyscanner/backpack-node-sass/blob/master/CHANGELOG.md)

--- a/docs/src/pages/StatusPage/content/eslintConfigSkyscannerStatus.md
+++ b/docs/src/pages/StatusPage/content/eslintConfigSkyscannerStatus.md
@@ -1,5 +1,5 @@
 [![Build Status](https://travis-ci.org/Skyscanner/eslint-config-skyscanner.svg?branch=master)](https://travis-ci.org/Skyscanner/eslint-config-skyscanner)
-[![Greenkeeper badge](https://badges.greenkeeper.io/Skyscanner/eslint-config-skyscanner.svg)](https://greenkeeper.io/)
+[![Snyk](https://snyk.io/test/github/skyscanner/eslint-config-skyscanner/badge.svg)](https://snyk.io/test/github/skyscanner/eslint-config-skyscanner)
 [![License](https://img.shields.io/github/license/Skyscanner/eslint-config-skyscanner.svg)](https://github.com/Skyscanner/eslint-config-skyscanner/blob/master/LICENSE.txt)
 
 [Changelog](https://github.com/Skyscanner/eslint-config-skyscanner/blob/master/CHANGELOG.md)

--- a/docs/src/pages/StatusPage/content/eslintPluginBackpackStatus.md
+++ b/docs/src/pages/StatusPage/content/eslintPluginBackpackStatus.md
@@ -1,5 +1,5 @@
 [![Build Status](https://travis-ci.org/Skyscanner/eslint-plugin-backpack.svg?branch=master)](https://travis-ci.org/Skyscanner/eslint-plugin-backpack)
-[![Greenkeeper badge](https://badges.greenkeeper.io/Skyscanner/eslint-plugin-backpack.svg)](https://greenkeeper.io/)
+[![Snyk](https://snyk.io/test/github/skyscanner/eslint-plugin-backpack/badge.svg)](https://snyk.io/test/github/skyscanner/eslint-plugin-backpack)
 [![License](https://img.shields.io/github/license/Skyscanner/eslint-plugin-backpack.svg)](https://github.com/Skyscanner/eslint-plugin-backpack/blob/master/LICENSE.txt)
 
 [Changelog](https://github.com/Skyscanner/eslint-plugin-backpack/blob/master/CHANGELOG.md)

--- a/docs/src/pages/StatusPage/content/iosStatus.md
+++ b/docs/src/pages/StatusPage/content/iosStatus.md
@@ -1,5 +1,5 @@
 [![Build Status](https://travis-ci.org/Skyscanner/backpack-ios.svg?branch=master)](https://travis-ci.org/Skyscanner/backpack-ios)
-[![Greenkeeper badge](https://badges.greenkeeper.io/Skyscanner/backpack-ios.svg)](https://greenkeeper.io/)
+[![Snyk](https://snyk.io/test/github/skyscanner/backpack-ios/badge.svg)](https://snyk.io/test/github/skyscanner/backpack-ios)
 [![Version](https://img.shields.io/cocoapods/v/Backpack.svg?style=flat)](https://cocoapods.org/pods/Backpack)
 [![Platform](https://img.shields.io/cocoapods/p/Backpack.svg?style=flat)](https://cocoapods.org/pods/Backpack)
 [![License](https://img.shields.io/github/license/Skyscanner/backpack-ios.svg)](https://github.com/Skyscanner/backpack-ios/blob/master/LICENSE.txt)

--- a/docs/src/pages/StatusPage/content/nativeStatus.md
+++ b/docs/src/pages/StatusPage/content/nativeStatus.md
@@ -1,5 +1,5 @@
 [![Build Status](https://travis-ci.org/Skyscanner/backpack-react-native.svg?branch=master)](https://travis-ci.org/Skyscanner/backpack-react-native)
-[![Greenkeeper badge](https://badges.greenkeeper.io/Skyscanner/backpack-react-native.svg)](https://greenkeeper.io/)
+[![Snyk](https://snyk.io/test/github/skyscanner/backpack-react-native/badge.svg)](https://snyk.io/test/github/skyscanner/backpack-react-native)
 [![Platform](https://img.shields.io/badge/platform-native-blue.svg)](https://github.com/Skyscanner/backpack-react-native)
 [![License](https://img.shields.io/github/license/Skyscanner/backpack-react-native.svg)](https://github.com/Skyscanner/backpack-react-native/blob/master/LICENSE.txt)
 

--- a/docs/src/pages/StatusPage/content/webStatus.md
+++ b/docs/src/pages/StatusPage/content/webStatus.md
@@ -1,5 +1,5 @@
 [![Build Status](https://travis-ci.org/Skyscanner/backpack.svg?branch=master)](https://travis-ci.org/Skyscanner/backpack)
-[![Greenkeeper badge](https://badges.greenkeeper.io/Skyscanner/backpack.svg)](https://greenkeeper.io/)
+[![Snyk](https://snyk.io/test/github/skyscanner/backpack/badge.svg)](https://snyk.io/test/github/skyscanner/backpack)
 [![Platform](https://img.shields.io/badge/platform-web-blue.svg)](https://github.com/Skyscanner/backpack)
 [![License](https://img.shields.io/github/license/Skyscanner/backpack.svg)](https://github.com/Skyscanner/backpack/blob/master/LICENSE.txt)
 


### PR DESCRIPTION
Now that we have moved from using Greenkeeper as our dependency manager, this PR removes the Greenkeeper badges and replaces them with Snyk badges for reporting the status