### PR TITLE
[No Jira] Fix code block display

### DIFF
--- a/docs/src/components/MDXContent/renderers.js
+++ b/docs/src/components/MDXContent/renderers.js
@@ -49,14 +49,9 @@ const Renderer = () => {
   renderers.a = BpkLink;
   renderers.blockquote = BpkBlockquote;
 
-  renderers.code = (codeBlockProps: { value: string }) => {
-    const { value, ...codeBlockRest } = codeBlockProps;
-    return <BpkCodeBlock {...codeBlockRest}>{value}</BpkCodeBlock>;
-  };
-
-  renderers.pre = (codeBlockProps: { value: string }) => {
-    const { value, ...codeBlockRest } = codeBlockProps;
-    return <BpkCodeBlock {...codeBlockRest}>{value}</BpkCodeBlock>;
+  renderers.code = (codeBlockProps: { children: any }) => {
+    const { ...rest } = codeBlockProps;
+    return <BpkCodeBlock {...rest} alternate />;
   };
 
   TAG_NAMES.forEach(tag => {


### PR DESCRIPTION
On prod – where are the code blocks?
<img width="1015" alt="Screen Shot 2021-03-19 at 11 56 19" src="https://user-images.githubusercontent.com/73652/111776700-3af6c200-88aa-11eb-96a2-ffc5530852c1.png">

This PR – all fixed:
<img width="1043" alt="Screen Shot 2021-03-19 at 11 56 14" src="https://user-images.githubusercontent.com/73652/111776692-39c59500-88aa-11eb-9a54-d86d3e963fb5.png">
