### PR TITLE
Adding Range calendar docs examples

### DIFF
--- a/docs/src/pages/components/Calendar/WebCalendar.mdx
+++ b/docs/src/pages/components/Calendar/WebCalendar.mdx
@@ -12,7 +12,8 @@ import {
   DefaultExample,
   CalendarNavExample,
   CalendarGridAndHeaderExample,
-  ArabicExample
+  ArabicExample,
+  RangeDateCalendar
 } from 'bpk-component-calendar/examples'
 
 ## Table of contents
@@ -23,6 +24,14 @@ The default calendar configuration includes navigation to select months, select 
 
 <PresentationBlock>
   <DefaultExample />
+</PresentationBlock>
+
+## Range
+
+The calendar can be configured to support ranges between two dates.
+
+<PresentationBlock>
+  <RangeDateCalendar />
 </PresentationBlock>
 
 ## Localised

--- a/docs/src/pages/components/Datepicker/WebDatepicker.mdx
+++ b/docs/src/pages/components/Datepicker/WebDatepicker.mdx
@@ -9,7 +9,9 @@ import PresentationBlock from 'components/PresentationBlock';
 import Readme from 'bpk-component-datepicker/README.md';
 
 import {
-  DefaultExample
+  DefaultExample,
+  RangeExample,
+  MultipleRangeInputExample
 } from 'bpk-component-datepicker/examples';
 
 ## Table of contents
@@ -20,6 +22,22 @@ Default calendar, input and popover configuration. See the [BpkCalendar document
 
 <PresentationBlock>
   <DefaultExample />
+</PresentationBlock>
+
+## With Ranges
+
+The datepicker can be configured to support ranges.
+
+<PresentationBlock>
+  <RangeExample />
+</PresentationBlock>
+
+## With multiple inputs
+
+If the datepicker is configured to use range mode the datepicker can be configured to open when supplying multiple inputs and triggering the same calendar to input a start and end date.
+
+<PresentationBlock>
+  <MultipleRangeInputExample />
 </PresentationBlock>
 
 ## Implementation


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:
Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

Adding range examples for Calendar and Datepicker.

Currently excluding the Scrollable Calendar due to a visual bug when using ranges which is currently a fix in progress

Remember to include the following changes:
+ [ ] [Links platform metadata](https://github.com/Skyscanner/backpack-docs/blob/main/docs/src/layouts/links.js)
