### PR TITLE
[BPK-4141] Migrate Android pages to use AndroidComponentPage

### DIFF
--- a/docs/src/components/ComponentPage/AndroidComponentPage.js
+++ b/docs/src/components/ComponentPage/AndroidComponentPage.js
@@ -29,10 +29,11 @@ import ComponentScreenshots from '../DocsPageBuilder/ComponentScreenshots';
 import ComponentPage from './ComponentPage';
 
 type Props = {
-  documentationId: string,
+  documentationId: ?string,
   readme: string,
   screenshots: [
     {
+      blurb: ?string,
       id: string,
       screenshots: [
         {
@@ -55,36 +56,43 @@ type Props = {
 
 const AndroidComponentPage = (props: Props) => {
   const { documentationId, screenshots, readme, usageTable } = props;
-  const screenshotsAsExamples = screenshots.map(screenshot => ({
-    id: screenshot.id,
-    title: screenshot.title,
-    content: <ComponentScreenshots screenshots={screenshot.screenshots} />,
+  const screenshotsAsExamples = screenshots.map(screenshotSet => ({
+    id: screenshotSet.id,
+    title: screenshotSet.title,
+    content: (
+      <>
+        {screenshotSet.blurb && <p>{screenshotSet.blurb}</p>}
+        <ComponentScreenshots screenshots={screenshotSet.screenshots} />
+      </>
+    ),
   }));
+  const additionalContent = [
+    {
+      id: 'readme',
+      title: 'Implementation',
+      content: (
+        <BpkContentContainer bareHtml alternate>
+          <BpkMarkdownRenderer source={getMarkdownString(readme)} />
+        </BpkContentContainer>
+      ),
+    },
+  ];
+  if (documentationId) {
+    additionalContent.push({
+      id: 'docs',
+      title: 'Class reference',
+      content: (
+        <BpkLink href={`/android/versions/latest/${documentationId}`} blank>
+          View on Backpack&apos;s Android documentation
+        </BpkLink>
+      ),
+    });
+  }
   return (
     <ComponentPage
       usageTable={usageTable}
       examples={screenshotsAsExamples}
-      readme={readme}
-      additionalContent={[
-        {
-          id: 'readme',
-          title: 'Implementation',
-          content: (
-            <BpkContentContainer bareHtml alternate>
-              <BpkMarkdownRenderer source={getMarkdownString(readme)} />
-            </BpkContentContainer>
-          ),
-        },
-        {
-          id: 'docs',
-          title: 'Class reference',
-          content: (
-            <BpkLink href={`/android/versions/latest/${documentationId}`} blank>
-              View on Backpack&apos;s Android documentation
-            </BpkLink>
-          ),
-        },
-      ]}
+      additionalContent={additionalContent}
     />
   );
 };

--- a/docs/src/components/ComponentPage/IOSComponentPage.js
+++ b/docs/src/components/ComponentPage/IOSComponentPage.js
@@ -33,6 +33,7 @@ type Props = {
   readme: string,
   screenshots: [
     {
+      blurb: ?string,
       id: string,
       screenshots: [
         {
@@ -55,10 +56,15 @@ type Props = {
 
 const IOSComponentPage = (props: Props) => {
   const { documentationId, screenshots, readme, usageTable } = props;
-  const screenshotsAsExamples = screenshots.map(screenshot => ({
-    id: screenshot.id,
-    title: screenshot.title,
-    content: <ComponentScreenshots screenshots={screenshot.screenshots} />,
+  const screenshotsAsExamples = screenshots.map(screenshotSet => ({
+    id: screenshotSet.id,
+    title: screenshotSet.title,
+    content: (
+      <>
+        {screenshotSet.blurb && <p>{screenshotSet.blurb}</p>}
+        <ComponentScreenshots screenshots={screenshotSet.screenshots} />
+      </>
+    ),
   }));
   return (
     <ComponentPage

--- a/docs/src/components/ComponentPage/NativeComponentPage.js
+++ b/docs/src/components/ComponentPage/NativeComponentPage.js
@@ -31,6 +31,7 @@ type Props = {
   readme: string,
   screenshots: [
     {
+      blurb: ?string,
       id: string,
       screenshots: [
         {
@@ -53,10 +54,15 @@ type Props = {
 
 const NativeComponentPage = (props: Props) => {
   const { screenshots, readme, usageTable } = props;
-  const screenshotsAsExamples = screenshots.map(screenshot => ({
-    id: screenshot.id,
-    title: screenshot.title,
-    content: <ComponentScreenshots screenshots={screenshot.screenshots} />,
+  const screenshotsAsExamples = screenshots.map(screenshotSet => ({
+    id: screenshotSet.id,
+    title: screenshotSet.title,
+    content: (
+      <>
+        {screenshotSet.blurb && <p>{screenshotSet.blurb}</p>}
+        <ComponentScreenshots screenshots={screenshotSet.screenshots} />
+      </>
+    ),
   }));
   return (
     <ComponentPage

--- a/docs/src/components/ComponentPage/WebComponentPage.js
+++ b/docs/src/components/ComponentPage/WebComponentPage.js
@@ -36,7 +36,7 @@ type Props = {
     blurb: Node,
     examples: Node,
   }>,
-  readme: string,
+  readme: ?string,
   sassdocId: ?string,
   usageTable: ?{
     dos: Array<string>,
@@ -62,8 +62,9 @@ const WebComponentPage = (props: Props) => {
     };
   });
 
-  const additionalContent = [
-    {
+  const additionalContent = [];
+  if (readme) {
+    additionalContent.push({
       id: 'readme',
       title: 'Implementation',
       content: (
@@ -71,8 +72,8 @@ const WebComponentPage = (props: Props) => {
           <BpkMarkdownRenderer source={getMarkdownString(readme)} />
         </BpkContentContainer>
       ),
-    },
-  ];
+    });
+  }
   if (sassdocId) {
     additionalContent.push({
       id: 'docs',
@@ -90,7 +91,9 @@ const WebComponentPage = (props: Props) => {
       usageTable={usageTable}
       examples={mappedExamples}
       readme={readme}
-      additionalContent={additionalContent}
+      additionalContent={
+        additionalContent.length === 0 ? null : additionalContent
+      }
     />
   );
 };

--- a/docs/src/pages/AccordionsPage/AccordionsPage.js
+++ b/docs/src/pages/AccordionsPage/AccordionsPage.js
@@ -16,6 +16,8 @@
  * limitations under the License.
  */
 
+/* @flow strict */
+
 import React from 'react';
 import BpkCheckbox from 'bpk-component-checkbox';
 import { withAlignment } from 'bpk-component-icon';
@@ -35,7 +37,7 @@ import {
   spacingSm,
 } from 'bpk-tokens/tokens/base.es6';
 
-import DocsPageBuilder from '../../components/DocsPageBuilder';
+import { WebComponentPage } from '../../components/ComponentPage';
 import DocsPageWrapper from '../../components/DocsPageWrapper';
 import Paragraph from '../../components/Paragraph';
 import IntroBlurb from '../../components/IntroBlurb';
@@ -249,20 +251,15 @@ const blurb = [
   </IntroBlurb>,
 ];
 
-const AccordionsSubPage = ({ ...rest }) => (
-  <DocsPageBuilder
-    title="Accordion"
-    components={components}
-    readme={accordionsReadme}
-    {...rest}
-  />
+const AccordionsSubPage = () => (
+  <WebComponentPage examples={components} readme={accordionsReadme} />
 );
 
 const AccordionsPage = () => (
   <DocsPageWrapper
     title="Accordion"
     blurb={blurb}
-    webSubpage={<AccordionsSubPage wrapped />}
+    webSubpage={<AccordionsSubPage />}
   />
 );
 

--- a/docs/src/pages/AlertPage/AlertPage.js
+++ b/docs/src/pages/AlertPage/AlertPage.js
@@ -16,6 +16,8 @@
  * limitations under the License.
  */
 
+/* @flow strict */
+
 import React from 'react';
 import { BpkCode } from 'bpk-component-code';
 
@@ -27,7 +29,7 @@ import androidScreenshotDefault from '../../../../backpack-react-native/lib/bpk-
 import androidCancelable from '../../../../backpack-react-native/lib/bpk-component-alert/screenshots/android/cancelable.png';
 import androidThreeButton from '../../../../backpack-react-native/lib/bpk-component-alert/screenshots/android/three-button.png';
 import IntroBlurb from '../../components/IntroBlurb';
-import DocsPageBuilder from '../../components/DocsPageBuilder';
+import { NativeComponentPage } from '../../components/ComponentPage';
 import DocsPageWrapper from '../../components/DocsPageWrapper';
 import Paragraph from '../../components/Paragraph';
 
@@ -115,12 +117,7 @@ const components = [
 ];
 
 const AlertSubPage = () => (
-  <DocsPageBuilder
-    title="Alert"
-    components={components}
-    readme={readme}
-    wrapped
-  />
+  <NativeComponentPage screenshots={components} readme={readme} />
 );
 
 const AlertPage = () => (

--- a/docs/src/pages/AlignmentPage/AlignmentPage.js
+++ b/docs/src/pages/AlignmentPage/AlignmentPage.js
@@ -16,6 +16,8 @@
  * limitations under the License.
  */
 
+/* @flow strict */
+
 import React from 'react';
 import {
   colors,
@@ -37,7 +39,7 @@ import LongArrowRightIcon from 'bpk-component-icon/lg/long-arrow-right';
 import LongArrowRightIconSm from 'bpk-component-icon/sm/long-arrow-right';
 import AwardIcon from 'bpk-component-icon/lg/award';
 
-import DocsPageBuilder from '../../components/DocsPageBuilder';
+import { WebComponentPage } from '../../components/ComponentPage';
 import DocsPageWrapper from '../../components/DocsPageWrapper';
 import Heading from '../../components/Heading';
 import Paragraph from '../../components/Paragraph';
@@ -277,15 +279,13 @@ const blurb = [
   </Paragraph>,
 ];
 
-const AlignmentSubPage = ({ ...rest }) => (
-  <DocsPageBuilder title="Alignment" components={components} {...rest} />
-);
+const AlignmentSubPage = () => <WebComponentPage examples={components} />;
 
 const AlignmentPage = () => (
   <DocsPageWrapper
     title="Alignment"
     blurb={blurb}
-    webSubpage={<AlignmentSubPage wrapped />}
+    webSubpage={<AlignmentSubPage />}
   />
 );
 

--- a/docs/src/pages/AndroidBarChartPage/AndroidBarChartPage.js
+++ b/docs/src/pages/AndroidBarChartPage/AndroidBarChartPage.js
@@ -16,12 +16,14 @@
  * limitations under the License.
  */
 
+/* @flow strict */
+
 import React from 'react';
 
 import readme from '../../../../backpack-android/docs/BarChart/README.md';
 import screenshotDefault from '../../../../backpack-android/docs/BarChart/screenshots/default.png';
 import screenshotDefaultDm from '../../../../backpack-android/docs/BarChart/screenshots/default_dm.png';
-import DocsPageBuilder from '../../components/DocsPageBuilder';
+import { AndroidComponentPage } from '../../components/ComponentPage';
 
 const components = [
   {
@@ -48,13 +50,11 @@ const components = [
   },
 ];
 
-const AndroidBarChartPage = ({ ...rest }) => (
-  <DocsPageBuilder
-    title="BarChart"
-    androidDocId="net.skyscanner.backpack.barchart"
-    components={components}
+const AndroidBarChartPage = () => (
+  <AndroidComponentPage
+    documentationId="net.skyscanner.backpack.barchart"
+    screenshots={components}
     readme={readme}
-    {...rest}
   />
 );
 

--- a/docs/src/pages/AndroidBottomNavPage/AndroidBottomNavPage.js
+++ b/docs/src/pages/AndroidBottomNavPage/AndroidBottomNavPage.js
@@ -16,12 +16,14 @@
  * limitations under the License.
  */
 
+/* @flow strict */
+
 import React from 'react';
 
 import readme from '../../../../backpack-android/docs/BottomNav/README.md';
 import screenshotDefault from '../../../../backpack-android/docs/BottomNav/screenshots/default.png';
 import screenshotDefaultDm from '../../../../backpack-android/docs/BottomNav/screenshots/default_dm.png';
-import DocsPageBuilder from '../../components/DocsPageBuilder';
+import { AndroidComponentPage } from '../../components/ComponentPage';
 
 const components = [
   {
@@ -48,13 +50,11 @@ const components = [
   },
 ];
 
-const AndroidBottomNavPage = ({ ...rest }) => (
-  <DocsPageBuilder
-    title="Bottom Nav"
-    components={components}
+const AndroidBottomNavPage = () => (
+  <AndroidComponentPage
+    screenshots={components}
     readme={readme}
-    androidDocId="net.skyscanner.backpack.bottomnav"
-    {...rest}
+    documentationId="net.skyscanner.backpack.bottomnav"
   />
 );
 

--- a/docs/src/pages/AndroidButtonPage/AndroidButtonPage.js
+++ b/docs/src/pages/AndroidButtonPage/AndroidButtonPage.js
@@ -32,7 +32,7 @@ import screenshotFeatured from '../../../../backpack-android/docs/Button/screens
 import screenshotFeaturedDm from '../../../../backpack-android/docs/Button/screenshots/featured_dm.png';
 import screenshotLink from '../../../../backpack-android/docs/ButtonLink/screenshots/default.png';
 import screenshotLinkDm from '../../../../backpack-android/docs/ButtonLink/screenshots/default_dm.png';
-import DocsPageBuilder from '../../components/DocsPageBuilder';
+import { AndroidComponentPage } from '../../components/ComponentPage';
 
 const components = [
   {
@@ -135,9 +135,6 @@ const components = [
       },
     ],
   },
-];
-
-const customSections = [
   {
     id: 'link',
     title: 'Link',
@@ -159,19 +156,14 @@ const customSections = [
         subText: '(Google Pixel emulator - dark mode)',
       },
     ],
-    readme: linkReadme,
   },
 ];
 
-const AndroidButtonPage = ({ ...rest }) => (
-  <DocsPageBuilder
-    title="Button"
-    components={components}
-    readme={readme}
-    customSections={customSections}
+const AndroidButtonPage = () => (
+  <AndroidComponentPage
+    screenshots={components}
+    readme={readme + linkReadme}
     androidDocId="net.skyscanner.backpack.button"
-    showMenu
-    {...rest}
   />
 );
 

--- a/docs/src/pages/AndroidCalendarPage/AndroidCalendarPage.js
+++ b/docs/src/pages/AndroidCalendarPage/AndroidCalendarPage.js
@@ -16,6 +16,8 @@
  * limitations under the License.
  */
 
+/* @flow strict */
+
 import React from 'react';
 
 import readme from '../../../../backpack-android/docs/Calendar/README.md';
@@ -23,7 +25,7 @@ import screenshotAll from '../../../../backpack-android/docs/Calendar/screenshot
 import screenshotAllDm from '../../../../backpack-android/docs/Calendar/screenshots/range_dm.png';
 import screenshotColored from '../../../../backpack-android/docs/Calendar/screenshots/colored.png';
 import screenshotColoredDm from '../../../../backpack-android/docs/Calendar/screenshots/colored_dm.png';
-import DocsPageBuilder from '../../components/DocsPageBuilder';
+import { AndroidComponentPage } from '../../components/ComponentPage';
 
 const components = [
   {
@@ -68,14 +70,11 @@ const components = [
   },
 ];
 
-const AndroidCalendarPage = ({ ...rest }) => (
-  <DocsPageBuilder
-    title="Calendar"
-    components={components}
+const AndroidCalendarPage = () => (
+  <AndroidComponentPage
+    screenshots={components}
     readme={readme}
-    androidDocId="net.skyscanner.backpack.calendar"
-    showMenu
-    {...rest}
+    documentationId="net.skyscanner.backpack.calendar"
   />
 );
 

--- a/docs/src/pages/AndroidCardPage/AndroidCardPage.js
+++ b/docs/src/pages/AndroidCardPage/AndroidCardPage.js
@@ -16,6 +16,8 @@
  * limitations under the License.
  */
 
+/* @flow strict */
+
 import React from 'react';
 
 import readme from '../../../../backpack-android/docs/Card/README.md';
@@ -35,7 +37,7 @@ import screenshotWithDividerCornerStyleLarge from '../../../../backpack-android/
 import screenshotWithDividerCornerStyleLargeDm from '../../../../backpack-android/docs/Card/screenshots/with-divider-and-corner-style-large_dm.png';
 import screenshotWithDividerWithoutPadding from '../../../../backpack-android/docs/Card/screenshots/with-divider-without-padding.png';
 import screenshotWithDividerWithoutPaddingDm from '../../../../backpack-android/docs/Card/screenshots/with-divider-without-padding_dm.png';
-import DocsPageBuilder from '../../components/DocsPageBuilder';
+import { AndroidComponentPage } from '../../components/ComponentPage';
 
 const components = [
   {
@@ -200,14 +202,11 @@ const components = [
   },
 ];
 
-const AndroidCardPage = ({ ...rest }) => (
-  <DocsPageBuilder
-    title="Card"
-    components={components}
+const AndroidCardPage = () => (
+  <AndroidComponentPage
+    screenshots={components}
     readme={readme}
-    androidDocId="net.skyscanner.backpack.card"
-    showMenu
-    {...rest}
+    documentationId="net.skyscanner.backpack.card"
   />
 );
 

--- a/docs/src/pages/AndroidCheckboxPage/AndroidCheckboxPage.js
+++ b/docs/src/pages/AndroidCheckboxPage/AndroidCheckboxPage.js
@@ -16,12 +16,14 @@
  * limitations under the License.
  */
 
+/* @flow strict */
+
 import React from 'react';
 
 import readme from '../../../../backpack-android/docs/Checkbox/README.md';
 import screenshotDefault from '../../../../backpack-android/docs/Checkbox/screenshots/default.png';
 import screenshotDefaultDm from '../../../../backpack-android/docs/Checkbox/screenshots/default_dm.png';
-import DocsPageBuilder from '../../components/DocsPageBuilder';
+import { AndroidComponentPage } from '../../components/ComponentPage';
 
 const components = [
   {
@@ -48,12 +50,11 @@ const components = [
   },
 ];
 
-const AndroidCheckboxPage = ({ ...rest }) => (
-  <DocsPageBuilder
-    title="Checkbox"
-    components={components}
+const AndroidCheckboxPage = () => (
+  <AndroidComponentPage
+    screenshots={components}
     readme={readme}
-    {...rest}
+    documentationId="net.skyscanner.backpack.checkbox"
   />
 );
 

--- a/docs/src/pages/AndroidChipPage/AndroidChipPage.js
+++ b/docs/src/pages/AndroidChipPage/AndroidChipPage.js
@@ -16,6 +16,8 @@
  * limitations under the License.
  */
 
+/* @flow strict */
+
 import React from 'react';
 
 import readme from '../../../../backpack-android/docs/Chip/README.md';
@@ -25,7 +27,7 @@ import screenshotOutline from '../../../../backpack-android/docs/Chip/screenshot
 import screenshotOutlineDm from '../../../../backpack-android/docs/Chip/screenshots/outline_dm.png';
 import screenshotIcon from '../../../../backpack-android/docs/Chip/screenshots/with-icon.png';
 import screenshotIconDm from '../../../../backpack-android/docs/Chip/screenshots/with-icon_dm.png';
-import DocsPageBuilder from '../../components/DocsPageBuilder';
+import { AndroidComponentPage } from '../../components/ComponentPage';
 
 const components = [
   {
@@ -90,14 +92,11 @@ const components = [
   },
 ];
 
-const AndroidChipPage = ({ ...rest }) => (
-  <DocsPageBuilder
-    title="Chip"
-    components={components}
+const AndroidChipPage = () => (
+  <AndroidComponentPage
+    screenshots={components}
     readme={readme}
-    androidDocId="net.skyscanner.backpack.chip"
-    showMenu
-    {...rest}
+    documentationId="net.skyscanner.backpack.chip"
   />
 );
 

--- a/docs/src/pages/AndroidDialogPage/AndroidDialogPage.js
+++ b/docs/src/pages/AndroidDialogPage/AndroidDialogPage.js
@@ -16,6 +16,8 @@
  * limitations under the License.
  */
 
+/* @flow strict */
+
 import React from 'react';
 
 import readme from '../../../../backpack-android/docs/Dialog/README.md';
@@ -23,7 +25,7 @@ import screenshotAlert from '../../../../backpack-android/docs/Dialog/screenshot
 import screenshotAlertDm from '../../../../backpack-android/docs/Dialog/screenshots/with-cta_dm.png';
 import screenshotBottomSheet from '../../../../backpack-android/docs/Dialog/screenshots/delete-confirmation.png';
 import screenshotBottomSheetDm from '../../../../backpack-android/docs/Dialog/screenshots/delete-confirmation_dm.png';
-import DocsPageBuilder from '../../components/DocsPageBuilder';
+import { AndroidComponentPage } from '../../components/ComponentPage';
 
 const components = [
   {
@@ -76,14 +78,11 @@ const components = [
   },
 ];
 
-const AndroidDialogPage = ({ ...rest }) => (
-  <DocsPageBuilder
-    title="Dialog"
-    components={components}
+const AndroidDialogPage = () => (
+  <AndroidComponentPage
+    screenshots={components}
     readme={readme}
-    androidDocId="net.skyscanner.backpack.dialog"
-    showMenu
-    {...rest}
+    documentationId="net.skyscanner.backpack.dialog"
   />
 );
 

--- a/docs/src/pages/AndroidFlarePage/AndroidFlarePage.js
+++ b/docs/src/pages/AndroidFlarePage/AndroidFlarePage.js
@@ -16,6 +16,8 @@
  * limitations under the License.
  */
 
+/* @flow strict */
+
 import React from 'react';
 
 import readme from '../../../../backpack-android/docs/Flare/README.md';
@@ -29,7 +31,7 @@ import screenshotInsetPadding from '../../../../backpack-android/docs/Flare/scre
 import screenshotInsetPaddingDm from '../../../../backpack-android/docs/Flare/screenshots/inset-padding_dm.png';
 import screenshotPointingUp from '../../../../backpack-android/docs/Flare/screenshots/pointing-up.png';
 import screenshotPointingUpDm from '../../../../backpack-android/docs/Flare/screenshots/pointing-up_dm.png';
-import DocsPageBuilder from '../../components/DocsPageBuilder';
+import { AndroidComponentPage } from '../../components/ComponentPage';
 
 const components = [
   {
@@ -134,14 +136,11 @@ const components = [
   },
 ];
 
-const AndroidFlarePage = ({ ...rest }) => (
-  <DocsPageBuilder
-    title="Toggle"
-    components={components}
+const AndroidFlarePage = () => (
+  <AndroidComponentPage
+    screenshots={components}
     readme={readme}
-    androidDocId="net.skyscanner.backpack.flare"
-    showMenu
-    {...rest}
+    documentationId="net.skyscanner.backpack.flare"
   />
 );
 

--- a/docs/src/pages/AndroidFloatingActionButtonPage/AndroidFloatingActionButtonPage.js
+++ b/docs/src/pages/AndroidFloatingActionButtonPage/AndroidFloatingActionButtonPage.js
@@ -16,12 +16,14 @@
  * limitations under the License.
  */
 
+/* @flow strict */
+
 import React from 'react';
 
 import readme from '../../../../backpack-android/docs/FloatingActionButton/README.md';
 import screenshotDefault from '../../../../backpack-android/docs/FloatingActionButton/screenshots/default.png';
 import screenshotDefaultDm from '../../../../backpack-android/docs/FloatingActionButton/screenshots/default_dm.png';
-import DocsPageBuilder from '../../components/DocsPageBuilder';
+import { AndroidComponentPage } from '../../components/ComponentPage';
 
 const components = [
   {
@@ -48,13 +50,8 @@ const components = [
   },
 ];
 
-const AndroidFloatingActionButtonPage = ({ ...rest }) => (
-  <DocsPageBuilder
-    title="Floating action buttons"
-    components={components}
-    readme={readme}
-    {...rest}
-  />
+const AndroidFloatingActionButtonPage = () => (
+  <AndroidComponentPage screenshots={components} readme={readme} />
 );
 
 export default AndroidFloatingActionButtonPage;

--- a/docs/src/pages/AndroidHorizontalNavPage/AndroidHorizontalNavPage.js
+++ b/docs/src/pages/AndroidHorizontalNavPage/AndroidHorizontalNavPage.js
@@ -16,12 +16,14 @@
  * limitations under the License.
  */
 
+/* @flow strict */
+
 import React from 'react';
 
 import readme from '../../../../backpack-android/docs/HorizontalNav/README.md';
 import screenshotDefault from '../../../../backpack-android/docs/HorizontalNav/screenshots/default.png';
 import screenshotDefaultDm from '../../../../backpack-android/docs/HorizontalNav/screenshots/default_dm.png';
-import DocsPageBuilder from '../../components/DocsPageBuilder';
+import { AndroidComponentPage } from '../../components/ComponentPage';
 
 const components = [
   {
@@ -48,12 +50,13 @@ const components = [
   },
 ];
 
-const AndroidHorizontalNavPage = ({ ...rest }) => (
-  <DocsPageBuilder
-    title="HorizontalNav"
-    components={components}
+const AndroidHorizontalNavPage = () => (
+  <AndroidComponentPage
+    screenshots={components}
     readme={readme}
-    {...rest}
+    // This is deliberately misspelled because the package name
+    // was published with a typo. :seenoevil:
+    documentationId="net.skyscanner.backpack.horisontalnav"
   />
 );
 

--- a/docs/src/pages/AndroidIconPage/AndroidIconPage.js
+++ b/docs/src/pages/AndroidIconPage/AndroidIconPage.js
@@ -21,7 +21,7 @@ import React from 'react';
 import readme from '../../../../backpack-android/docs/Icon/README.md';
 import screenshotAll from '../../../../backpack-android/docs/Icon/screenshots/all.png';
 import screenshotAllDm from '../../../../backpack-android/docs/Icon/screenshots/all_dm.png';
-import DocsPageBuilder from '../../components/DocsPageBuilder';
+import { AndroidComponentPage } from '../../components/ComponentPage';
 
 const components = [
   {
@@ -46,14 +46,8 @@ const components = [
   },
 ];
 
-const AndroidIconPage = ({ ...rest }) => (
-  <DocsPageBuilder
-    title="Icon"
-    components={components}
-    readme={readme}
-    showMenu
-    {...rest}
-  />
+const AndroidIconPage = () => (
+  <AndroidComponentPage screenshots={components} readme={readme} />
 );
 
 export default AndroidIconPage;

--- a/docs/src/pages/AndroidNavBarPage/AndroidNavBarPage.js
+++ b/docs/src/pages/AndroidNavBarPage/AndroidNavBarPage.js
@@ -16,6 +16,8 @@
  * limitations under the License.
  */
 
+/* @flow strict */
+
 import React from 'react';
 
 import readme from '../../../../backpack-android/docs/NavBar/README.md';
@@ -25,7 +27,7 @@ import screenshotExpanded from '../../../../backpack-android/docs/NavBar/screens
 import screenshotExpandedDm from '../../../../backpack-android/docs/NavBar/screenshots/expanded_dm.png';
 import screenshotNavigation from '../../../../backpack-android/docs/NavBar/screenshots/navigation.png';
 import screenshotNavigationDm from '../../../../backpack-android/docs/NavBar/screenshots/navigation_dm.png';
-import DocsPageBuilder from '../../components/DocsPageBuilder';
+import { AndroidComponentPage } from '../../components/ComponentPage';
 
 const components = [
   {
@@ -90,14 +92,11 @@ const components = [
   },
 ];
 
-const AndroidNavBarPage = ({ ...rest }) => (
-  <DocsPageBuilder
-    title="Navigation Bar"
-    components={components}
+const AndroidNavBarPage = () => (
+  <AndroidComponentPage
+    screenshots={components}
     readme={readme}
-    androidDocId="net.skyscanner.backpack.navbar"
-    showMenu
-    {...rest}
+    documentationId="net.skyscanner.backpack.navbar"
   />
 );
 

--- a/docs/src/pages/AndroidPanelPage/AndroidPanelPage.js
+++ b/docs/src/pages/AndroidPanelPage/AndroidPanelPage.js
@@ -16,12 +16,14 @@
  * limitations under the License.
  */
 
+/* @flow strict */
+
 import React from 'react';
 
 import readme from '../../../../backpack-android/docs/Panel/README.md';
 import screenshotDefault from '../../../../backpack-android/docs/Panel/screenshots/all.png';
 import screenshotDefaultDm from '../../../../backpack-android/docs/Panel/screenshots/all_dm.png';
-import DocsPageBuilder from '../../components/DocsPageBuilder';
+import { AndroidComponentPage } from '../../components/ComponentPage';
 
 const components = [
   {
@@ -46,14 +48,11 @@ const components = [
   },
 ];
 
-const AndroidSpinnerPage = ({ ...rest }) => (
-  <DocsPageBuilder
-    title="Panel"
-    components={components}
+const AndroidSpinnerPage = () => (
+  <AndroidComponentPage
+    screenshots={components}
     readme={readme}
-    androidDocId="net.skyscanner.backpack.panel"
-    showMenu
-    {...rest}
+    documentationId="net.skyscanner.backpack.panel"
   />
 );
 

--- a/docs/src/pages/AndroidRatingPage/AndroidRatingPage.js
+++ b/docs/src/pages/AndroidRatingPage/AndroidRatingPage.js
@@ -16,6 +16,8 @@
  * limitations under the License.
  */
 
+/* @flow strict */
+
 import React from 'react';
 
 import readme from '../../../../backpack-android/docs/Rating/README.md';
@@ -25,7 +27,7 @@ import screenshotSizes from '../../../../backpack-android/docs/Rating/screenshot
 import screenshotSizesDm from '../../../../backpack-android/docs/Rating/screenshots/sizes_dm.png';
 import screenshotVertical from '../../../../backpack-android/docs/Rating/screenshots/vertical.png';
 import screenshotVerticalDm from '../../../../backpack-android/docs/Rating/screenshots/vertical_dm.png';
-import DocsPageBuilder from '../../components/DocsPageBuilder';
+import { AndroidComponentPage } from '../../components/ComponentPage';
 
 const components = [
   {
@@ -96,13 +98,11 @@ const components = [
   },
 ];
 
-const AndroidRatingPage = ({ ...rest }) => (
-  <DocsPageBuilder
-    title="Rating"
-    components={components}
+const AndroidRatingPage = () => (
+  <AndroidComponentPage
+    screenshots={components}
     readme={readme}
-    androidDocId="net.skyscanner.backpack.rating"
-    {...rest}
+    documentationId="net.skyscanner.backpack.rating"
   />
 );
 

--- a/docs/src/pages/AndroidSnackbarPage/AndroidSnackbarPage.js
+++ b/docs/src/pages/AndroidSnackbarPage/AndroidSnackbarPage.js
@@ -16,12 +16,14 @@
  * limitations under the License.
  */
 
+/* @flow strict */
+
 import React from 'react';
 
 import readme from '../../../../backpack-android/docs/Snackbar/README.md';
 import screenshotDefault from '../../../../backpack-android/docs/Snackbar/screenshots/default.png';
 import screenshotDefaultDm from '../../../../backpack-android/docs/Snackbar/screenshots/default_dm.png';
-import DocsPageBuilder from '../../components/DocsPageBuilder';
+import { AndroidComponentPage } from '../../components/ComponentPage';
 
 const components = [
   {
@@ -48,13 +50,11 @@ const components = [
   },
 ];
 
-const AndroidSnackbarPage = ({ ...rest }) => (
-  <DocsPageBuilder
-    title="Snackbar"
-    androidDocId="net.skyscanner.backpack.snackbar"
-    components={components}
+const AndroidSnackbarPage = () => (
+  <AndroidComponentPage
+    documentationId="net.skyscanner.backpack.snackbar"
+    screenshots={components}
     readme={readme}
-    {...rest}
   />
 );
 

--- a/docs/src/pages/AndroidSpinnerPage/AndroidSpinnerPage.js
+++ b/docs/src/pages/AndroidSpinnerPage/AndroidSpinnerPage.js
@@ -16,6 +16,8 @@
  * limitations under the License.
  */
 
+/* @flow strict */
+
 import React from 'react';
 
 import readme from '../../../../backpack-android/docs/Spinner/README.md';
@@ -23,7 +25,7 @@ import screenshotDefault from '../../../../backpack-android/docs/Spinner/screens
 import screenshotDefaultDm from '../../../../backpack-android/docs/Spinner/screenshots/default_dm.png';
 import screenshotSmall from '../../../../backpack-android/docs/Spinner/screenshots/small.png';
 import screenshotSmallDm from '../../../../backpack-android/docs/Spinner/screenshots/small_dm.png';
-import DocsPageBuilder from '../../components/DocsPageBuilder';
+import { AndroidComponentPage } from '../../components/ComponentPage';
 
 const components = [
   {
@@ -68,14 +70,11 @@ const components = [
   },
 ];
 
-const AndroidSpinnerPage = ({ ...rest }) => (
-  <DocsPageBuilder
-    title="Spinner"
-    components={components}
+const AndroidSpinnerPage = () => (
+  <AndroidComponentPage
+    screenshots={components}
     readme={readme}
-    androidDocId="net.skyscanner.backpack.spinner"
-    showMenu
-    {...rest}
+    documentationId="net.skyscanner.backpack.spinner"
   />
 );
 

--- a/docs/src/pages/AndroidStarRatingPage/AndroidStarRatingPage.js
+++ b/docs/src/pages/AndroidStarRatingPage/AndroidStarRatingPage.js
@@ -16,6 +16,8 @@
  * limitations under the License.
  */
 
+/* @flow strict */
+
 import React from 'react';
 
 import starRatingReadme from '../../../../backpack-android/docs/StarRating/README.md';
@@ -24,7 +26,7 @@ import screenshotStarRating from '../../../../backpack-android/docs/StarRating/s
 import screenshotStarRatingDm from '../../../../backpack-android/docs/StarRating/screenshots/default_dm.png';
 import screenshotInteractive from '../../../../backpack-android/docs/InteractiveStarRating/screenshots/default.png';
 import screenshotInteractiveDm from '../../../../backpack-android/docs/InteractiveStarRating/screenshots/default_dm.png';
-import DocsPageBuilder from '../../components/DocsPageBuilder';
+import { AndroidComponentPage } from '../../components/ComponentPage';
 import Paragraph from '../../components/Paragraph';
 
 const components = [
@@ -51,7 +53,6 @@ const components = [
         subText: '(Google Pixel emulator - dark mode)',
       },
     ],
-    readme: starRatingReadme,
   },
   {
     id: 'interactive',
@@ -80,12 +81,15 @@ const components = [
         subText: '(Google Pixel emulator - dark mode)',
       },
     ],
-    readme: starRatingInteractiveReadme,
   },
 ];
 
-const AndroidStarRatingPage = ({ ...rest }) => (
-  <DocsPageBuilder title="Star rating" components={components} {...rest} />
+const AndroidStarRatingPage = () => (
+  <AndroidComponentPage
+    screenshots={components}
+    readme={starRatingReadme + starRatingInteractiveReadme}
+    documentationId="net.skyscanner.backpack.starrating"
+  />
 );
 
 export default AndroidStarRatingPage;

--- a/docs/src/pages/AndroidSwitchPage/AndroidSwitchPage.js
+++ b/docs/src/pages/AndroidSwitchPage/AndroidSwitchPage.js
@@ -16,12 +16,14 @@
  * limitations under the License.
  */
 
+/* @flow strict */
+
 import React from 'react';
 
 import readme from '../../../../backpack-android/docs/Switch/README.md';
 import screenshotDefault from '../../../../backpack-android/docs/Switch/screenshots/default.png';
 import screenshotDefaultDm from '../../../../backpack-android/docs/Switch/screenshots/default_dm.png';
-import DocsPageBuilder from '../../components/DocsPageBuilder';
+import { AndroidComponentPage } from '../../components/ComponentPage';
 
 const components = [
   {
@@ -46,14 +48,11 @@ const components = [
   },
 ];
 
-const AndroidSwitchPage = ({ ...rest }) => (
-  <DocsPageBuilder
-    title="Toggle"
-    components={components}
+const AndroidSwitchPage = () => (
+  <AndroidComponentPage
+    screenshots={components}
     readme={readme}
-    androidDocId="net.skyscanner.backpack.toggle"
-    showMenu
-    {...rest}
+    documentationId="net.skyscanner.backpack.toggle"
   />
 );
 

--- a/docs/src/pages/AndroidTextFieldPage/AndroidTextFieldPage.js
+++ b/docs/src/pages/AndroidTextFieldPage/AndroidTextFieldPage.js
@@ -16,12 +16,14 @@
  * limitations under the License.
  */
 
+/* @flow strict */
+
 import React from 'react';
 
 import readme from '../../../../backpack-android/docs/TextField/README.md';
 import screenshotDefault from '../../../../backpack-android/docs/TextField/screenshots/default.png';
 import screenshotDefaultDm from '../../../../backpack-android/docs/TextField/screenshots/default_dm.png';
-import DocsPageBuilder from '../../components/DocsPageBuilder';
+import { AndroidComponentPage } from '../../components/ComponentPage';
 
 const components = [
   {
@@ -48,12 +50,11 @@ const components = [
   },
 ];
 
-const AndroidTextFieldPage = ({ ...rest }) => (
-  <DocsPageBuilder
-    title="Text Field"
-    components={components}
+const AndroidTextFieldPage = () => (
+  <AndroidComponentPage
+    screenshots={components}
     readme={readme}
-    {...rest}
+    documentationId="net.skyscanner.backpack.text/-bpk-text-field"
   />
 );
 

--- a/docs/src/pages/AndroidTextPage/AndroidTextPage.js
+++ b/docs/src/pages/AndroidTextPage/AndroidTextPage.js
@@ -16,6 +16,8 @@
  * limitations under the License.
  */
 
+/* @flow strict */
+
 import React from 'react';
 
 import readme from '../../../../backpack-android/docs/Text/README.md';
@@ -28,7 +30,7 @@ import screenshotHeavy from '../../../../backpack-android/docs/Text/screenshots/
 import screenshotHeavyDm from '../../../../backpack-android/docs/Text/screenshots/heavy_dm.png';
 import screenshotTextSpan from '../../../../backpack-android/docs/TextSpans/screenshots/default.png';
 import screenshotTextSpanDm from '../../../../backpack-android/docs/TextSpans/screenshots/default_dm.png';
-import DocsPageBuilder from '../../components/DocsPageBuilder';
+import { AndroidComponentPage } from '../../components/ComponentPage';
 import IntroBlurb from '../../components/IntroBlurb';
 
 const components = [
@@ -92,9 +94,6 @@ const components = [
       },
     ],
   },
-];
-
-const customSections = [
   {
     id: 'text-span',
     title: 'Text Span',
@@ -121,19 +120,15 @@ const customSections = [
         subText: '(Google Pixel emulator - dark mode)',
       },
     ],
-    readme: textSpanReadme,
   },
 ];
 
-const AndroidTextPage = ({ ...rest }) => (
-  <DocsPageBuilder
+const AndroidTextPage = () => (
+  <AndroidComponentPage
     title="Text"
-    components={components}
-    customSections={customSections}
-    readme={readme}
-    androidDocId="net.skyscanner.backpack.text"
-    showMenu
-    {...rest}
+    screenshots={components}
+    readme={readme + textSpanReadme}
+    documentationId="net.skyscanner.backpack.text"
   />
 );
 

--- a/docs/src/pages/AndroidThemingPage/AndroidThemingPage.js
+++ b/docs/src/pages/AndroidThemingPage/AndroidThemingPage.js
@@ -16,22 +16,21 @@
  * limitations under the License.
  */
 
+/* @flow strict */
+
 import React from 'react';
 
 import readme from '../../../../backpack-android/docs/THEMING.md';
-import DocsPageBuilder from '../../components/DocsPageBuilder';
+import { AndroidComponentPage } from '../../components/ComponentPage';
 
 const components = [];
 
-const AndroidTextPage = ({ ...rest }) => (
-  <DocsPageBuilder
-    title="Theming"
-    components={components}
+const AndroidThemingPage = () => (
+  <AndroidComponentPage
+    screenshots={components}
     readme={readme}
-    androidDocId="net.skyscanner.backpack.theming"
-    showMenu
-    {...rest}
+    documentationId="net.skyscanner.backpack.theming"
   />
 );
 
-export default AndroidTextPage;
+export default AndroidThemingPage;


### PR DESCRIPTION
Also migrated web accordion and alignment pages. Basically all pages beginning in `A`.