### PR TITLE
[BPKR-141] Add dark mode colours to docs

### DIFF
--- a/docs/src/pages/ColorsPage/ColorsPage.js
+++ b/docs/src/pages/ColorsPage/ColorsPage.js
@@ -33,6 +33,7 @@ import * as ROUTES from '../../constants/routes';
 import STYLES from './colors-page.scss';
 import intro from './content/intro.md';
 import colors from './colors';
+import darkModeColors from './darkModeColors';
 import dynamicColors from './dynamicColors';
 import ColorChart from './ColorChart';
 
@@ -51,8 +52,22 @@ const sections = [
     content: colors,
   },
   {
+    id: 'dark-mode-palette',
+    title: 'Dark Mode palette',
+    content: (
+      <Fragment>
+        <BpkParagraph>
+          The Dark Mode palette extends our regular palette. The colours in this
+          palette should <strong>never ever</strong> be used in light mode.
+        </BpkParagraph>
+        {darkModeColors}
+      </Fragment>
+    ),
+  },
+  {
     id: 'dynamic-palette',
     title: 'Dark Mode dynamic colours',
+    backgroundStyle: 'light',
     content: (
       <Fragment>
         <BpkParagraph>
@@ -67,7 +82,6 @@ const sections = [
   {
     id: 'pairings',
     title: 'Colour pairings',
-    backgroundStyle: 'light',
     content: (
       <Fragment>
         <BpkParagraph>
@@ -86,6 +100,7 @@ const sections = [
   {
     id: 'examples',
     title: 'Examples',
+    backgroundStyle: 'light',
     content: (
       <BpkImage
         className={getClassName('bpk-docs-colors-page__image')}

--- a/docs/src/pages/ColorsPage/darkModeColors.js
+++ b/docs/src/pages/ColorsPage/darkModeColors.js
@@ -1,0 +1,104 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2016-2019 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { colors } from 'bpk-tokens/tokens/base.es6';
+import { cssModules } from 'bpk-react-utils';
+
+import ColorSwatch from '../../components/ColorSwatch';
+
+import STYLES from './colors-page.scss';
+
+const getClassName = cssModules(STYLES);
+
+const darkModeColors = [
+  <div className={getClassName('bpk-docs-colors-page')}>
+    <ColorSwatch
+      name="Black"
+      color="black"
+      textColor={colors.colorWhite}
+      colorValues={{
+        RGB: '0, 0, 0',
+        HEX: '#000000',
+        CMYK: '000, 000, 000, 100',
+      }}
+    />
+    <ColorSwatch
+      name="Black Tint 01"
+      color="#1D1B20"
+      textColor={colors.colorWhite}
+      colorValues={{
+        RGB: '29, 27, 32',
+        HEX: '#1D1B20',
+        CMYK: '009, 016, 000, 087',
+      }}
+    />
+    <ColorSwatch
+      name="Black Tint 02"
+      color="#2C2C2E"
+      textColor={colors.colorWhite}
+      colorValues={{
+        RGB: '44, 44, 46',
+        HEX: '#2C2C2E',
+        CMYK: '004, 004, 000, 082',
+      }}
+    />
+    <ColorSwatch
+      name="Black Tint 03"
+      color="#3A3A3C"
+      textColor={colors.colorWhite}
+      colorValues={{
+        RGB: '58, 58, 60',
+        HEX: '#3A3A3C',
+        CMYK: '003, 003, 000, 076',
+      }}
+    />
+    <ColorSwatch
+      name="Black Tint 04"
+      color="#48484A"
+      textColor={colors.colorWhite}
+      colorValues={{
+        RGB: '72, 72, 74',
+        HEX: '#48484A',
+        CMYK: '003, 003, 000, 071',
+      }}
+    />
+    <ColorSwatch
+      name="Black Tint 05"
+      color="#636366"
+      textColor={colors.colorWhite}
+      colorValues={{
+        RGB: '99, 99, 102',
+        HEX: '#636366',
+        CMYK: '003, 003, 000, 060',
+      }}
+    />
+    <ColorSwatch
+      name="Black Tint 06"
+      color="#8E8E93"
+      textColor={colors.colorWhite}
+      colorValues={{
+        RGB: '142, 142, 147',
+        HEX: '#8E8E93',
+        CMYK: '003, 003, 000, 042',
+      }}
+    />
+  </div>,
+];
+
+export default darkModeColors;


### PR DESCRIPTION

![Screenshot 2020-04-08 at 09 27 21](https://user-images.githubusercontent.com/30267516/78761993-409a1700-797b-11ea-9b95-6750d4acf020.png)

![image](https://user-images.githubusercontent.com/30267516/78762002-4263da80-797b-11ea-820b-b1e545b52244.png)

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack/blob/master/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] [Links platform metadata](https://github.com/Skyscanner/backpack-docs/blob/master/docs/src/layouts/links.js)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
