### PR TITLE
[BPK-4141] Finish moving components to new page builder

### DIFF
--- a/docs/src/components/ComponentPage/WebComponentPage.js
+++ b/docs/src/components/ComponentPage/WebComponentPage.js
@@ -34,7 +34,7 @@ type Props = {
     dark?: boolean,
     title: string,
     blurb: Node,
-    examples: Node,
+    examples: ?Node,
   }>,
   readme: ?string,
   sassdocId: ?string,
@@ -51,14 +51,14 @@ const WebComponentPage = (props: Props) => {
       id: example.id,
       title: example.title,
       blurb: example.blurb,
-      content: (
+      content: example.examples ? (
         <PresentationBlock
           whiteBackground={!example.dark}
           darkBackground={example.dark}
         >
           {example.examples}
         </PresentationBlock>
-      ),
+      ) : null,
     };
   });
 

--- a/docs/src/pages/NavigationStackPage/NavigationStackPage.js
+++ b/docs/src/pages/NavigationStackPage/NavigationStackPage.js
@@ -22,7 +22,7 @@ import React from 'react';
 import navigationStackReadme from 'bpk-component-navigation-stack/README.md';
 import { cssModules } from 'bpk-react-utils';
 
-import DocsPageBuilder from '../../components/DocsPageBuilder';
+import { WebComponentPage } from '../../components/ComponentPage';
 import DocsPageWrapper from '../../components/DocsPageWrapper';
 import Paragraph from '../../components/Paragraph';
 import IntroBlurb from '../../components/IntroBlurb';
@@ -73,20 +73,15 @@ const blurb = [
   </IntroBlurb>,
 ];
 
-const NavigationStackSubPage = ({ ...rest }: { [string]: any }) => (
-  <DocsPageBuilder
-    title="Navigation stack"
-    components={components}
-    readme={navigationStackReadme}
-    {...rest}
-  />
+const NavigationStackSubPage = () => (
+  <WebComponentPage examples={components} readme={navigationStackReadme} />
 );
 
 const NavigationStackPage = () => (
   <DocsPageWrapper
     title="Navigation stack"
     blurb={blurb}
-    webSubpage={<NavigationStackSubPage wrapped />}
+    webSubpage={<NavigationStackSubPage />}
   />
 );
 

--- a/docs/src/pages/PaginationPage/PaginationPage.js
+++ b/docs/src/pages/PaginationPage/PaginationPage.js
@@ -21,7 +21,7 @@ import React, { Component } from 'react';
 import BpkPagination from 'bpk-component-pagination';
 import paginationReadme from 'bpk-component-pagination/README.md';
 
-import DocsPageBuilder from '../../components/DocsPageBuilder';
+import { WebComponentPage } from '../../components/ComponentPage';
 import DocsPageWrapper from '../../components/DocsPageWrapper';
 import Paragraph from '../../components/Paragraph';
 import IntroBlurb from '../../components/IntroBlurb';
@@ -108,20 +108,15 @@ const blurb = [
   </IntroBlurb>,
 ];
 
-const PaginationSubPage = ({ ...rest }) => (
-  <DocsPageBuilder
-    title="Pagination"
-    components={components}
-    readme={paginationReadme}
-    {...rest}
-  />
+const PaginationSubPage = () => (
+  <WebComponentPage examples={components} readme={paginationReadme} />
 );
 
 const PaginationPage = () => (
   <DocsPageWrapper
     title="Pagination"
     blurb={blurb}
-    webSubpage={<PaginationSubPage wrapped />}
+    webSubpage={<PaginationSubPage />}
   />
 );
 

--- a/docs/src/pages/PhoneInputPage/PhoneInputPage.js
+++ b/docs/src/pages/PhoneInputPage/PhoneInputPage.js
@@ -24,7 +24,7 @@ import readme from 'bpk-component-phone-input/README.md';
 import BpkImage from 'bpk-component-image';
 
 import DocsPageWrapper from '../../components/DocsPageWrapper';
-import DocsPageBuilder from '../../components/DocsPageBuilder';
+import { WebComponentPage } from '../../components/ComponentPage';
 import IntroBlurb from '../../components/IntroBlurb';
 import NativePhoneInput from '../NativePhoneInputPage';
 
@@ -117,13 +117,7 @@ const components = [
 ];
 
 const WebSubPage = () => (
-  <DocsPageBuilder
-    title="Phone input"
-    components={components}
-    readme={readme}
-    showMenu={false}
-    wrapped
-  />
+  <WebComponentPage examples={components} readme={readme} />
 );
 
 const BadgePage = () => (

--- a/docs/src/pages/PopoversPage/PopoversPage.js
+++ b/docs/src/pages/PopoversPage/PopoversPage.js
@@ -24,7 +24,7 @@ import BpkRouterLink from 'bpk-component-router-link';
 import popoverReadme from 'bpk-component-popover/README.md';
 
 import * as ROUTES from '../../constants/routes';
-import DocsPageBuilder from '../../components/DocsPageBuilder';
+import { WebComponentPage } from '../../components/ComponentPage';
 import DocsPageWrapper from '../../components/DocsPageWrapper';
 import Paragraph from '../../components/Paragraph';
 import IntroBlurb from '../../components/IntroBlurb';
@@ -147,10 +147,9 @@ const blurb = [
   </IntroBlurb>,
 ];
 
-const PopoversSubPage = ({ ...rest }) => (
-  <DocsPageBuilder
-    title="Popovers"
-    components={components}
+const PopoversSubPage = () => (
+  <WebComponentPage
+    examples={components}
     readme={popoverReadme}
     usageTable={{
       dos: [
@@ -167,7 +166,6 @@ const PopoversSubPage = ({ ...rest }) => (
         "Don't use when you want content to be accessed on hover.",
       ],
     }}
-    {...rest}
   />
 );
 
@@ -175,7 +173,7 @@ const PopoversPage = () => (
   <DocsPageWrapper
     title="Popover"
     blurb={blurb}
-    webSubpage={<PopoversSubPage wrapped />}
+    webSubpage={<PopoversSubPage />}
   />
 );
 

--- a/docs/src/pages/SlidersPage/SlidersPage.js
+++ b/docs/src/pages/SlidersPage/SlidersPage.js
@@ -21,7 +21,7 @@ import BpkSlider from 'bpk-component-slider';
 import sliderReadme from 'bpk-component-slider/README.md';
 import { updateOnDirectionChange } from 'bpk-component-rtl-toggle';
 
-import DocsPageBuilder from '../../components/DocsPageBuilder';
+import { WebComponentPage } from '../../components/ComponentPage';
 import DocsPageWrapper from '../../components/DocsPageWrapper';
 import Paragraph from '../../components/Paragraph';
 import IntroBlurb from '../../components/IntroBlurb';
@@ -84,20 +84,15 @@ const blurb = [
   </IntroBlurb>,
 ];
 
-const SlidersSubPage = ({ ...rest }) => (
-  <DocsPageBuilder
-    title="Slider"
-    components={components}
-    readme={sliderReadme}
-    {...rest}
-  />
+const SlidersSubPage = () => (
+  <WebComponentPage examples={components} readme={sliderReadme} />
 );
 
 const SlidersPage = () => (
   <DocsPageWrapper
     title="Slider"
     blurb={blurb}
-    webSubpage={<SlidersSubPage wrapped />}
+    webSubpage={<SlidersSubPage />}
   />
 );
 

--- a/docs/src/pages/TablesPage/TablesPage.js
+++ b/docs/src/pages/TablesPage/TablesPage.js
@@ -29,7 +29,7 @@ import tablesReadme from 'bpk-component-table/README.md';
 import { BpkDataTable, BpkDataTableColumn } from 'bpk-component-datatable';
 import dataTablesReadme from 'bpk-component-datatable/README.md';
 
-import DocsPageBuilder from '../../components/DocsPageBuilder';
+import { WebComponentPage } from '../../components/ComponentPage';
 import DocsPageWrapper from '../../components/DocsPageWrapper';
 import IntroBlurb from '../../components/IntroBlurb';
 
@@ -106,7 +106,6 @@ const components = [
         </BpkTableBody>
       </BpkTable>,
     ],
-    readme: tablesReadme,
   },
   {
     id: 'datatable',
@@ -119,19 +118,21 @@ const components = [
       </IntroBlurb>
     ),
     examples: [<DataTableExample />],
-    readme: dataTablesReadme,
   },
 ];
 
-const TablesSubPage = ({ ...rest }) => (
-  <DocsPageBuilder title="Table" components={components} {...rest} />
+const TablesSubPage = () => (
+  <WebComponentPage
+    examples={components}
+    readme={tablesReadme + dataTablesReadme}
+  />
 );
 
 const TablesPage = () => (
   <DocsPageWrapper
     title="Table"
     components={components}
-    webSubpage={<TablesSubPage wrapped />}
+    webSubpage={<TablesSubPage />}
   />
 );
 

--- a/docs/src/pages/ThemingPage/ThemingPage.js
+++ b/docs/src/pages/ThemingPage/ThemingPage.js
@@ -28,7 +28,10 @@ import IntroBlurb from '../../components/IntroBlurb';
 import ColorSwatch from '../../components/ColorSwatch';
 import Android from '../AndroidThemingPage';
 import IOS from '../IOSThemingPage';
-import DocsPageBuilder from '../../components/DocsPageBuilder';
+import {
+  WebComponentPage,
+  NativeComponentPage,
+} from '../../components/ComponentPage';
 import DocsPageWrapper from '../../components/DocsPageWrapper';
 
 import STYLES from './theming-page.scss';
@@ -100,27 +103,22 @@ const webComponents = [
   },
 ];
 
-const WebThemingPage = ({ ...rest }) => (
-  <DocsPageBuilder
-    components={webComponents}
-    showMenu={false}
-    readme={webReadme}
-    {...rest}
-  />
+const WebThemingPage = () => (
+  <WebComponentPage examples={webComponents} readme={webReadme} />
 );
 
-const NativeThemingPage = ({ ...rest }) => (
-  <DocsPageBuilder showMenu={false} readme={nativeReadme} {...rest} />
+const NativeThemingPage = () => (
+  <NativeComponentPage readme={nativeReadme} screenshots={[]} />
 );
 
 const ThemingPage = () => (
   <DocsPageWrapper
     title="Theming"
     blurb={blurb}
-    webSubpage={<WebThemingPage wrapped />}
-    nativeSubpage={<NativeThemingPage wrapped />}
-    iosSubpage={<IOS wrapped />}
-    androidSubpage={<Android wrapped />}
+    webSubpage={<WebThemingPage />}
+    nativeSubpage={<NativeThemingPage />}
+    iosSubpage={<IOS />}
+    androidSubpage={<Android />}
   />
 );
 

--- a/docs/src/pages/TicketsPage/TicketsPage.js
+++ b/docs/src/pages/TicketsPage/TicketsPage.js
@@ -22,7 +22,7 @@ import BpkRouterLink from 'bpk-component-router-link';
 import ticketReadme from 'bpk-component-ticket/README.md';
 
 import * as ROUTES from '../../constants/routes';
-import DocsPageBuilder from '../../components/DocsPageBuilder';
+import { WebComponentPage } from '../../components/ComponentPage';
 import DocsPageWrapper from '../../components/DocsPageWrapper';
 import Paragraph from '../../components/Paragraph';
 import IntroBlurb from '../../components/IntroBlurb';
@@ -95,20 +95,15 @@ const blurb = [
   </IntroBlurb>,
 ];
 
-const TicketsSubPage = ({ ...rest }) => (
-  <DocsPageBuilder
-    title="Tickets"
-    components={components}
-    readme={ticketReadme}
-    {...rest}
-  />
+const TicketsSubPage = () => (
+  <WebComponentPage examples={components} readme={ticketReadme} />
 );
 
 const TicketsPage = () => (
   <DocsPageWrapper
     title="Ticket"
     blurb={blurb}
-    webSubpage={<TicketsSubPage wrapped />}
+    webSubpage={<TicketsSubPage />}
   />
 );
 

--- a/docs/src/pages/TooltipsPage/TooltipsPage.js
+++ b/docs/src/pages/TooltipsPage/TooltipsPage.js
@@ -22,7 +22,7 @@ import tooltipReadme from 'bpk-component-tooltip/README.md';
 import { spacingSm, colorMonteverde } from 'bpk-tokens/tokens/base.es6';
 import { cssModules } from 'bpk-react-utils';
 
-import DocsPageBuilder from '../../components/DocsPageBuilder';
+import { WebComponentPage } from '../../components/ComponentPage';
 import DocsPageWrapper from '../../components/DocsPageWrapper';
 import Heading from '../../components/Heading';
 import Paragraph from '../../components/Paragraph';
@@ -159,10 +159,9 @@ const blurb = [
   </Paragraph>,
 ];
 
-const TooltipsSubPage = ({ ...rest }) => (
-  <DocsPageBuilder
-    title="Tooltips"
-    components={components}
+const TooltipsSubPage = () => (
+  <WebComponentPage
+    examples={components}
     readme={tooltipReadme}
     usageTable={{
       dos: [
@@ -177,7 +176,6 @@ const TooltipsSubPage = ({ ...rest }) => (
         "Don't mix and match light and dark tooltips within the same product or interface.",
       ],
     }}
-    {...rest}
   />
 );
 
@@ -185,7 +183,7 @@ const TooltipsPage = () => (
   <DocsPageWrapper
     title="Tooltip"
     blurb={blurb}
-    webSubpage={<TooltipsSubPage wrapped />}
+    webSubpage={<TooltipsSubPage />}
   />
 );
 

--- a/docs/src/pages/WebBannerAlertsPage/BannerAlertsPage.js
+++ b/docs/src/pages/WebBannerAlertsPage/BannerAlertsPage.js
@@ -33,7 +33,7 @@ import CurrencyIcon from 'bpk-component-icon/sm/currency';
 import BpkButton from 'bpk-component-button';
 import bannerAlertReadme from 'bpk-component-banner-alert/README.md';
 
-import DocsPageBuilder from '../../components/DocsPageBuilder';
+import { WebComponentPage } from '../../components/ComponentPage';
 import Paragraph from '../../components/Paragraph';
 
 import STYLES from './bpk-banner-alerts-page.scss';
@@ -476,13 +476,11 @@ const components = [
   },
 ];
 
-const BannerAlertsPage = ({ ...rest }: { [string]: any }) => (
-  <DocsPageBuilder
-    title="Banner alerts"
-    components={components}
+const BannerAlertsPage = () => (
+  <WebComponentPage
+    examples={components}
     sassdocId="notifications"
     readme={bannerAlertReadme}
-    {...rest}
   />
 );
 

--- a/docs/src/pages/WebButtonsPage/ButtonsPage.js
+++ b/docs/src/pages/WebButtonsPage/ButtonsPage.js
@@ -38,7 +38,7 @@ import loadingButtonReadme from 'bpk-component-loading-button/README.md';
 import { cssModules } from 'bpk-react-utils';
 
 import * as ROUTES from '../../constants/routes';
-import DocsPageBuilder from '../../components/DocsPageBuilder';
+import { WebComponentPage } from '../../components/ComponentPage';
 import Paragraph from '../../components/Paragraph';
 import Code from '../../components/Code';
 
@@ -317,9 +317,6 @@ const components = [
     ],
     examples: [],
   },
-];
-
-const customSections = [
   {
     id: 'loading-buttons',
     title: 'Loading buttons',
@@ -338,17 +335,14 @@ const customSections = [
       ' ',
       <LoadingButtonContainer large />,
     ],
-    readme: loadingButtonReadme,
   },
 ];
 
-const ButtonsPage = ({ ...rest }: { [string]: any }) => (
-  <DocsPageBuilder
-    title="Buttons"
-    components={components}
+const ButtonsPage = () => (
+  <WebComponentPage
+    examples={components}
     sassdocId="buttons"
-    readme={buttonReadme}
-    customSections={customSections}
+    readme={buttonReadme + loadingButtonReadme}
     usageTable={{
       dos: [
         'Use the large and small sizes as they are provided, so that we deliver consistent, accessible buttons across the product.',
@@ -357,7 +351,6 @@ const ButtonsPage = ({ ...rest }: { [string]: any }) => (
         "Don't override font properties or the size of the button using custom styles, as you will make the component inconsistent and inaccessible.",
       ],
     }}
-    {...rest}
   />
 );
 

--- a/docs/src/pages/WebCalendarPage/WebCalendarPage.js
+++ b/docs/src/pages/WebCalendarPage/WebCalendarPage.js
@@ -37,7 +37,7 @@ import {
   formatMonthArabic,
 } from 'bpk-component-calendar/test-utils';
 
-import DocsPageBuilder from '../../components/DocsPageBuilder';
+import { WebComponentPage } from '../../components/ComponentPage';
 import Paragraph from '../../components/Paragraph';
 
 import STYLES from './calendar-page.scss';
@@ -190,13 +190,11 @@ const components = [
   },
 ];
 
-const WebCalendarPage = ({ ...rest }) => (
-  <DocsPageBuilder
-    title="Calendar"
-    components={components}
+const WebCalendarPage = () => (
+  <WebComponentPage
+    examples={components}
     readme={calendarReadme}
     sassdocId="calendar"
-    {...rest}
   />
 );
 

--- a/docs/src/pages/WebCardsPage/CardsPage.js
+++ b/docs/src/pages/WebCardsPage/CardsPage.js
@@ -20,7 +20,7 @@ import React from 'react';
 import BpkCard from 'bpk-component-card';
 import cardReadme from 'bpk-component-card/README.md';
 
-import DocsPageBuilder from '../../components/DocsPageBuilder';
+import { WebComponentPage } from '../../components/ComponentPage';
 import Paragraph from '../../components/Paragraph';
 
 const components = [
@@ -56,13 +56,11 @@ const components = [
   },
 ];
 
-const CardsPage = ({ ...rest }) => (
-  <DocsPageBuilder
-    title="Cards"
-    components={components}
+const CardsPage = () => (
+  <WebComponentPage
+    examples={components}
     readme={cardReadme}
     sassdocId="cards"
-    {...rest}
   />
 );
 

--- a/docs/src/pages/WebCheckboxPage/WebCheckboxPage.js
+++ b/docs/src/pages/WebCheckboxPage/WebCheckboxPage.js
@@ -22,8 +22,7 @@ import { cssModules } from 'bpk-react-utils';
 import readme from 'bpk-component-checkbox/README.md';
 
 import InputContainer from '../FormsPage/InputContainer';
-import DocsPageBuilder from '../../components/DocsPageBuilder';
-import IntroBlurb from '../../components/IntroBlurb';
+import { WebComponentPage } from '../../components/ComponentPage';
 import Paragraph from '../../components/Paragraph';
 
 import STYLES from './checkbox-page.scss';
@@ -170,22 +169,11 @@ const components = [
   },
 ];
 
-const blurb = [
-  <IntroBlurb>
-    Backpack selects override the default styles in most modern browsers. In
-    some older browsers they simply fall back to the browser default.
-  </IntroBlurb>,
-];
-
-const WebCheckboxPage = ({ ...rest }) => (
-  <DocsPageBuilder
-    title="Checkbox"
+const WebCheckboxPage = () => (
+  <WebComponentPage
     sassdocId="forms-mixin-bpk-checkbox"
-    blurb={blurb}
-    components={components}
+    examples={components}
     readme={readme}
-    showMenu={false}
-    {...rest}
   />
 );
 

--- a/docs/src/pages/WebChipsPage/ChipsPage.js
+++ b/docs/src/pages/WebChipsPage/ChipsPage.js
@@ -32,7 +32,7 @@ import CarsIconSm from 'bpk-component-icon/sm/cars';
 import TickCircleIconSm from 'bpk-component-icon/sm/tick-circle';
 
 import Paragraph from '../../components/Paragraph';
-import DocsPageBuilder from '../../components/DocsPageBuilder';
+import { WebComponentPage } from '../../components/ComponentPage';
 
 import STYLES from './ChipsPage.scss';
 
@@ -276,13 +276,8 @@ const components = [
   },
 ];
 
-const ChipsPage = ({ ...rest }: { [string]: any }) => (
-  <DocsPageBuilder
-    title="Chips"
-    components={components}
-    readme={chipReadme}
-    {...rest}
-  />
+const ChipsPage = () => (
+  <WebComponentPage examples={components} readme={chipReadme} />
 );
 
 export default ChipsPage;

--- a/docs/src/pages/WebDialogPage/DialogsPage.js
+++ b/docs/src/pages/WebDialogPage/DialogsPage.js
@@ -22,7 +22,7 @@ import React from 'react';
 import dialogReadme from 'bpk-component-dialog/README.md';
 
 import Paragraph from '../../components/Paragraph';
-import DocsPageBuilder from '../../components/DocsPageBuilder';
+import { WebComponentPage } from '../../components/ComponentPage';
 
 import {
   DialogContainer,
@@ -60,10 +60,9 @@ const components = [
   },
 ];
 
-const DialogsPage = ({ ...rest }: { [string]: any }) => (
-  <DocsPageBuilder
-    title="Dialogs"
-    components={components}
+const DialogsPage = () => (
+  <WebComponentPage
+    examples={components}
     readme={dialogReadme}
     usageTable={{
       dos: [
@@ -79,7 +78,6 @@ const DialogsPage = ({ ...rest }: { [string]: any }) => (
       ],
     }}
     sassdocId="dialogs"
-    {...rest}
   />
 );
 

--- a/docs/src/pages/WebFlarePage/WebFlarePage.js
+++ b/docs/src/pages/WebFlarePage/WebFlarePage.js
@@ -22,7 +22,7 @@ import { BpkContentBubble } from 'bpk-component-flare';
 import flareReadme from 'bpk-component-flare/README.md';
 import { cssModules } from 'bpk-react-utils';
 
-import DocsPageBuilder from '../../components/DocsPageBuilder';
+import { WebComponentPage } from '../../components/ComponentPage';
 
 import STYLES from './Flare.scss';
 
@@ -46,13 +46,8 @@ const components = [
   },
 ];
 
-const WebFlarePage = ({ ...rest }) => (
-  <DocsPageBuilder
-    title="Flare"
-    components={components}
-    readme={flareReadme}
-    {...rest}
-  />
+const WebFlarePage = () => (
+  <WebComponentPage examples={components} readme={flareReadme} />
 );
 
 export default WebFlarePage;

--- a/docs/src/pages/WebFormLabelPage/WebFormLabelPage.js
+++ b/docs/src/pages/WebFormLabelPage/WebFormLabelPage.js
@@ -17,14 +17,11 @@
  */
 
 import React from 'react';
-import BpkRouterLink from 'bpk-component-router-link';
 import BpkLabel from 'bpk-component-label';
 import { cssModules } from 'bpk-react-utils';
 import readme from 'bpk-component-label/README.md';
 
-import * as ROUTES from '../../constants/routes';
-import DocsPageBuilder from '../../components/DocsPageBuilder';
-import BpkParagraph from '../../components/Paragraph';
+import { WebComponentPage } from '../../components/ComponentPage';
 import STYLES from '../FormsPage/forms-page.scss';
 
 const getClassName = cssModules(STYLES);
@@ -94,24 +91,18 @@ const components = [
   },
 ];
 
-const blurb = [
-  <BpkParagraph>
-    Labels should always be used with form elements to provide context to the
-    user. Relying on placeholders alone is not good practise. Have a look at the{' '}
-    <BpkRouterLink to={ROUTES.FIELDSET}>fieldset</BpkRouterLink> component which
-    composes labels, fields and validation messages accordingly.
-  </BpkParagraph>,
-];
-
-const WebFormLabelPage = ({ ...rest }) => (
-  <DocsPageBuilder
-    title="Form label"
+const WebFormLabelPage = () => (
+  <WebComponentPage
     sassdocId="forms-mixin-bpk-label"
-    blurb={blurb}
-    components={components}
+    examples={components}
     readme={readme}
-    showMenu={false}
-    {...rest}
+    usageTable={{
+      dos: [
+        'Always use labels with form elements to provide context to the user.',
+        'Use the fieldset component which combines labels, fields and validation messages where possible.',
+      ],
+      donts: ['Rely on placeholders alone.'],
+    }}
   />
 );
 

--- a/docs/src/pages/WebFormValidationPage/WebFormValidationPage.js
+++ b/docs/src/pages/WebFormValidationPage/WebFormValidationPage.js
@@ -17,8 +17,6 @@
  */
 
 import React from 'react';
-import BpkLink from 'bpk-component-link';
-import BpkRouterLink from 'bpk-component-router-link';
 import BpkSelect from 'bpk-component-select';
 import BpkCheckbox from 'bpk-component-checkbox';
 import BpkTextarea from 'bpk-component-textarea';
@@ -27,9 +25,7 @@ import BpkFormValidation from 'bpk-component-form-validation';
 import { cssModules } from 'bpk-react-utils';
 import readme from 'bpk-component-form-validation/README.md';
 
-import * as ROUTES from '../../constants/routes';
-import DocsPageBuilder from '../../components/DocsPageBuilder';
-import BpkParagraph from '../../components/Paragraph';
+import { WebComponentPage } from '../../components/ComponentPage';
 import InputContainer from '../FormsPage/InputContainer';
 import STYLES from '../FormsPage/forms-page.scss';
 
@@ -105,28 +101,21 @@ const components = [
   },
 ];
 
-const blurb = [
-  <BpkParagraph>
-    Validation messages should be used to provide the user with specific
-    feedback about an error with a particular form input field. They can be
-    attached to <BpkLink href={ROUTES.TEXT_INPUT}>inputs</BpkLink>,{' '}
-    <BpkLink href={ROUTES.SELECT}>selects</BpkLink> and{' '}
-    <BpkLink href={ROUTES.CHECKBOX}>checkboxes</BpkLink>. They should either be
-    displayed on form submit or on field blur. Have a look at the{' '}
-    <BpkRouterLink to={ROUTES.FIELDSET}>fieldset</BpkRouterLink> component which
-    composes labels, fields and validation messages accordingly.
-  </BpkParagraph>,
-];
-
-const WebFormValidationPage = ({ ...rest }) => (
-  <DocsPageBuilder
-    title="Validation"
+const WebFormValidationPage = () => (
+  <WebComponentPage
     sassdocId="forms-mixin-bpk-label"
-    blurb={blurb}
-    components={components}
+    examples={components}
     readme={readme}
-    showMenu={false}
-    {...rest}
+    usageTable={{
+      dos: [
+        'Use validation messages to provide the user with specific feedback about errors with an input field.',
+        'Display validation messages on form submit or field blur.',
+        'Use the fieldset component which combines labels, fields and validation messages where possible.',
+      ],
+      donts: [
+        'Validate while the user types, as this can be confusing and bad for accessibility.',
+      ],
+    }}
   />
 );
 

--- a/docs/src/pages/WebHorizontalNavPage/HorizontalNavPage.js
+++ b/docs/src/pages/WebHorizontalNavPage/HorizontalNavPage.js
@@ -24,7 +24,7 @@ import BpkHorizontalNav, {
   HORIZONTAL_NAV_TYPES,
 } from 'bpk-component-horizontal-nav';
 
-import DocsPageBuilder from '../../components/DocsPageBuilder';
+import { WebComponentPage } from '../../components/ComponentPage';
 
 class HorizontalNavContainer extends Component {
   constructor() {
@@ -112,13 +112,8 @@ const components = [
   },
 ];
 
-const HorizontalNavPage = ({ ...rest }) => (
-  <DocsPageBuilder
-    title="Horizontal navigation"
-    components={components}
-    readme={readme}
-    {...rest}
-  />
+const HorizontalNavPage = () => (
+  <WebComponentPage examples={components} readme={readme} />
 );
 
 export default HorizontalNavPage;

--- a/docs/src/pages/WebIconsPage/IconsPage.js
+++ b/docs/src/pages/WebIconsPage/IconsPage.js
@@ -21,7 +21,7 @@ import BpkLink from 'bpk-component-link';
 import iconReadme from 'bpk-component-icon/README.md';
 
 import * as ROUTES from '../../constants/routes';
-import DocsPageBuilder from '../../components/DocsPageBuilder';
+import { WebComponentPage } from '../../components/ComponentPage';
 import Paragraph from '../../components/Paragraph';
 import Code from '../../components/Code';
 
@@ -39,13 +39,11 @@ const components = [
   },
 ];
 
-const IconsPage = ({ ...rest }) => (
-  <DocsPageBuilder
-    title="Icons"
-    components={components}
+const IconsPage = () => (
+  <WebComponentPage
+    examples={components}
     readme={iconReadme}
     sassdocId="svgs-mixin-bpk-icon"
-    {...rest}
   />
 );
 

--- a/docs/src/pages/WebImagesPage/WebImagesPage.js
+++ b/docs/src/pages/WebImagesPage/WebImagesPage.js
@@ -28,7 +28,7 @@ import imagesReadme from 'bpk-component-image/README.md';
 import * as SPACINGS from 'bpk-tokens/tokens/base.es6';
 import * as BREAKPOINTS from 'bpk-tokens/tokens/breakpoints.es6';
 
-import DocsPageBuilder from '../../components/DocsPageBuilder';
+import { WebComponentPage } from '../../components/ComponentPage';
 
 const documentIfExists = typeof window !== 'undefined' ? document : null;
 const FadingImage = withLoadingBehavior(BpkImage);
@@ -215,13 +215,8 @@ const components = [
   },
 ];
 
-const WebImagesPage = ({ ...rest }) => (
-  <DocsPageBuilder
-    title="Images"
-    components={components}
-    readme={imagesReadme}
-    {...rest}
-  />
+const WebImagesPage = () => (
+  <WebComponentPage examples={components} readme={imagesReadme} />
 );
 
 export default WebImagesPage;

--- a/docs/src/pages/WebLinksPage/LinksPage.js
+++ b/docs/src/pages/WebLinksPage/LinksPage.js
@@ -21,7 +21,7 @@ import BpkLink, { BpkButtonLink } from 'bpk-component-link';
 import linkReadme from 'bpk-component-link/README.md';
 import { cssModules } from 'bpk-react-utils';
 
-import DocsPageBuilder from '../../components/DocsPageBuilder';
+import { WebComponentPage } from '../../components/ComponentPage';
 import Paragraph from '../../components/Paragraph';
 
 import STYLES from './LinksPage.scss';
@@ -59,13 +59,8 @@ const components = [
   },
 ];
 
-const LinkPage = ({ ...rest }) => (
-  <DocsPageBuilder
-    title="Links"
-    readme={linkReadme}
-    components={components}
-    {...rest}
-  />
+const LinkPage = () => (
+  <WebComponentPage readme={linkReadme} examples={components} />
 );
 
 export default LinkPage;

--- a/docs/src/pages/WebNavigationBarPage/NavigationBarPage.js
+++ b/docs/src/pages/WebNavigationBarPage/NavigationBarPage.js
@@ -29,7 +29,7 @@ import BpkNavigationBar, {
 import navigationBarReadme from 'bpk-component-navigation-bar/README.md';
 import { cssModules } from 'bpk-react-utils';
 
-import DocsPageBuilder from '../../components/DocsPageBuilder';
+import { WebComponentPage } from '../../components/ComponentPage';
 import Paragraph from '../../components/Paragraph';
 
 import AirlineLogo from './AirlineLogo';
@@ -148,13 +148,8 @@ const components = [
   },
 ];
 
-const NavigationBarPage = ({ ...rest }: { [string]: any }) => (
-  <DocsPageBuilder
-    title="Navigation bar"
-    components={components}
-    readme={navigationBarReadme}
-    {...rest}
-  />
+const NavigationBarPage = () => (
+  <WebComponentPage examples={components} readme={navigationBarReadme} />
 );
 
 export default NavigationBarPage;

--- a/docs/src/pages/WebNudgersPage/NudgersPage.js
+++ b/docs/src/pages/WebNudgersPage/NudgersPage.js
@@ -23,7 +23,7 @@ import BpkNudger, { BpkConfigurableNudger } from 'bpk-component-nudger';
 import nudgersReadme from 'bpk-component-nudger/README.md';
 import { cssModules } from 'bpk-react-utils';
 
-import DocsPageBuilder from '../../components/DocsPageBuilder';
+import { WebComponentPage } from '../../components/ComponentPage';
 import Paragraph from '../../components/Paragraph';
 
 import STYLES from './nudger-page.scss';
@@ -155,13 +155,8 @@ const components = [
   },
 ];
 
-const NudgersPage = ({ ...rest }: { [string]: any }) => (
-  <DocsPageBuilder
-    title="Nudgers"
-    components={components}
-    readme={nudgersReadme}
-    {...rest}
-  />
+const NudgersPage = () => (
+  <WebComponentPage examples={components} readme={nudgersReadme} />
 );
 
 export default NudgersPage;

--- a/docs/src/pages/WebPanelsPage/PanelsPage.js
+++ b/docs/src/pages/WebPanelsPage/PanelsPage.js
@@ -20,7 +20,7 @@ import React from 'react';
 import BpkPanel from 'bpk-component-panel';
 import panelReadme from 'bpk-component-panel/README.md';
 
-import DocsPageBuilder from '../../components/DocsPageBuilder';
+import { WebComponentPage } from '../../components/ComponentPage';
 import Paragraph from '../../components/Paragraph';
 
 const components = [
@@ -69,13 +69,11 @@ const components = [
   },
 ];
 
-const PanelsPage = ({ ...rest }) => (
-  <DocsPageBuilder
-    title="Panel"
-    components={components}
+const PanelsPage = () => (
+  <WebComponentPage
+    examples={components}
     readme={panelReadme}
     sassdocId="panels"
-    {...rest}
   />
 );
 

--- a/docs/src/pages/WebProgressPage/ProgressPage.js
+++ b/docs/src/pages/WebProgressPage/ProgressPage.js
@@ -19,7 +19,7 @@
 import React from 'react';
 import progressReadme from 'bpk-component-progress/README.md';
 
-import DocsPageBuilder from '../../components/DocsPageBuilder';
+import { WebComponentPage } from '../../components/ComponentPage';
 import Paragraph from '../../components/Paragraph';
 
 import ProgressContainer from './ProgressContainer';
@@ -62,20 +62,19 @@ const components = [
   },
 ];
 
-const ProgressPage = ({ ...rest }) => (
-  <DocsPageBuilder
+const ProgressPage = () => (
+  <WebComponentPage
     title="Progress bars"
-    components={components}
+    examples={components}
     readme={progressReadme}
     usageTable={{
       dos: [
         'Use exclusively for tracking user progress through a set of actions, for example a form.',
       ],
       donts: [
-        "Don't use in others contexts. This component is described to screen readers as a progress bar, so using it in other contexts harms accessibility.",
+        "Don't use in other contexts. This component is described to screen readers as a progress bar, so using it in other contexts harms accessibility.",
       ],
     }}
-    {...rest}
   />
 );
 

--- a/docs/src/pages/WebRadioButtonPage/WebRadioButtonsPage.js
+++ b/docs/src/pages/WebRadioButtonPage/WebRadioButtonsPage.js
@@ -20,8 +20,7 @@ import React from 'react';
 import readme from 'bpk-component-radio/README.md';
 
 import RadioContainer from '../FormsPage/RadioContainer';
-import DocsPageBuilder from '../../components/DocsPageBuilder';
-import IntroBlurb from '../../components/IntroBlurb';
+import { WebComponentPage } from '../../components/ComponentPage';
 
 const components = [
   {
@@ -49,22 +48,11 @@ const components = [
   },
 ];
 
-const blurb = [
-  <IntroBlurb>
-    Backpack overrides the browser default styles for radio buttons. In some
-    older browsers they simply fall back to the browser default.
-  </IntroBlurb>,
-];
-
-const WebRadioButtonsPage = ({ ...rest }) => (
-  <DocsPageBuilder
-    title="Radio buttons"
+const WebRadioButtonsPage = () => (
+  <WebComponentPage
     sassdocId="forms-mixin-bpk-radio"
-    blurb={blurb}
-    components={components}
+    examples={components}
     readme={readme}
-    showMenu={false}
-    {...rest}
   />
 );
 

--- a/docs/src/pages/WebRatingPage/WebRatingPage.js
+++ b/docs/src/pages/WebRatingPage/WebRatingPage.js
@@ -21,7 +21,7 @@ import BpkRating, { RATING_SIZES, RATING_TYPES } from 'bpk-component-rating';
 import ratingReadme from 'bpk-component-rating/README.md';
 import { cssModules } from 'bpk-react-utils';
 
-import DocsPageBuilder from '../../components/DocsPageBuilder';
+import { WebComponentPage } from '../../components/ComponentPage';
 import Paragraph from '../../components/Paragraph';
 
 import STYLES from './Rating.scss';
@@ -221,13 +221,8 @@ const components = [
   },
 ];
 
-const WebImagesPage = ({ ...rest }) => (
-  <DocsPageBuilder
-    title="Ratings"
-    components={components}
-    readme={ratingReadme}
-    {...rest}
-  />
+const WebRatingPage = () => (
+  <WebComponentPage examples={components} readme={ratingReadme} />
 );
 
-export default WebImagesPage;
+export default WebRatingPage;

--- a/docs/src/pages/WebScrollableCalendarPage/WebScrollableCalendarPage.js
+++ b/docs/src/pages/WebScrollableCalendarPage/WebScrollableCalendarPage.js
@@ -25,7 +25,7 @@ import BpkScrollableCalendar, {
 } from 'bpk-component-scrollable-calendar';
 import scrollableCalendarReadme from 'bpk-component-scrollable-calendar/README.md';
 
-import DocsPageBuilder from '../../components/DocsPageBuilder';
+import { WebComponentPage } from '../../components/ComponentPage';
 
 import {
   weekDays,
@@ -127,13 +127,8 @@ const components = [
   },
 ];
 
-const WebScrollableCalendarPage = ({ ...rest }) => (
-  <DocsPageBuilder
-    title="Scrollable Calendar"
-    components={components}
-    readme={scrollableCalendarReadme}
-    {...rest}
-  />
+const WebScrollableCalendarPage = () => (
+  <WebComponentPage examples={components} readme={scrollableCalendarReadme} />
 );
 
 export default WebScrollableCalendarPage;

--- a/docs/src/pages/WebSectionListPage/SectionListPage.js
+++ b/docs/src/pages/WebSectionListPage/SectionListPage.js
@@ -24,7 +24,7 @@ import BpkSectionList, {
 import sectionListReadme from 'bpk-component-section-list/README.md';
 import { BpkCode } from 'bpk-component-code';
 
-import DocsPageBuilder from '../../components/DocsPageBuilder';
+import { WebComponentPage } from '../../components/ComponentPage';
 import Paragraph from '../../components/Paragraph';
 
 const components = [
@@ -54,13 +54,8 @@ const components = [
   },
 ];
 
-const SectionListPage = ({ ...rest }) => (
-  <DocsPageBuilder
-    title="Section list"
-    readme={sectionListReadme}
-    components={components}
-    {...rest}
-  />
+const SectionListPage = () => (
+  <WebComponentPage readme={sectionListReadme} examples={components} />
 );
 
 export default SectionListPage;

--- a/docs/src/pages/WebSelectPage/WebSelectPage.js
+++ b/docs/src/pages/WebSelectPage/WebSelectPage.js
@@ -25,8 +25,7 @@ import readme from 'bpk-component-select/README.md';
 
 import * as ROUTES from '../../constants/routes';
 import InputContainer from '../FormsPage/InputContainer';
-import DocsPageBuilder from '../../components/DocsPageBuilder';
-import IntroBlurb from '../../components/IntroBlurb';
+import { WebComponentPage } from '../../components/ComponentPage';
 import BpkParagraph from '../../components/Paragraph';
 import STYLES from '../FormsPage/forms-page.scss';
 
@@ -175,22 +174,11 @@ const components = [
   },
 ];
 
-const blurb = [
-  <IntroBlurb>
-    Backpack selects override the default styles in most modern browsers. In
-    some older browsers they simply fall back to the browser default.
-  </IntroBlurb>,
-];
-
-const WebSelectPage = ({ ...rest }) => (
-  <DocsPageBuilder
-    title="Select"
+const WebSelectPage = () => (
+  <WebComponentPage
     sassdocId="forms-mixin-bpk-select"
-    blurb={blurb}
-    components={components}
+    examples={components}
     readme={readme}
-    showMenu={false}
-    {...rest}
   />
 );
 

--- a/docs/src/pages/WebSpinnersPage/SpinnersPage.js
+++ b/docs/src/pages/WebSpinnersPage/SpinnersPage.js
@@ -26,7 +26,7 @@ import {
   SPINNER_TYPES,
 } from 'bpk-component-spinner';
 
-import DocsPageBuilder from '../../components/DocsPageBuilder';
+import { WebComponentPage } from '../../components/ComponentPage';
 
 const components = [
   {
@@ -64,13 +64,11 @@ const components = [
   },
 ];
 
-const SpinnersPage = ({ ...rest }) => (
-  <DocsPageBuilder
-    title="Spinners"
-    components={components}
+const SpinnersPage = () => (
+  <WebComponentPage
+    examples={components}
     readme={spinnerReadme}
     sassdocId="svgs-mixin-bpk-spinner"
-    {...rest}
   />
 );
 

--- a/docs/src/pages/WebStarRatingPage/StarRatingPage.js
+++ b/docs/src/pages/WebStarRatingPage/StarRatingPage.js
@@ -23,7 +23,7 @@ import BpkStarRating, {
 } from 'bpk-component-star-rating';
 import starRatingReadme from 'bpk-component-star-rating/README.md';
 
-import DocsPageBuilder from '../../components/DocsPageBuilder';
+import { WebComponentPage } from '../../components/ComponentPage';
 import Paragraph from '../../components/Paragraph';
 
 const InteractiveStarRating = withInteractiveStarRatingState(
@@ -71,13 +71,8 @@ const components = [
   },
 ];
 
-const StarRatingPage = ({ ...rest }) => (
-  <DocsPageBuilder
-    title="Star rating"
-    components={components}
-    readme={starRatingReadme}
-    {...rest}
-  />
+const StarRatingPage = () => (
+  <WebComponentPage examples={components} readme={starRatingReadme} />
 );
 
 export default StarRatingPage;

--- a/docs/src/pages/WebSwitchPage/WebSwitchPage.js
+++ b/docs/src/pages/WebSwitchPage/WebSwitchPage.js
@@ -21,7 +21,7 @@ import BpkSwitch, { SWITCH_TYPES } from 'bpk-component-switch';
 import readme from 'bpk-component-switch/README.md';
 
 import Paragraph from '../../components/Paragraph';
-import DocsPageBuilder from '../../components/DocsPageBuilder';
+import { WebComponentPage } from '../../components/ComponentPage';
 
 const components = [
   {
@@ -60,10 +60,9 @@ const components = [
   },
 ];
 
-const WebSwitchPage = ({ ...rest }) => (
-  <DocsPageBuilder
-    title="Switch"
-    components={components}
+const WebSwitchPage = () => (
+  <WebComponentPage
+    examples={components}
     readme={readme}
     usageTable={{
       dos: [
@@ -75,7 +74,6 @@ const WebSwitchPage = ({ ...rest }) => (
         "Don't use for actions that have no immediate effect, like in a form. In that situation, use a checkbox.",
       ],
     }}
-    {...rest}
   />
 );
 

--- a/docs/src/pages/WebTextInputPage/WebTextInputPage.js
+++ b/docs/src/pages/WebTextInputPage/WebTextInputPage.js
@@ -27,9 +27,8 @@ import readme from 'bpk-component-input/README.md';
 import textareaReadme from 'bpk-component-textarea/README.md';
 
 import InputContainer from '../FormsPage/InputContainer';
-import DocsPageBuilder from '../../components/DocsPageBuilder';
+import { WebComponentPage } from '../../components/ComponentPage';
 import BpkParagraph from '../../components/Paragraph';
-import IntroBlurb from '../../components/IntroBlurb';
 import STYLES from '../FormsPage/forms-page.scss';
 
 const getClassName = cssModules(STYLES);
@@ -51,6 +50,12 @@ const containerClassName = [
 ]
   .map(getClassName)
   .join(' ');
+
+const loremIpsum = 'Lorem ipsum dolor sit amet, consectetur adipisicing elit.';
+
+const loremIpsumLong = `Lorem ipsum dolor sit amet, consectetur adipisicing elit. Voluptate repellat assumenda
+necessitatibus reiciendis, porro temporibus expedita excepturi! Nostrum pariatur odit porro, dolorem dignissimos
+laudantium quis, tempore iste non, nam magnam.`;
 
 const components = [
   {
@@ -487,15 +492,6 @@ const components = [
       </form>,
     ],
   },
-];
-
-const loremIpsum = 'Lorem ipsum dolor sit amet, consectetur adipisicing elit.';
-
-const loremIpsumLong = `Lorem ipsum dolor sit amet, consectetur adipisicing elit. Voluptate repellat assumenda
-necessitatibus reiciendis, porro temporibus expedita excepturi! Nostrum pariatur odit porro, dolorem dignissimos
-laudantium quis, tempore iste non, nam magnam.`;
-
-const customSections = [
   {
     id: 'text-area',
     title: 'Multiline text input',
@@ -558,27 +554,14 @@ const customSections = [
         />
       </form>,
     ],
-    readme: textareaReadme,
   },
 ];
 
-const blurb = [
-  <IntroBlurb>
-    Backpack selects override the default styles in most modern browsers. In
-    some older browsers they simply fall back to the browser default.
-  </IntroBlurb>,
-];
-
-const WebTextInputPage = ({ ...rest }) => (
-  <DocsPageBuilder
-    title="Input"
+const WebTextInputPage = () => (
+  <WebComponentPage
     sassdocId="forms-mixin-bpk-input"
-    blurb={blurb}
-    components={components}
-    readme={readme}
-    customSections={customSections}
-    showMenu={false}
-    {...rest}
+    examples={components}
+    readme={readme + textareaReadme}
   />
 );
 

--- a/docs/src/pages/WebTextPage/TextPage.js
+++ b/docs/src/pages/WebTextPage/TextPage.js
@@ -20,7 +20,7 @@ import React from 'react';
 import BpkText from 'bpk-component-text';
 import textReadme from 'bpk-component-text/README.md';
 
-import DocsPageBuilder from '../../components/DocsPageBuilder';
+import { WebComponentPage } from '../../components/ComponentPage';
 
 const TEXT = 'Lorem ipsum';
 
@@ -53,13 +53,8 @@ const components = [
   },
 ];
 
-const TextPage = ({ ...rest }) => (
-  <DocsPageBuilder
-    title="Text"
-    readme={textReadme}
-    components={components}
-    {...rest}
-  />
+const TextPage = () => (
+  <WebComponentPage readme={textReadme} examples={components} />
 );
 
 export default TextPage;


### PR DESCRIPTION
The only uses of `DocsPageBuilder` left are in non-component pages, which are out of scope for this task:

<img width="298" alt="Screen Shot 2020-08-27 at 13 50 07" src="https://user-images.githubusercontent.com/73652/91444761-1fc05880-e86d-11ea-8382-eb507ac5b558.png">

At some point in the future we can create a new page builder component to handle these non-component use cases, and then kill `DocsPageBuilder`.