### PR TITLE
[BPK-3734]: Add design tab for icons

### DIFF
--- a/docs/src/components/DocsPageWrapper/DocsPageWrapper.js
+++ b/docs/src/components/DocsPageWrapper/DocsPageWrapper.js
@@ -37,14 +37,16 @@ import STYLES from './DocsPageWrapper.scss';
 const getClassName = cssModules(STYLES);
 
 const contentShape = PropTypes.oneOfType([PropTypes.string, PropTypes.node]);
-const platformQueryParamRegex = /platform=(android|ios|native|web)/;
+const platformQueryParamRegex = /platform=(design|android|ios|native|web)/;
 
 const PlatformNav = ({
   platform,
+  onDesignClick,
   onNativeClick,
   onWebClick,
   onAndroidClick,
   onIOSClick,
+  disableDesignTab,
   disableNativeTab,
   disableWebTab,
   disableAndroidTab,
@@ -54,6 +56,14 @@ const PlatformNav = ({
     autoScrollToSelected
     className={getClassName('bpkdocs-page-wrapper__platform-switcher')}
   >
+    <BpkHorizontalNavItem
+      name="design"
+      disabled={disableDesignTab}
+      selected={platform === 'design'}
+      onClick={onDesignClick}
+    >
+      Design
+    </BpkHorizontalNavItem>
     <BpkHorizontalNavItem
       name="android"
       disabled={disableAndroidTab}
@@ -90,11 +100,14 @@ const PlatformNav = ({
 );
 
 PlatformNav.propTypes = {
-  platform: PropTypes.oneOf(['android', 'ios', 'native', 'web']).isRequired,
+  platform: PropTypes.oneOf(['design', 'android', 'ios', 'native', 'web'])
+    .isRequired,
+  onDesignClick: PropTypes.func.isRequired,
   onAndroidClick: PropTypes.func.isRequired,
   onIOSClick: PropTypes.func.isRequired,
   onNativeClick: PropTypes.func.isRequired,
   onWebClick: PropTypes.func.isRequired,
+  disableDesignTab: PropTypes.bool.isRequired,
   disableAndroidTab: PropTypes.bool.isRequired,
   disableIOSTab: PropTypes.bool.isRequired,
   disableNativeTab: PropTypes.bool.isRequired,
@@ -104,6 +117,7 @@ PlatformNav.propTypes = {
 const DocsPageWrapper = props => {
   const {
     blurb,
+    designSubpage,
     androidSubpage,
     iosSubpage,
     nativeSubpage,
@@ -116,6 +130,7 @@ const DocsPageWrapper = props => {
   const path = match.url;
 
   const platforms = {
+    design: designSubpage,
     android: androidSubpage,
     ios: iosSubpage,
     native: nativeSubpage,
@@ -129,7 +144,7 @@ const DocsPageWrapper = props => {
     return !!platforms[platformPreference];
   };
 
-  let initiallySelectedPlatform = 'web';
+  let initiallySelectedPlatform = 'design';
   const platformFromLocalStorage = getPlatformFromLocalStorage();
   if (canUsePlatformPreference(platformFromLocalStorage)) {
     initiallySelectedPlatform = platformFromLocalStorage;
@@ -139,6 +154,8 @@ const DocsPageWrapper = props => {
     initiallySelectedPlatform = 'ios';
   } else if (nativeSubpage) {
     initiallySelectedPlatform = 'native';
+  } else if (webSubpage) {
+    initiallySelectedPlatform = 'web';
   }
 
   const platformQueryParamMatches = platformQueryParamRegex.exec(
@@ -168,10 +185,12 @@ const DocsPageWrapper = props => {
       <div>
         <PlatformNav
           platform={initiallySelectedPlatform}
+          onDesignClick={() => onPlatformClick('design')}
           onAndroidClick={() => onPlatformClick('android')}
           onIOSClick={() => onPlatformClick('ios')}
           onNativeClick={() => onPlatformClick('native')}
           onWebClick={() => onPlatformClick('web')}
+          disableDesignTab={!designSubpage}
           disableAndroidTab={!androidSubpage}
           disableIOSTab={!iosSubpage}
           disableNativeTab={!nativeSubpage}
@@ -197,6 +216,7 @@ DocsPageWrapper.propTypes = {
     search: PropTypes.string.isRequired,
   }).isRequired,
   blurb: contentShape,
+  designSubpage: PropTypes.element,
   webSubpage: PropTypes.element,
   nativeSubpage: PropTypes.element,
   androidSubpage: PropTypes.element,
@@ -205,6 +225,7 @@ DocsPageWrapper.propTypes = {
 
 DocsPageWrapper.defaultProps = {
   blurb: null,
+  designSubpage: null,
   webSubpage: null,
   nativeSubpage: null,
   androidSubpage: null,

--- a/docs/src/pages/IconPage/IconPage.js
+++ b/docs/src/pages/IconPage/IconPage.js
@@ -22,6 +22,7 @@ import React from 'react';
 
 import DocsPageWrapper from '../../components/DocsPageWrapper';
 import IntroBlurb from '../../components/IntroBlurb';
+import IconsDesignPage from '../IconsDesignPage';
 import Android from '../AndroidIconPage';
 import IOS from '../IOSIconPage';
 import Web from '../WebIconsPage';
@@ -35,6 +36,7 @@ const Page = () => (
         A suite of icons for representing concepts, features and actions.
       </IntroBlurb>,
     ]}
+    designSubpage={<IconsDesignPage wrapped />}
     androidSubpage={<Android wrapped />}
     iosSubpage={<IOS wrapped />}
     webSubpage={<Web wrapped />}

--- a/docs/src/pages/IconsDesignPage/IconDesignPage.js
+++ b/docs/src/pages/IconsDesignPage/IconDesignPage.js
@@ -1,0 +1,79 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2016-2019 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import _ from 'lodash';
+import React from 'react';
+import BpkButton from 'bpk-component-button';
+import { withButtonAlignment } from 'bpk-component-icon';
+import BpkSmallDownloadIcon from 'bpk-component-icon/sm/download';
+import icons from 'bpk-component-icon/all';
+
+import IconSearchApp from '../../components/IconSearchApp';
+import DocsPageBuilder from '../../components/DocsPageBuilder';
+import Heading from '../../components/Heading';
+import Paragraph from '../../components/Paragraph';
+import IntroBlurb from '../../components/IntroBlurb';
+
+// This file can actually be resolved eslint is just confused
+// eslint-disable-next-line import/no-webpack-loader-syntax, import/extensions, import/no-unresolved
+import iconsSvgs from '!!file-loader?name=[name].[hash].zip!zip-it-loader!./../../../../backpack/packages/bpk-svgs/src/icons/icons';
+
+const AlignedBpkSmallDownloadIcon = withButtonAlignment(BpkSmallDownloadIcon);
+
+const friendlyNameMap = {
+  sm: 'Small',
+  lg: 'Large',
+};
+
+const getFriendlyName = id => friendlyNameMap[id] || id;
+
+const iconsFinal = _(icons)
+  .flatMap((category, categoryId) =>
+    Object.keys(category).map(name => ({
+      name,
+      categoryId,
+      categoryName: getFriendlyName(categoryId),
+      component: category[name],
+    })),
+  )
+  .value();
+
+const blurb = [
+  <IntroBlurb>
+    Skyscanner&apos;s icons are designed to be simple, modern, friendly, and
+    sometimes quirky. Each icon is reduced to its minimal form, expressing
+    essential characteristics.
+  </IntroBlurb>,
+  <Heading level="h2">Find the right icon</Heading>,
+  <Paragraph>
+    Icons are provided in two sizes: small (18px) and large (24px). Both are
+    pixel-snapped for clarity at the intended usage sizes.
+  </Paragraph>,
+  <IconSearchApp icons={iconsFinal} />,
+  <Paragraph>
+    <BpkButton href={`/${iconsSvgs}`}>
+      Download SVG files <AlignedBpkSmallDownloadIcon />
+    </BpkButton>
+  </Paragraph>,
+];
+
+const IconsDesignPage = ({ ...rest }) => (
+  <DocsPageBuilder title="Icons" blurb={blurb} {...rest} />
+);
+
+export default IconsDesignPage;

--- a/docs/src/pages/IconsDesignPage/index.js
+++ b/docs/src/pages/IconsDesignPage/index.js
@@ -1,0 +1,23 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2016-2019 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* @flow strict */
+
+import page from './IconDesignPage';
+
+export default page;

--- a/docs/src/pages/WebIconsPage/IconsPage.js
+++ b/docs/src/pages/WebIconsPage/IconsPage.js
@@ -16,76 +16,33 @@
  * limitations under the License.
  */
 
-import _ from 'lodash';
 import React from 'react';
 import BpkLink from 'bpk-component-link';
-import BpkButton from 'bpk-component-button';
-import { withButtonAlignment } from 'bpk-component-icon';
-import BpkSmallDownloadIcon from 'bpk-component-icon/sm/download';
-import icons from 'bpk-component-icon/all';
 import iconReadme from 'bpk-component-icon/README.md';
 
 import * as ROUTES from '../../constants/routes';
-import IconSearchApp from '../../components/IconSearchApp';
 import DocsPageBuilder from '../../components/DocsPageBuilder';
-import Heading from '../../components/Heading';
 import Paragraph from '../../components/Paragraph';
-import IntroBlurb from '../../components/IntroBlurb';
 import Code from '../../components/Code';
 
-// This file can actually be resolved eslint is just confused
-// eslint-disable-next-line import/no-webpack-loader-syntax, import/extensions
-import iconsSvgs from '!!file-loader?name=[name].[hash].zip!zip-it-loader!./../../../../backpack/packages/bpk-svgs/src/icons/icons';
-
-const AlignedBpkSmallDownloadIcon = withButtonAlignment(BpkSmallDownloadIcon);
-
-const friendlyNameMap = {
-  sm: 'Small',
-  lg: 'Large',
-};
-
-const getFriendlyName = id => friendlyNameMap[id] || id;
-
-const iconsFinal = _(icons)
-  .flatMap((category, categoryId) =>
-    Object.keys(category).map(name => ({
-      name,
-      categoryId,
-      categoryName: getFriendlyName(categoryId),
-      component: category[name],
-    })),
-  )
-  .value();
-
-const blurb = [
-  <IntroBlurb>
-    Icons are provided in two sizes: small (18px) and large (24px). Both are
-    pixel-snapped for clarity at the intended usage sizes.
-  </IntroBlurb>,
-  <Paragraph>
-    <BpkButton href={`/${iconsSvgs}`}>
-      Download SVG files <AlignedBpkSmallDownloadIcon />
-    </BpkButton>
-  </Paragraph>,
-  <Paragraph>
-    The <BpkLink href="#readme">readme</BpkLink> for the component is available
-    below the search tool.
-  </Paragraph>,
-  <Heading level="h2">Find the right icon</Heading>,
-  <IconSearchApp icons={iconsFinal} />,
-  <Heading level="h2">Aligning icons within components</Heading>,
-  <Paragraph>
-    The <BpkLink href={ROUTES.ALIGNMENT}>Alignment</BpkLink> page gives examples
-    of icon alignment using HOCs provided in the <Code>bpk-component-icon</Code>{' '}
-    package.
-  </Paragraph>,
+const components = [
+  {
+    id: 'Alignment',
+    title: 'Aligning icons within components',
+    blurb: [
+      <Paragraph>
+        The <BpkLink href={ROUTES.ALIGNMENT}>Alignment</BpkLink> page gives
+        examples of icon alignment using HOCs provided in the{' '}
+        <Code>bpk-component-icon</Code> package.
+      </Paragraph>,
+    ],
+  },
 ];
 
 const IconsPage = ({ ...rest }) => (
   <DocsPageBuilder
     title="Icons"
-    blurb={blurb}
-    components={[]}
+    components={components}
     readme={iconReadme}
     sassdocId="svgs-mixin-bpk-icon"
     {...rest}


### PR DESCRIPTION
## **Background**
The purpose of this PR is to add the ability for a design tab for the icons page to hold the list of icons that consumers can use.

## **Changes:**

- DocsPageWrapper.js - now includes a platform query `design` this will **future proof** us should we want to add design tabs for components or other pages in the future. By default the page will try to select the `design` tab first but if not available will navigate the correct page for the component
- Added `IconsDesignPage` that now holds the icon list and search functionality fields
- Removed icon list and search field from `WebIconsPage` as this is no longer required here.

## **Screenshot:**
![IconsPage](https://user-images.githubusercontent.com/8831547/76419637-97bac500-6398-11ea-95ad-1f7f5bc4cb46.png)
