### PR TITLE
[NO-JIRA] Fix sassdoc search link

### DIFF
--- a/docs/src/layouts/links.js
+++ b/docs/src/layouts/links.js
@@ -563,7 +563,7 @@ export default [
     id: 'MISC',
     category: 'Miscellaneous',
     links: [
-      { id: 'SASSDOC', route: '/sassdoc', children: 'SassDoc' },
+      { id: 'SASSDOC', route: '/sassdoc', children: 'SassDoc', blank: true },
       {
         id: 'GITHUB',
         route: externalRoutes.GITHUB,


### PR DESCRIPTION
Currently clicking `SassDoc` from search tries to navigate to that page within the docs web app, which results in a blank page. It should instead be navigating to `backpack.github.io/sassdoc` and loading the page in its entirety.

The easiest way to achieve this is to treat it as a link to an external site (which it kinda is anyway).

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack/blob/master/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] [Links platform metadata](https://github.com/Skyscanner/backpack-docs/blob/master/docs/src/layouts/links.js)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
