### PR TITLE
[NO JIRA]: Excluding danger from running on dependabot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
 
       - name: Danger
         run: npm run danger
+        if: github.actor != 'dependabot[bot]'
         env:
           GITHUB_TOKEN: ${{ secrets.DANGER_GITHUB_API_TOKEN }}
 


### PR DESCRIPTION
All our dependabot PRs are failing when it comes to the Danger step in CI, which is due to how it has access to the token and uses it - means that this step fails due to the token not working for 'bots'.

This PR excludes the danger step from any PR builds which can be verfied CI passes with this on #957 - https://github.com/Skyscanner/backpack-docs/runs/2325786683?check_suite_focus=true. 