### PR TITLE
Adding dependabot config to exclude bpk updates

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,12 @@
+version: 1
+update_configs:
+  - package_manager: "javascript"
+    directory: "/"
+    update_schedule: "daily"
+    ignored_updates:
+      # As dependabot doesn't currently support custom npm tags we exlude all bpk updates
+      # so that they don't bump non css versions
+      - match:
+          dependency_name: "bpk*"
+    default_labels:
+      - "dependabot"


### PR DESCRIPTION
This PR adds the dependabot config as per the documentation here: https://dependabot.com/docs/config-file/

So that it doesn't go crazy and update all our bpk dependencies to the non CSS versions as it doesn't look like its currently supported feature - this config ignores all these updates using the `*` operator.