### PR TITLE
[NO-JIRA] Remove og:title

### DIFF
--- a/docs/src/template.js
+++ b/docs/src/template.js
@@ -30,7 +30,6 @@ export default ({ head = {}, html = '', assets = {} }) => `<!doctype html>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="robots" content="noindex">
 
-  <meta property="og:title" content="Backpack">
   <meta property="og:locale" content="en_GB">
   <meta name="description" content="Backpack is Skyscanner's open-source design system.">
   <meta property="og:description" content="Backpack is Skyscanner's open-source design system.">


### PR DESCRIPTION
I think setting `og:title` is preventing shared links from using the title set by Helmet. As a result, a preview for http://backpack.github.io/components/section-list/?platform=web will say `Backpack` instead of `Section list | Backpack`.

By removing `og:title` it will (hopefully) fallback to the title set by Helmet.