### PR TITLE
[BPK-4332] Rephrase icons page

### DIFF
--- a/docs/src/pages/components/Icon/DesignIconPage.js
+++ b/docs/src/pages/components/Icon/DesignIconPage.js
@@ -61,10 +61,10 @@ const blurb = [
   </IntroBlurb>,
   <Heading level="h2">Find the right icon</Heading>,
   <Paragraph>
-    Icons are provided in two sizes: small (18px) and large (24px). Both are
-    pixel-snapped for clarity at the intended usage sizes.
+    On web, icons are available at 18px and 24px. In apps, icons are available
+    at 16px and 24px.
   </Paragraph>,
-  <Paragraph>Note that some icons are only available at one size.</Paragraph>,
+  <Paragraph>Some icons are only available at one size.</Paragraph>,
   <IconSearchApp icons={iconsFinal} />,
   <Paragraph>
     <BpkButton href={`/${iconsSvgs}`}>


### PR DESCRIPTION
I also removed this:

> Both are pixel-snapped for clarity at the intended usage sizes.

I have no idea what this means, so it's unlikely consumers will.