### PR TITLE
[No Jira] Fix metadata on Slack

### DIFF
--- a/docs/src/index.js
+++ b/docs/src/index.js
@@ -36,6 +36,7 @@ import Routes, { ROUTES_MAPPINGS } from './routes';
 import template from './template';
 import { extractAssets } from './webpackStats';
 import TopBanner from './components/TopBanner/TopBanner';
+import Meta from './meta';
 
 /*
  In our Webpack config file, we allow the base path to be set,
@@ -74,6 +75,7 @@ if (typeof window !== 'undefined' && typeof document !== 'undefined') {
   ReactDOM.render(
     <BrowserRouter basename={basePath}>
       <ScrollToTop>
+        <Meta basePath={basePath} />
         {basePath !== '' && (
           <TopBanner>
             <strong>Pull request build</strong>

--- a/docs/src/meta.js
+++ b/docs/src/meta.js
@@ -1,0 +1,79 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2016-2019 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* @flow strict */
+
+import React from 'react';
+import Helmet from 'react-helmet';
+
+type Props = {
+  basePath: string,
+};
+
+const Meta = (props: Props) => {
+  const { basePath } = props;
+
+  return (
+    <Helmet>
+      <meta charset="utf-8" />
+      <meta httpEquiv="x-ua-compatible" content="ie=edge" />
+      <meta name="viewport" content="width=device-width, initial-scale=1" />
+      <meta name="robots" content="noindex" />
+
+      <meta
+        property="description"
+        content="Backpack is Skyscanner's open-source design system."
+      />
+
+      <meta
+        property="og:description"
+        content="Backpack is Skyscanner's open-source design system."
+      />
+      <meta
+        property="og:image"
+        content={`https://backpack.github.io${basePath}/social-preview.png`}
+      />
+      <meta property="og:image:width" content="256" />
+      <meta property="og:image:height" content="256" />
+      <meta property="og:locale" content="en_GB" />
+      <meta property="og:site_name" content="Backpack" />
+      <meta property="og:title" content="Backpack" />
+      <meta property="og:type" content="website" />
+      <meta
+        property="og:url"
+        content={`https://backpack.github.io${basePath}"`}
+      />
+
+      <meta property="twitter:card" content="summary" />
+      <meta property="twitter:creator" content="@skyscanner" />
+      <meta
+        property="twitter:image"
+        content={`https://backpack.github.io${basePath}/social-preview.png`}
+      />
+      <meta
+        property="twitter:image:alt"
+        content="Backpack — Skyscanner's design system"
+      />
+      <meta property="twitter:title" content="Backpack" />
+      <meta property="twitter:site" content="@skyscanner" />
+      <meta property="twitter:title" content="Backpack" />
+    </Helmet>
+  );
+};
+
+export default Meta;

--- a/docs/src/template.js
+++ b/docs/src/template.js
@@ -31,32 +31,6 @@ export default ({
 <html lang="en">
 
 <head>
-  <meta charset="utf-8">
-  <meta http-equiv="x-ua-compatible" content="ie=edge">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="robots" content="noindex">
-
-  <meta property="description" content="Backpack is Skyscanner's open-source design system.">
-
-  <meta property="og:description" content="Backpack is Skyscanner's open-source design system.">
-  <meta property="og:image" content="https://backpack.github.io${basePath}/social-preview.png">
-  <meta property="og:image:width" content="256">
-  <meta property="og:image:height" content="256">
-  <meta property="og:locale" content="en_GB">
-  <meta property="og:site_name" content="Backpack">
-  <meta property="og:site_name" content="Backpack">
-  <meta property="og:title" content="Backpack">
-  <meta property="og:type" content="website">
-  <meta property="og:url" content="https://backpack.github.io${basePath}">
-
-  <meta property="twitter:card" content="summary">
-  <meta property="twitter:creator" content="@skyscanner">
-  <meta property="twitter:image" content="https://backpack.github.io${basePath}/social-preview.png">
-  <meta property="twitter:image:alt" content="Backpack — Skyscanner's design system">
-  <meta property="twitter:title" content="Backpack">
-  <meta property="twitter:site" content="@skyscanner">
-  <meta property="twitter:title" content="Backpack">
-
   ${head.title.toString()}
   ${head.meta.toString()}
   <link rel="stylesheet" href="${basePath}/${assets.docs.css}">


### PR DESCRIPTION
Previously our document head contained two sets of meta tags and we were relying on sites to take the latest ones. This works on Twitter but not Slack.

This PR puts our meta tags into `react-helmet` so they can be overridden. See below for a screenshot of the animation page's meta tags. Note how there is only one set of `og:description` and `og:title` now. This means that Slack should correctly preview our pages.

<img width="818" alt="Screen Shot 2020-12-15 at 16 35 51" src="https://user-images.githubusercontent.com/73652/102244544-58577100-3ef4-11eb-9477-dde5afc48f29.png">
