### PR TITLE
[BPK-3976] Add skip-link docs

### DIFF
--- a/docs/src/constants/routes.js
+++ b/docs/src/constants/routes.js
@@ -96,6 +96,7 @@ export const BREAKPOINT = '/components/breakpoint';
 export const HORIZONTAL_GRID = '/components/horizontal-grid';
 export const SCROLLABLE_CALENDAR = '/components/scrollable-calendar';
 export const SLIDER = '/components/slider';
+export const SKIP_LINK = '/components/skip-link';
 export const DRAWER = '/components/drawer';
 export const DIALOG = '/components/dialog';
 export const FLAT_LIST = '/components/flat-list';

--- a/docs/src/layouts/SideNavLayout/SideNavLayout.js
+++ b/docs/src/layouts/SideNavLayout/SideNavLayout.js
@@ -22,6 +22,7 @@ import BpkModal from 'bpk-component-modal';
 import { cssModules } from 'bpk-react-utils';
 import React, { Component, type Node } from 'react';
 import BpkBreakpoint, { BREAKPOINTS } from 'bpk-component-breakpoint';
+import BpkSkipLink from 'bpk-component-skip-link';
 
 import Sidebar from './Sidebar';
 import STYLES from './SideNavLayout.scss';
@@ -91,6 +92,11 @@ export default class SideNavLayout extends Component<Props, State> {
 
     return (
       <section className={getClassName('bpkdocs-side-nav-layout')}>
+        <BpkSkipLink
+          className={getClassName('bpkdocs-side-nav-layout__skip-link')}
+          label="Skip to main content"
+          href="#main-content"
+        />
         <BpkBreakpoint query={BREAKPOINTS.TABLET}>
           {isTablet =>
             isTablet ? (
@@ -123,7 +129,10 @@ export default class SideNavLayout extends Component<Props, State> {
             )
           }
         </BpkBreakpoint>
-        <section className={getClassName('bpkdocs-side-nav-layout__main')}>
+        <section
+          id="main-content"
+          className={getClassName('bpkdocs-side-nav-layout__main')}
+        >
           <MenuToggle onHamburgerClick={this.onHamburgerClick} />
           {children}
         </section>

--- a/docs/src/layouts/SideNavLayout/SideNavLayout.scss
+++ b/docs/src/layouts/SideNavLayout/SideNavLayout.scss
@@ -47,7 +47,12 @@
 
   &__skip-link {
     position: absolute;
-    top: 1rem;
-    left: 1rem;
+    top: $bpk-spacing-md;
+    left: $bpk-spacing-md;
+
+    // There's no point having this in smaller view-ports as the navigation is hidden anyway
+    @include bpk-breakpoint-tablet {
+      display: none;
+    }
   }
 }

--- a/docs/src/layouts/links.js
+++ b/docs/src/layouts/links.js
@@ -30,6 +30,13 @@ const ComponentsLinks = [
     sort: true,
     links: [
       {
+        id: 'SKIP_LINK',
+        route: routes.SKIP_LINK,
+        children: 'Skip link',
+        tags: ['web'],
+        keywords: ['skiplink'],
+      },
+      {
         id: 'BOTTOM_NAV',
         route: routes.BOTTOM_NAV,
         children: 'Bottom Nav',

--- a/docs/src/pages/components/SkipLink/SkipLinkPage.js
+++ b/docs/src/pages/components/SkipLink/SkipLinkPage.js
@@ -16,38 +16,26 @@
  * limitations under the License.
  */
 
-@import '~bpk-mixins/index';
+/* @flow strict */
 
-.bpkdocs-side-nav-layout {
-  display: flex;
-  min-height: 35 * $bpk-spacing-xl;
-  overflow: hidden;
+import React from 'react';
 
-  @include bpk-breakpoint-tablet {
-    min-height: 20 * $bpk-spacing-xl;
-  }
+import DocsPageWrapper from '../../../components/DocsPageWrapper';
+import IntroBlurb from '../../../components/IntroBlurb';
 
-  &__sidebar-destop-wrapper {
-    display: flex;
+import WebSkipLinks from './WebSkipLinkPage';
 
-    @include bpk-breakpoint-tablet {
-      display: none;
-    }
-  }
+const SkipLinkPage = () => (
+  <DocsPageWrapper
+    title="Skip link"
+    blurb={[
+      <IntroBlurb>
+        Skip links help users of assistive technology as well as power-users
+        navigate our site quicker.
+      </IntroBlurb>,
+    ]}
+    webSubpage={<WebSkipLinks wrapped />}
+  />
+);
 
-  &__modal-content {
-    display: flex;
-    flex-direction: column;
-  }
-
-  &__main {
-    min-width: 0;
-    flex: 1;
-  }
-
-  &__skip-link {
-    position: absolute;
-    top: 1rem;
-    left: 1rem;
-  }
-}
+export default SkipLinkPage;

--- a/docs/src/pages/components/SkipLink/SkipLinkPage.js
+++ b/docs/src/pages/components/SkipLink/SkipLinkPage.js
@@ -30,7 +30,7 @@ const SkipLinkPage = () => (
     title="Skip link"
     blurb={[
       <IntroBlurb>
-        Skip links help users of assistive technology as well as power-users
+        Skip links help users of assistive technology as well as power users
         navigate our site quicker.
       </IntroBlurb>,
     ]}

--- a/docs/src/pages/components/SkipLink/WebSkipLinkPage.js
+++ b/docs/src/pages/components/SkipLink/WebSkipLinkPage.js
@@ -1,0 +1,73 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2016-2019 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* @flow strict */
+
+import React from 'react';
+import BpkSkipLink from 'bpk-component-skip-link';
+import skipLinkReadme from 'bpk-component-skip-link/README.md';
+import { cssModules } from 'bpk-react-utils';
+
+import { WebComponentPage } from '../../../components/ComponentPage';
+import Paragraph from '../../../components/Paragraph';
+
+import STYLES from './skip-link-page.scss';
+
+const getClassName = cssModules(STYLES);
+
+const components = [
+  {
+    id: 'default',
+    title: 'Default',
+    blurb: [
+      <Paragraph>
+        Skip links benefit sighted keyboard or switch users by providing them
+        with a way to skip over lengthy menus or filters. Skip links should be
+        absolute-positioned to ensure that when they become visible they do not
+        shift other content.
+        <br />
+        <br />
+        It’s ok for a skip link to overlap other content on the page, as long as
+        you are still able to tab forwards/backwards to that content. The skip
+        link is very noticeable, and doesn’t disappear immediately. These are
+        deliberate design decisions to ensure that a user tabbing quickly
+        through the page won’t miss the skip link.
+      </Paragraph>,
+    ],
+    examples: [
+      <div className={null}>
+        <BpkSkipLink
+          className={getClassName('bpkdocs-skip-link-page__skip-link')}
+          href="#readme"
+          label="Skip to readme"
+        />
+        <Paragraph>Tab to this area to see the skip-link in action.</Paragraph>
+      </div>,
+    ],
+  },
+];
+
+const SkipLinksPage = () => (
+  <WebComponentPage
+    examples={components}
+    readme={skipLinkReadme}
+    packageName="bpk-component-skip-link"
+  />
+);
+
+export default SkipLinksPage;

--- a/docs/src/pages/components/SkipLink/WebSkipLinkPage.js
+++ b/docs/src/pages/components/SkipLink/WebSkipLinkPage.js
@@ -19,6 +19,7 @@
 /* @flow strict */
 
 import React from 'react';
+import BpkLink from 'bpk-component-link';
 import BpkSkipLink from 'bpk-component-skip-link';
 import skipLinkReadme from 'bpk-component-skip-link/README.md';
 import { cssModules } from 'bpk-react-utils';
@@ -38,15 +39,22 @@ const components = [
       <Paragraph>
         Skip links benefit sighted keyboard or switch users by providing them
         with a way to skip over lengthy menus or filters. Skip links should be
-        absolute-positioned to ensure that when they become visible they do not
-        shift other content.
+        absolutely positioned to ensure that when they become visible they do
+        not shift other content.
         <br />
         <br />
         It’s ok for a skip link to overlap other content on the page, as long as
-        you are still able to tab forwards/backwards to that content. The skip
-        link is very noticeable, and doesn’t disappear immediately. These are
-        deliberate design decisions to ensure that a user tabbing quickly
+        you are still able to tab forwards or backwards to that content. The
+        skip link is very noticeable, and doesn’t disappear immediately. These
+        are deliberate design decisions to ensure that a user tabbing quickly
         through the page won’t miss the skip link.
+        <br />
+        <br />
+        For more information see this{' '}
+        <BpkLink href="https://www.nomensa.com/blog/2004/what-are-skip-links">
+          Nomensa blog about Skip Links
+        </BpkLink>
+        .
       </Paragraph>,
     ],
     examples: [

--- a/docs/src/pages/components/SkipLink/index.js
+++ b/docs/src/pages/components/SkipLink/index.js
@@ -16,38 +16,8 @@
  * limitations under the License.
  */
 
-@import '~bpk-mixins/index';
+/* @flow strict */
 
-.bpkdocs-side-nav-layout {
-  display: flex;
-  min-height: 35 * $bpk-spacing-xl;
-  overflow: hidden;
+import page from './SkipLinkPage';
 
-  @include bpk-breakpoint-tablet {
-    min-height: 20 * $bpk-spacing-xl;
-  }
-
-  &__sidebar-destop-wrapper {
-    display: flex;
-
-    @include bpk-breakpoint-tablet {
-      display: none;
-    }
-  }
-
-  &__modal-content {
-    display: flex;
-    flex-direction: column;
-  }
-
-  &__main {
-    min-width: 0;
-    flex: 1;
-  }
-
-  &__skip-link {
-    position: absolute;
-    top: 1rem;
-    left: 1rem;
-  }
-}
+export default page;

--- a/docs/src/pages/components/SkipLink/skip-link-page.scss
+++ b/docs/src/pages/components/SkipLink/skip-link-page.scss
@@ -18,36 +18,8 @@
 
 @import '~bpk-mixins/index';
 
-.bpkdocs-side-nav-layout {
-  display: flex;
-  min-height: 35 * $bpk-spacing-xl;
-  overflow: hidden;
-
-  @include bpk-breakpoint-tablet {
-    min-height: 20 * $bpk-spacing-xl;
-  }
-
-  &__sidebar-destop-wrapper {
-    display: flex;
-
-    @include bpk-breakpoint-tablet {
-      display: none;
-    }
-  }
-
-  &__modal-content {
-    display: flex;
-    flex-direction: column;
-  }
-
-  &__main {
-    min-width: 0;
-    flex: 1;
-  }
-
+.bpkdocs-skip-link-page {
   &__skip-link {
     position: absolute;
-    top: 1rem;
-    left: 1rem;
   }
 }

--- a/docs/src/routes/Routes.js
+++ b/docs/src/routes/Routes.js
@@ -93,6 +93,7 @@ import RadioButtonPage from '../pages/components/RadioButton';
 import ScrollableCalendarPage from '../pages/components/ScrollableCalendar';
 import SectionListPage from '../pages/components/SectionList';
 import SlidersPage from '../pages/components/Sliders';
+import SkipLinkPage from '../pages/components/SkipLink';
 import SpinnerPage from '../pages/components/Spinner';
 import StarRatingPage from '../pages/components/StarRating';
 import SwitchPage from '../pages/components/Switch';
@@ -290,6 +291,7 @@ export const ROUTES_MAPPINGS = [
       },
       { path: ROUTES.SELECT, component: SelectPage },
       { path: ROUTES.SLIDER, component: SlidersPage },
+      { path: ROUTES.SKIP_LINK, component: SkipLinkPage },
       { path: ROUTES.SPINNER, component: SpinnerPage },
       {
         path: ROUTES.STAR_RATING,

--- a/docs/src/static-pages/developer-accessibility.mdx
+++ b/docs/src/static-pages/developer-accessibility.mdx
@@ -379,6 +379,7 @@ Many travellers interact with websites and apps using a keyboard, switch, or alt
 
 Make sure all interactive elements can be tabbed to in a predictable order, and activated without using a mouse or touching a screen.
 
+If large menus of filters are present on the page. Provide skip links for jumping over them to the main content. See [`BpkSkipLink`](components/skip-link?platform=web).
 
 ### **Tips**
 - Non-functional elements should not be focusable

--- a/package-lock.json
+++ b/package-lock.json
@@ -9866,6 +9866,32 @@
         "prop-types": "^15.6.2"
       }
     },
+    "bpk-component-skip-link": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bpk-component-skip-link/-/bpk-component-skip-link-1.0.1.tgz",
+      "integrity": "sha512-QBlnZyC+xSUOKkU2z8TdPASyMeqMLqXSUtFqerxHI+0vqGX0Pwp5PLNx/fhbH8lOB6X92AH75oANsQgP+PMMFQ==",
+      "requires": {
+        "bpk-mixins": "^20.1.12",
+        "bpk-react-utils": "^3.0.7",
+        "prop-types": "^15.5.8"
+      },
+      "dependencies": {
+        "bpk-mixins": {
+          "version": "20.1.12",
+          "resolved": "https://registry.npmjs.org/bpk-mixins/-/bpk-mixins-20.1.12.tgz",
+          "integrity": "sha512-KtdHUNzjwtv1G1cv1wY6vYnwtsYP3RI7N6nTscrqvL3OfqbuHCWp1cR5Jjfo/8pX13nXpSuT+YZ7PHiywnV6fw==",
+          "requires": {
+            "bpk-svgs": "^12.2.3",
+            "bpk-tokens": "^36.0.1"
+          }
+        },
+        "bpk-svgs": {
+          "version": "12.2.3",
+          "resolved": "https://registry.npmjs.org/bpk-svgs/-/bpk-svgs-12.2.3.tgz",
+          "integrity": "sha512-q/nUHx5hXmNKcoBvHVj9is+vJ1wUrL+ZjknWPwXpBOdDAe8uNhxESyBSu8J9ccZlwvzj5fx5NBbY7UzTyXPKKA=="
+        }
+      }
+    },
     "bpk-component-slider": {
       "version": "2.0.92",
       "resolved": "https://registry.npmjs.org/bpk-component-slider/-/bpk-component-slider-2.0.92.tgz",

--- a/package.json
+++ b/package.json
@@ -251,6 +251,7 @@
     "not ie < 9"
   ],
   "dependencies": {
+    "bpk-component-skip-link": "^1.0.1",
     "get-contrast-ratio": "^0.2.1"
   },
   "snyk": true

--- a/package.json
+++ b/package.json
@@ -137,6 +137,7 @@
     "bpk-component-scrollable-calendar": "2.0.93",
     "bpk-component-section-list": "2.0.91",
     "bpk-component-select": "3.0.90",
+    "bpk-component-skip-link": "^1.0.1",
     "bpk-component-slider": "2.0.92",
     "bpk-component-spinner": "3.1.19",
     "bpk-component-star-rating": "2.1.88",
@@ -251,7 +252,6 @@
     "not ie < 9"
   ],
   "dependencies": {
-    "bpk-component-skip-link": "^1.0.1",
     "get-contrast-ratio": "^0.2.1"
   },
   "snyk": true


### PR DESCRIPTION
I also added one at the top of the doc page:
![Screenshot 2020-12-10 at 14 46 01](https://user-images.githubusercontent.com/30267516/101786945-70934e80-3af6-11eb-8f9d-09018d35edde.png)

![Screenshot 2020-12-10 at 14 45 51](https://user-images.githubusercontent.com/30267516/101787204-bbad6180-3af6-11eb-8952-01aeeb0f45ca.png)

![Screenshot_2020-12-10 Skip link Backpack](https://user-images.githubusercontent.com/30267516/101786853-58233400-3af6-11eb-9589-053b7722010d.png)

<!--
Thanks for contributing to Backpack :pray:
Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack/blob/master/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] [Links platform metadata](https://github.com/Skyscanner/backpack-docs/blob/master/docs/src/layouts/links.js)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
