### PR TITLE
[no-jira]: Disable dependabot for bpk deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,5 @@ updates:
   labels:
   - dependabot
   versioning-strategy: increase-if-necessary
+  ignore:
+    - dependency-name: "bpk-*"


### PR DESCRIPTION
As Dependabot does not natively support grouping of dependencies (yet) disabling the updating of Backpack components post release from the main repo to stop having multiple PRs to bump all Backpack packages.

There will be a separate process that is responsible for handling the group bumping as part of the release process.