### PR TITLE
[BPK-4418]: Fixing Relative font loading by opting into font loading from bpk-stylesheets

### DIFF
--- a/docs/src/index.js
+++ b/docs/src/index.js
@@ -19,8 +19,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import 'bpk-stylesheets/base';
+import 'bpk-stylesheets/font';
 import ReactDOM from 'react-dom';
 import 'bpk-stylesheets/base.css';
+import 'bpk-stylesheets/font.css';
 import Helmet from 'react-helmet';
 import ReactDOMServer from 'react-dom/server';
 import {


### PR DESCRIPTION
Fixed an issue where Relative was not loading on the docs site in Safari by opting the docs site into the font loading from the `bpk-stylesheets/font` import. As some time ago font loading was removed from `bpk-stylesheet/base` and required opt in to get the fonts

<!--
Thanks for contributing to Backpack :pray:
Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] [Links platform metadata](https://github.com/Skyscanner/backpack-docs/blob/main/docs/src/layouts/links.js)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_
