### PR TITLE
[BPK-3839] Add chip icons screenshots to iOS page

### DIFF
--- a/docs/src/pages/IOSChipPage/IOSChipPage.js
+++ b/docs/src/pages/IOSChipPage/IOSChipPage.js
@@ -20,9 +20,11 @@ import React from 'react';
 
 import readme from '../../../../backpack-ios/Backpack/Chip/README.md';
 import screenshotDefault from '../../../../backpack-ios/screenshots/iPhone 8-chip___default_lm.png';
+import screenshotWithIcons from '../../../../backpack-ios/screenshots/iPhone 8-chip___with-icons_lm.png';
 import screenshotWithoutShadow from '../../../../backpack-ios/screenshots/iPhone 8-chip___without-shadow_lm.png';
 import screenshotWithBackgroundColor from '../../../../backpack-ios/screenshots/iPhone 8-chip___background-color_lm.png';
 import screenshotDefaultDm from '../../../../backpack-ios/screenshots/iPhone 8-chip___default_dm.png';
+import screenshotWithIconsDm from '../../../../backpack-ios/screenshots/iPhone 8-chip___with-icons_dm.png';
 import screenshotWithoutShadowDm from '../../../../backpack-ios/screenshots/iPhone 8-chip___without-shadow_dm.png';
 import screenshotWithBackgroundColorDm from '../../../../backpack-ios/screenshots/iPhone 8-chip___background-color_dm.png';
 import DocsPageBuilder from '../../components/DocsPageBuilder';
@@ -43,6 +45,26 @@ const components = [
         width: 750,
         height: 1334,
         src: `/${screenshotDefaultDm}`,
+        altText: 'Chips for iOS.',
+        subText: '(iPhone 8 simulator - dark mode)',
+      },
+    ],
+  },
+  {
+    id: 'withIcons',
+    title: 'With icons',
+    screenshots: [
+      {
+        width: 750,
+        height: 1334,
+        src: `/${screenshotWithIcons}`,
+        altText: 'Chips for iOS.',
+        subText: '(iPhone 8 simulator)',
+      },
+      {
+        width: 750,
+        height: 1334,
+        src: `/${screenshotWithIconsDm}`,
         altText: 'Chips for iOS.',
         subText: '(iPhone 8 simulator - dark mode)',
       },


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/30267516/79248767-2dec7a00-7e74-11ea-821a-7ec9adca50e8.png)

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack/blob/master/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] [Links platform metadata](https://github.com/Skyscanner/backpack-docs/blob/master/docs/src/layouts/links.js)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
