### PR TITLE
[NO-JIRA] Add overlay iOS docs

### DIFF
--- a/docs/src/layouts/links.js
+++ b/docs/src/layouts/links.js
@@ -159,7 +159,7 @@ const ComponentsLinks = [
         id: 'OVERLAY',
         route: routes.OVERLAY,
         children: 'Overlay',
-        tags: ['android', 'web'],
+        tags: ['android', 'web', 'ios'],
         keywords: ['tint', 'scrim'],
       },
       {

--- a/docs/src/pages/IOSOverlayPage/IOSOverlayPage.js
+++ b/docs/src/pages/IOSOverlayPage/IOSOverlayPage.js
@@ -1,0 +1,102 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2016-2019 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+
+import readme from '../../../../backpack-ios/Backpack/OverlayView/README.md';
+import screenshotDefault from '../../../../backpack-ios/screenshots/iPhone 8-overlay-view___default_lm.png';
+import screenshotDefaultDm from '../../../../backpack-ios/screenshots/iPhone 8-overlay-view___default_dm.png';
+import screenshotNoOverlay from '../../../../backpack-ios/screenshots/iPhone 8-overlay-view___overlay-type-none_lm.png';
+import screenshotNoOverlayDm from '../../../../backpack-ios/screenshots/iPhone 8-overlay-view___overlay-type-none_dm.png';
+import screenshotContent from '../../../../backpack-ios/screenshots/iPhone 8-overlay-view___foreground-content_lm.png';
+import screenshotContentDm from '../../../../backpack-ios/screenshots/iPhone 8-overlay-view___foreground-content_dm.png';
+import { IOSComponentPage } from '../../components/ComponentPage';
+
+const components = [
+  {
+    id: 'default',
+    title: 'Default',
+    screenshots: [
+      {
+        width: 750,
+        height: 1334,
+        src: `/${screenshotDefault}`,
+        altText: 'iOS default overlay-view.',
+        subText: '(iPhone 8 simulator)',
+      },
+      {
+        width: 750,
+        height: 1334,
+        src: `/${screenshotDefaultDm}`,
+        altText: 'iOS default overlay-view.',
+        subText: '(iPhone 8 simulator - dark mode)',
+      },
+    ],
+  },
+  {
+    id: 'no-tint',
+    title: 'Disabled tint',
+    screenshots: [
+      {
+        width: 750,
+        height: 1334,
+        src: `/${screenshotNoOverlay}`,
+        altText: 'iOS overlay-view with tint disabled.',
+        subText: '(iPhone 8 simulator)',
+      },
+      {
+        width: 750,
+        height: 1334,
+        src: `/${screenshotNoOverlayDm}`,
+        altText: 'iOS overlay-view with tint disabled.',
+        subText: '(iPhone 8 simulator - dark mode)',
+      },
+    ],
+  },
+  {
+    id: 'foreground-content',
+    title: 'Foreground content',
+    screenshots: [
+      {
+        width: 750,
+        height: 1334,
+        src: `/${screenshotContent}`,
+        altText: 'iOS overlay-view with foreground content.',
+        subText: '(iPhone 8 simulator)',
+      },
+      {
+        width: 750,
+        height: 1334,
+        src: `/${screenshotContentDm}`,
+        altText: 'iOS overlay-view with foreground content.',
+        subText: '(iPhone 8 simulator - dark mode)',
+      },
+    ],
+  },
+];
+
+const IOSOverlayPage = () => (
+  <IOSComponentPage
+    screenshots={components}
+    readme={readme}
+    documentationId="BPKOverlayView"
+    githubPath="OverlayView"
+  />
+);
+
+export default IOSOverlayPage;

--- a/docs/src/pages/IOSOverlayPage/index.js
+++ b/docs/src/pages/IOSOverlayPage/index.js
@@ -16,28 +16,6 @@
  * limitations under the License.
  */
 
-/* @flow strict */
+import page from './IOSOverlayPage';
 
-import React from 'react';
-
-import DocsPageWrapper from '../../components/DocsPageWrapper';
-import IntroBlurb from '../../components/IntroBlurb';
-import Android from '../AndroidOverlayPage';
-import IOS from '../IOSOverlayPage';
-import Web from '../WebOverlayPage';
-
-const Page = () => (
-  <DocsPageWrapper
-    title="Overlay"
-    blurb={[
-      <IntroBlurb>
-        The overlay component applies a dark tint to its content.
-      </IntroBlurb>,
-    ]}
-    iosSubpage={<IOS />}
-    androidSubpage={<Android />}
-    webSubpage={<Web />}
-  />
-);
-
-export default Page;
+export default page;


### PR DESCRIPTION
Forgot to do this before, so here it is

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack/blob/master/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] [Links platform metadata](https://github.com/Skyscanner/backpack-docs/blob/master/docs/src/layouts/links.js)

![Screenshot_2020-10-26 Overlay Backpack](https://user-images.githubusercontent.com/30267516/97180974-abcdfe00-1792-11eb-870b-a52ce76e0a8a.png)

