### PR TITLE
[No Jira] Fix images that were too large

### DIFF
--- a/docs/src/components/DocsPageBuilder/BpkMarkdownRenderer.scss
+++ b/docs/src/components/DocsPageBuilder/BpkMarkdownRenderer.scss
@@ -96,8 +96,7 @@
   }
 
   &__image {
-    width: 100%;
-    max-width: $bpk-spacing-xxl * 20;
+    max-width: 100%;
     margin: $bpk-spacing-md 0;
 
     @include bpk-border-radius-sm;


### PR DESCRIPTION
For now I've just changed the logic we're using in the CSS.

In the future we may want to add a plugin to the Markdown renderer so that we can specify extra props in our files. Jekyll supports this, so on my blog I can do this to add a custom class:

```
![Screenshots of Personal Best 2](/assets/post-images/personal-best-2-screenshots.png){:class="post-image"}
```

But this is good for now.