### PR TITLE
KOA-4773 Add compose platform docs

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,5 +3,6 @@ flow-typed
 dist
 coverage
 backpack-android
+backpack-compose
 backpack-ios
 backpack-react-native

--- a/.prettierignore
+++ b/.prettierignore
@@ -3,5 +3,6 @@ flow-typed
 dist
 coverage
 backpack-android
+backpack-compose
 backpack-ios
 backpack-react-native

--- a/.spelling
+++ b/.spelling
@@ -205,6 +205,7 @@ ja-JP
 
 # Filenames, repos
 backpack-android
+backpack-compose
 backpack-ios
 backpack-react-native
 contributing.md

--- a/docs/src/components/DocsPageWrapper/DocsPageWrapper.js
+++ b/docs/src/components/DocsPageWrapper/DocsPageWrapper.js
@@ -39,7 +39,7 @@ import STYLES from './DocsPageWrapper.scss';
 const getClassName = cssModules(STYLES);
 
 const contentShape = PropTypes.oneOfType([PropTypes.string, PropTypes.node]);
-const platformQueryParamRegex = /platform=(design|android|ios|native|web)/;
+const platformQueryParamRegex = /platform=(design|android|ios|native|web|compose)/;
 
 const PlatformNav = ({
   platform,
@@ -47,10 +47,12 @@ const PlatformNav = ({
   onNativeClick,
   onWebClick,
   onAndroidClick,
+  onComposeClick,
   onIOSClick,
   disableNativeTab,
   disableWebTab,
   disableAndroidTab,
+  disableComposeTab,
   disableIOSTab,
 }) => (
   <BpkHorizontalNav
@@ -71,6 +73,14 @@ const PlatformNav = ({
       onClick={onAndroidClick}
     >
       Android
+    </BpkHorizontalNavItem>
+    <BpkHorizontalNavItem
+      name="compose"
+      disabled={disableComposeTab}
+      selected={platform === 'compose'}
+      onClick={onComposeClick}
+    >
+      Compose (Preview)
     </BpkHorizontalNavItem>
     <BpkHorizontalNavItem
       name="ios"
@@ -100,14 +110,22 @@ const PlatformNav = ({
 );
 
 PlatformNav.propTypes = {
-  platform: PropTypes.oneOf(['design', 'android', 'ios', 'native', 'web'])
-    .isRequired,
+  platform: PropTypes.oneOf([
+    'design',
+    'android',
+    'ios',
+    'native',
+    'web',
+    'compose',
+  ]).isRequired,
   onDesignClick: PropTypes.func.isRequired,
   onAndroidClick: PropTypes.func.isRequired,
+  onComposeClick: PropTypes.func.isRequired,
   onIOSClick: PropTypes.func.isRequired,
   onNativeClick: PropTypes.func.isRequired,
   onWebClick: PropTypes.func.isRequired,
   disableAndroidTab: PropTypes.bool.isRequired,
+  disableComposeTab: PropTypes.bool.isRequired,
   disableIOSTab: PropTypes.bool.isRequired,
   disableNativeTab: PropTypes.bool.isRequired,
   disableWebTab: PropTypes.bool.isRequired,
@@ -118,6 +136,7 @@ const DocsPageWrapper = props => {
     blurb,
     designSubpage,
     androidSubpage,
+    composeSubpage,
     iosSubpage,
     nativeSubpage,
     webSubpage,
@@ -131,6 +150,7 @@ const DocsPageWrapper = props => {
   const platforms = {
     design: designSubpage || <DesignPlaceholderPage />,
     android: androidSubpage,
+    compose: composeSubpage,
     ios: iosSubpage,
     native: nativeSubpage,
     web: webSubpage,
@@ -151,6 +171,8 @@ const DocsPageWrapper = props => {
     initiallySelectedPlatform = 'design';
   } else if (androidSubpage) {
     initiallySelectedPlatform = 'android';
+  } else if (composeSubpage) {
+    initiallySelectedPlatform = 'compose';
   } else if (iosSubpage) {
     initiallySelectedPlatform = 'ios';
   } else if (nativeSubpage) {
@@ -189,10 +211,12 @@ const DocsPageWrapper = props => {
           platform={initiallySelectedPlatform}
           onDesignClick={() => onPlatformClick('design')}
           onAndroidClick={() => onPlatformClick('android')}
+          onComposeClick={() => onPlatformClick('compose')}
           onIOSClick={() => onPlatformClick('ios')}
           onNativeClick={() => onPlatformClick('native')}
           onWebClick={() => onPlatformClick('web')}
           disableAndroidTab={!androidSubpage}
+          disableComposeTab={!composeSubpage}
           disableIOSTab={!iosSubpage}
           disableNativeTab={!nativeSubpage}
           disableWebTab={!webSubpage}
@@ -221,6 +245,7 @@ DocsPageWrapper.propTypes = {
   webSubpage: PropTypes.element,
   nativeSubpage: PropTypes.element,
   androidSubpage: PropTypes.element,
+  composeSubpage: PropTypes.element,
   iosSubpage: PropTypes.element,
 };
 
@@ -230,6 +255,7 @@ DocsPageWrapper.defaultProps = {
   webSubpage: null,
   nativeSubpage: null,
   androidSubpage: null,
+  composeSubpage: null,
   iosSubpage: null,
 };
 

--- a/docs/src/components/MarkdownPage/AdditionalLinks.js
+++ b/docs/src/components/MarkdownPage/AdditionalLinks.js
@@ -206,7 +206,7 @@ const AdditionalLinks = (props: Props) => {
         {/* Android compose GitHub link */}
         {platform && platform === PLATFORMS.compose && githubPath && (
           <BpkLink
-            href={`https://github.com/Skyscanner/backpack-android/tree/main/backpack-compose/src/main/java/net/skyscanner/backpack/compose/${githubPath}`}
+            href={`https://github.com/Skyscanner/backpack-android/tree/main/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/${githubPath}`}
             blank
             className={getClassName('bpkdocs-markdown-page__link')}
           >

--- a/docs/src/components/MarkdownPage/AdditionalLinks.js
+++ b/docs/src/components/MarkdownPage/AdditionalLinks.js
@@ -33,6 +33,7 @@ export const PLATFORMS = {
   android: 'android',
   ios: 'ios',
   native: 'native',
+  compose: 'compose',
   web: 'web',
 };
 
@@ -60,7 +61,7 @@ const AdditionalLinks = (props: Props) => {
   return (
     <div className={getClassName('bpkdocs-markdown-page__additional-links')}>
       <div>
-        {/* Maven Central link */}
+        {/* Android view Maven Central link */}
         {platform && platform === PLATFORMS.android && (
           <BpkLink
             href="https://search.maven.org/artifact/net.skyscanner.backpack/backpack-android"
@@ -69,6 +70,20 @@ const AdditionalLinks = (props: Props) => {
           >
             <img
               src="https://img.shields.io/maven-central/v/net.skyscanner.backpack/backpack-android"
+              alt="View on Maven Central"
+            />
+          </BpkLink>
+        )}
+
+        {/* Android compose Maven Central link */}
+        {platform && platform === PLATFORMS.compose && (
+          <BpkLink
+            href="https://search.maven.org/artifact/net.skyscanner.backpack/backpack-compose"
+            blank
+            className={getClassName('bpkdocs-markdown-page__link')}
+          >
+            <img
+              src="https://img.shields.io/maven-central/v/net.skyscanner.backpack/backpack-compose"
               alt="View on Maven Central"
             />
           </BpkLink>
@@ -132,10 +147,24 @@ const AdditionalLinks = (props: Props) => {
           </BpkLink>
         )}
 
-        {/* Android documentation link */}
+        {/* Android view documentation link */}
         {platform && platform === PLATFORMS.android && documentationId && (
           <BpkLink
             href={`/android/Backpack/${documentationId}`}
+            blank
+            className={getClassName('bpkdocs-markdown-page__link')}
+          >
+            <img
+              src="https://img.shields.io/badge/Class%20reference-Android-blue"
+              alt="View class reference"
+            />
+          </BpkLink>
+        )}
+
+        {/* Android compose documentation link */}
+        {platform && platform === PLATFORMS.compose && documentationId && (
+          <BpkLink
+            href={`/android/backpack-compose/${documentationId}`}
             blank
             className={getClassName('bpkdocs-markdown-page__link')}
           >
@@ -160,10 +189,24 @@ const AdditionalLinks = (props: Props) => {
           </BpkLink>
         )}
 
-        {/* Android GitHub link */}
+        {/* Android view GitHub link */}
         {platform && platform === PLATFORMS.android && githubPath && (
           <BpkLink
             href={`https://github.com/Skyscanner/backpack-android/tree/main/Backpack/src/main/java/net/skyscanner/backpack/${githubPath}`}
+            blank
+            className={getClassName('bpkdocs-markdown-page__link')}
+          >
+            <img
+              src="https://img.shields.io/badge/Source%20code-GitHub-lightgrey"
+              alt="View source code on GitHub"
+            />
+          </BpkLink>
+        )}
+
+        {/* Android compose GitHub link */}
+        {platform && platform === PLATFORMS.compose && githubPath && (
+          <BpkLink
+            href={`https://github.com/Skyscanner/backpack-android/tree/main/backpack-compose/src/main/java/net/skyscanner/backpack/compose/${githubPath}`}
             blank
             className={getClassName('bpkdocs-markdown-page__link')}
           >

--- a/docs/src/components/PageSearch/PageSearch.js
+++ b/docs/src/components/PageSearch/PageSearch.js
@@ -32,7 +32,7 @@ import { getMatchingPages } from './search';
 const FlattenedLinks = flatMap(LINKS, section => section.links);
 
 const convertTagsToPlatformsString = (
-  tags: ?Array<'android' | 'ios' | 'native' | 'web'>,
+  tags: ?Array<'android' | 'ios' | 'native' | 'web' | 'compose'>,
 ): ?string => {
   if (!tags) {
     return null;
@@ -40,6 +40,9 @@ const convertTagsToPlatformsString = (
   const platforms = [];
   if (tags.indexOf('android') !== -1) {
     platforms.push('Android');
+  }
+  if (tags.indexOf('compose') !== -1) {
+    platforms.push('Compose (Preview)');
   }
   if (tags.indexOf('ios') !== -1) {
     platforms.push('iOS');

--- a/docs/src/layouts/SideNavLayout/NavListFilter.js
+++ b/docs/src/layouts/SideNavLayout/NavListFilter.js
@@ -29,6 +29,7 @@ const OPTIONS = {
   web: 'web',
   native: 'native',
   android: 'android',
+  compose: 'compose',
   ios: 'ios',
 };
 
@@ -87,6 +88,18 @@ const NavListFilter = (props: Props) => (
       onChange={e =>
         e.currentTarget.value === OPTIONS.android &&
         props.onSelectedFilterChange(OPTIONS.android)
+      }
+      white
+    />
+    <BpkRadio
+      className={getClassName('bpkdocs-nav-list-filter__option')}
+      value={OPTIONS.compose}
+      name="filter"
+      label="Compose (Preview)"
+      checked={props.selected === OPTIONS.compose}
+      onChange={e =>
+        e.currentTarget.value === OPTIONS.compose &&
+        props.onSelectedFilterChange(OPTIONS.compose)
       }
       white
     />

--- a/docs/src/layouts/links.js
+++ b/docs/src/layouts/links.js
@@ -53,7 +53,7 @@ const ComponentsLinks = [
         id: 'TEXT',
         route: routes.TEXT,
         children: 'Text',
-        tags: ['web', 'native', 'android', 'ios'],
+        tags: ['web', 'native', 'android', 'ios', 'compose'],
       },
       {
         id: 'LINK',

--- a/docs/src/pages/components/Badge/AndroidBadge.mdx
+++ b/docs/src/pages/components/Badge/AndroidBadge.mdx
@@ -8,9 +8,9 @@ githubPath: badge
 
 import AndroidComponentScreenshots from 'components/Screenshots/AndroidComponentScreenshots';
 
-import Readme from 'backpack-android/docs/Badge/README.md';
-import screenshotAll from 'backpack-android/docs/Badge/screenshots/all.png';
-import screenshotAllDm from 'backpack-android/docs/Badge/screenshots/all_dm.png';
+import Readme from 'backpack-android/docs/view/Badge/README.md';
+import screenshotAll from 'backpack-android/docs/view/Badge/screenshots/all.png';
+import screenshotAllDm from 'backpack-android/docs/view/Badge/screenshots/all_dm.png';
 
 ## Table of contents
 

--- a/docs/src/pages/components/Barcharts/AndroidBarChart.mdx
+++ b/docs/src/pages/components/Barcharts/AndroidBarChart.mdx
@@ -8,10 +8,10 @@ githubPath: barchart
 
 import AndroidComponentScreenshots from 'components/Screenshots/AndroidComponentScreenshots';
 
-import Readme from 'backpack-android/docs/BarChart/README.md';
+import Readme from 'backpack-android/docs/view/BarChart/README.md';
 
-import screenshotDefault from 'backpack-android/docs/BarChart/screenshots/default.png';
-import screenshotDefaultDm from 'backpack-android/docs/BarChart/screenshots/default_dm.png';
+import screenshotDefault from 'backpack-android/docs/view/BarChart/screenshots/default.png';
+import screenshotDefaultDm from 'backpack-android/docs/view/BarChart/screenshots/default_dm.png';
 
 
 ## Table of contents

--- a/docs/src/pages/components/BottomNav/AndroidBottomNav.mdx
+++ b/docs/src/pages/components/BottomNav/AndroidBottomNav.mdx
@@ -8,10 +8,10 @@ githubPath: bottomnav
 
 import AndroidComponentScreenshots from 'components/Screenshots/AndroidComponentScreenshots';
 
-import Readme from 'backpack-android/docs/BottomNav/README.md';
+import Readme from 'backpack-android/docs/view/BottomNav/README.md';
 
-import screenshotDefault from 'backpack-android/docs/BottomNav/screenshots/default.png';
-import screenshotDefaultDm from 'backpack-android/docs/BottomNav/screenshots/default_dm.png';
+import screenshotDefault from 'backpack-android/docs/view/BottomNav/screenshots/default.png';
+import screenshotDefaultDm from 'backpack-android/docs/view/BottomNav/screenshots/default_dm.png';
 
 ## Table of contents
 

--- a/docs/src/pages/components/BottomSheet/AndroidBottomSheet.mdx
+++ b/docs/src/pages/components/BottomSheet/AndroidBottomSheet.mdx
@@ -8,10 +8,10 @@ githubPath: BottomNav
 
 import AndroidComponentScreenshots from 'components/Screenshots/AndroidComponentScreenshots';
 
-import Readme from 'backpack-android/docs/BottomSheet/README.md';
+import Readme from 'backpack-android/docs/view/BottomSheet/README.md';
 
-import screenshotDefault from 'backpack-android/docs/BottomSheet/screenshots/default.png';
-import screenshotDefaultDm from 'backpack-android/docs/BottomSheet/screenshots/default_dm.png';
+import screenshotDefault from 'backpack-android/docs/view/BottomSheet/screenshots/default.png';
+import screenshotDefaultDm from 'backpack-android/docs/view/BottomSheet/screenshots/default_dm.png';
 
 ## Table of contents
 

--- a/docs/src/pages/components/Button/AndroidButton.mdx
+++ b/docs/src/pages/components/Button/AndroidButton.mdx
@@ -8,21 +8,21 @@ githubPath: button
 
 import AndroidComponentScreenshots from 'components/Screenshots/AndroidComponentScreenshots';
 
-import ButtonReadme from 'backpack-android/docs/Button/README.md';
-import LinkReadme from 'backpack-android/docs/ButtonLink/README.md';
+import ButtonReadme from 'backpack-android/docs/view/Button/README.md';
+import LinkReadme from 'backpack-android/docs/view/ButtonLink/README.md';
 
-import screenshotPrimary from 'backpack-android/docs/Button/screenshots/primary.png';
-import screenshotPrimaryDm from 'backpack-android/docs/Button/screenshots/primary_dm.png';
-import screenshotSecondary from 'backpack-android/docs/Button/screenshots/secondary.png';
-import screenshotSecondaryDm from 'backpack-android/docs/Button/screenshots/secondary_dm.png';
-import screenshotDestructive from 'backpack-android/docs/Button/screenshots/destructive.png';
-import screenshotDestructiveDm from 'backpack-android/docs/Button/screenshots/destructive_dm.png';
-import screenshotOutline from 'backpack-android/docs/Button/screenshots/outline.png';
-import screenshotOutlineDm from 'backpack-android/docs/Button/screenshots/outline_dm.png';
-import screenshotFeatured from 'backpack-android/docs/Button/screenshots/featured.png';
-import screenshotFeaturedDm from 'backpack-android/docs/Button/screenshots/featured_dm.png';
-import screenshotLink from 'backpack-android/docs/ButtonLink/screenshots/default.png';
-import screenshotLinkDm from 'backpack-android/docs/ButtonLink/screenshots/default_dm.png';
+import screenshotPrimary from 'backpack-android/docs/view/Button/screenshots/primary.png';
+import screenshotPrimaryDm from 'backpack-android/docs/view/Button/screenshots/primary_dm.png';
+import screenshotSecondary from 'backpack-android/docs/view/Button/screenshots/secondary.png';
+import screenshotSecondaryDm from 'backpack-android/docs/view/Button/screenshots/secondary_dm.png';
+import screenshotDestructive from 'backpack-android/docs/view/Button/screenshots/destructive.png';
+import screenshotDestructiveDm from 'backpack-android/docs/view/Button/screenshots/destructive_dm.png';
+import screenshotOutline from 'backpack-android/docs/view/Button/screenshots/outline.png';
+import screenshotOutlineDm from 'backpack-android/docs/view/Button/screenshots/outline_dm.png';
+import screenshotFeatured from 'backpack-android/docs/view/Button/screenshots/featured.png';
+import screenshotFeaturedDm from 'backpack-android/docs/view/Button/screenshots/featured_dm.png';
+import screenshotLink from 'backpack-android/docs/view/ButtonLink/screenshots/default.png';
+import screenshotLinkDm from 'backpack-android/docs/view/ButtonLink/screenshots/default_dm.png';
 
 ## Table of contents
 

--- a/docs/src/pages/components/Calendar/AndroidCalendar.mdx
+++ b/docs/src/pages/components/Calendar/AndroidCalendar.mdx
@@ -8,11 +8,11 @@ githubPath: calendar2
 
 import AndroidComponentScreenshots from 'components/Screenshots/AndroidComponentScreenshots';
 
-import Readme from 'backpack-android/docs/Calendar2/README.md';
-import screenshotAll from 'backpack-android/docs/Calendar2/screenshots/range.png';
-import screenshotAllDm from 'backpack-android/docs/Calendar2/screenshots/range_dm.png';
-import screenshotColored from 'backpack-android/docs/Calendar2/screenshots/colored.png';
-import screenshotColoredDm from 'backpack-android/docs/Calendar2/screenshots/colored_dm.png';
+import Readme from 'backpack-android/docs/view/Calendar2/README.md';
+import screenshotAll from 'backpack-android/docs/view/Calendar2/screenshots/range.png';
+import screenshotAllDm from 'backpack-android/docs/view/Calendar2/screenshots/range_dm.png';
+import screenshotColored from 'backpack-android/docs/view/Calendar2/screenshots/colored.png';
+import screenshotColoredDm from 'backpack-android/docs/view/Calendar2/screenshots/colored_dm.png';
 
 ## Table of contents
 

--- a/docs/src/pages/components/Card/AndroidCard.mdx
+++ b/docs/src/pages/components/Card/AndroidCard.mdx
@@ -8,23 +8,23 @@ githubPath: card
 
 import AndroidComponentScreenshots from 'components/Screenshots/AndroidComponentScreenshots';
 
-import Readme from 'backpack-android/docs/Card/README.md';
-import screenshotDefault from 'backpack-android/docs/Card/screenshots/default.png';
-import screenshotDefaultDm from 'backpack-android/docs/Card/screenshots/default_dm.png';
-import screenshotCornerStyleLarge from 'backpack-android/docs/Card/screenshots/corner-style-large.png';
-import screenshotCornerStyleLargeDm from 'backpack-android/docs/Card/screenshots/corner-style-large_dm.png';
-import screenshotSelected from 'backpack-android/docs/Card/screenshots/selected.png';
-import screenshotSelectedDm from 'backpack-android/docs/Card/screenshots/selected_dm.png';
-import screenshotWithoutPadding from 'backpack-android/docs/Card/screenshots/without-padding.png';
-import screenshotWithoutPaddingDm from 'backpack-android/docs/Card/screenshots/without-padding_dm.png';
-import screenshotWithDivider from 'backpack-android/docs/Card/screenshots/with-divider.png';
-import screenshotWithDividerDm from 'backpack-android/docs/Card/screenshots/with-divider_dm.png';
-import screenshotWithDividerArrangedVertically from 'backpack-android/docs/Card/screenshots/with-divider-arranged-vertically.png';
-import screenshotWithDividerArrangedVerticallyDm from 'backpack-android/docs/Card/screenshots/with-divider-arranged-vertically_dm.png';
-import screenshotWithDividerCornerStyleLarge from 'backpack-android/docs/Card/screenshots/with-divider-and-corner-style-large.png';
-import screenshotWithDividerCornerStyleLargeDm from 'backpack-android/docs/Card/screenshots/with-divider-and-corner-style-large_dm.png';
-import screenshotWithDividerWithoutPadding from 'backpack-android/docs/Card/screenshots/with-divider-without-padding.png';
-import screenshotWithDividerWithoutPaddingDm from 'backpack-android/docs/Card/screenshots/with-divider-without-padding_dm.png';
+import Readme from 'backpack-android/docs/view/Card/README.md';
+import screenshotDefault from 'backpack-android/docs/view/Card/screenshots/default.png';
+import screenshotDefaultDm from 'backpack-android/docs/view/Card/screenshots/default_dm.png';
+import screenshotCornerStyleLarge from 'backpack-android/docs/view/Card/screenshots/corner-style-large.png';
+import screenshotCornerStyleLargeDm from 'backpack-android/docs/view/Card/screenshots/corner-style-large_dm.png';
+import screenshotSelected from 'backpack-android/docs/view/Card/screenshots/selected.png';
+import screenshotSelectedDm from 'backpack-android/docs/view/Card/screenshots/selected_dm.png';
+import screenshotWithoutPadding from 'backpack-android/docs/view/Card/screenshots/without-padding.png';
+import screenshotWithoutPaddingDm from 'backpack-android/docs/view/Card/screenshots/without-padding_dm.png';
+import screenshotWithDivider from 'backpack-android/docs/view/Card/screenshots/with-divider.png';
+import screenshotWithDividerDm from 'backpack-android/docs/view/Card/screenshots/with-divider_dm.png';
+import screenshotWithDividerArrangedVertically from 'backpack-android/docs/view/Card/screenshots/with-divider-arranged-vertically.png';
+import screenshotWithDividerArrangedVerticallyDm from 'backpack-android/docs/view/Card/screenshots/with-divider-arranged-vertically_dm.png';
+import screenshotWithDividerCornerStyleLarge from 'backpack-android/docs/view/Card/screenshots/with-divider-and-corner-style-large.png';
+import screenshotWithDividerCornerStyleLargeDm from 'backpack-android/docs/view/Card/screenshots/with-divider-and-corner-style-large_dm.png';
+import screenshotWithDividerWithoutPadding from 'backpack-android/docs/view/Card/screenshots/with-divider-without-padding.png';
+import screenshotWithDividerWithoutPaddingDm from 'backpack-android/docs/view/Card/screenshots/with-divider-without-padding_dm.png';
 
 ## Table of contents
 

--- a/docs/src/pages/components/Checkbox/AndroidCheckbox.mdx
+++ b/docs/src/pages/components/Checkbox/AndroidCheckbox.mdx
@@ -8,9 +8,9 @@ githubPath: checkbox
 
 import AndroidComponentScreenshots from 'components/Screenshots/AndroidComponentScreenshots';
 
-import Readme from 'backpack-android/docs/Checkbox/README.md';
-import screenshotDefault from 'backpack-android/docs/Checkbox/screenshots/default.png';
-import screenshotDefaultDm from 'backpack-android/docs/Checkbox/screenshots/default_dm.png';
+import Readme from 'backpack-android/docs/view/Checkbox/README.md';
+import screenshotDefault from 'backpack-android/docs/view/Checkbox/screenshots/default.png';
+import screenshotDefaultDm from 'backpack-android/docs/view/Checkbox/screenshots/default_dm.png';
 
 ## Table of contents
 

--- a/docs/src/pages/components/Chips/AndroidChip.mdx
+++ b/docs/src/pages/components/Chips/AndroidChip.mdx
@@ -8,13 +8,13 @@ githubPath: chip
 
 import AndroidComponentScreenshots from 'components/Screenshots/AndroidComponentScreenshots';
 
-import Readme from 'backpack-android/docs/Chip/README.md';
-import screenshotAll from 'backpack-android/docs/Chip/screenshots/all.png';
-import screenshotAllDm from 'backpack-android/docs/Chip/screenshots/all_dm.png';
-import screenshotOutline from 'backpack-android/docs/Chip/screenshots/outline.png';
-import screenshotOutlineDm from 'backpack-android/docs/Chip/screenshots/outline_dm.png';
-import screenshotIcon from 'backpack-android/docs/Chip/screenshots/with-icon.png';
-import screenshotIconDm from 'backpack-android/docs/Chip/screenshots/with-icon_dm.png';
+import Readme from 'backpack-android/docs/view/Chip/README.md';
+import screenshotAll from 'backpack-android/docs/view/Chip/screenshots/all.png';
+import screenshotAllDm from 'backpack-android/docs/view/Chip/screenshots/all_dm.png';
+import screenshotOutline from 'backpack-android/docs/view/Chip/screenshots/outline.png';
+import screenshotOutlineDm from 'backpack-android/docs/view/Chip/screenshots/outline_dm.png';
+import screenshotIcon from 'backpack-android/docs/view/Chip/screenshots/with-icon.png';
+import screenshotIconDm from 'backpack-android/docs/view/Chip/screenshots/with-icon_dm.png';
 
 ## Table of contents
 

--- a/docs/src/pages/components/Dialogs/AndroidDialog.mdx
+++ b/docs/src/pages/components/Dialogs/AndroidDialog.mdx
@@ -8,11 +8,11 @@ githubPath: dialog
 
 import AndroidComponentScreenshots from 'components/Screenshots/AndroidComponentScreenshots';
 
-import Readme from 'backpack-android/docs/Dialog/README.md';
-import screenshotAlert from 'backpack-android/docs/Dialog/screenshots/with-cta.png';
-import screenshotAlertDm from 'backpack-android/docs/Dialog/screenshots/with-cta_dm.png';
-import screenshotBottomSheet from 'backpack-android/docs/Dialog/screenshots/delete-confirmation.png';
-import screenshotBottomSheetDm from 'backpack-android/docs/Dialog/screenshots/delete-confirmation_dm.png';
+import Readme from 'backpack-android/docs/view/Dialog/README.md';
+import screenshotAlert from 'backpack-android/docs/view/Dialog/screenshots/with-cta.png';
+import screenshotAlertDm from 'backpack-android/docs/view/Dialog/screenshots/with-cta_dm.png';
+import screenshotBottomSheet from 'backpack-android/docs/view/Dialog/screenshots/delete-confirmation.png';
+import screenshotBottomSheetDm from 'backpack-android/docs/view/Dialog/screenshots/delete-confirmation_dm.png';
 
 ## Table of contents
 

--- a/docs/src/pages/components/Flare/AndroidFlare.mdx
+++ b/docs/src/pages/components/Flare/AndroidFlare.mdx
@@ -8,17 +8,17 @@ githubPath: flare
 
 import AndroidComponentScreenshots from 'components/Screenshots/AndroidComponentScreenshots';
 
-import Readme from 'backpack-android/docs/Flare/README.md';
-import screenshotDefault from 'backpack-android/docs/Flare/screenshots/default.png';
-import screenshotDefaultDm from 'backpack-android/docs/Flare/screenshots/default_dm.png';
-import screenshotRounded from 'backpack-android/docs/Flare/screenshots/rounded.png';
-import screenshotRoundedDm from 'backpack-android/docs/Flare/screenshots/rounded_dm.png';
-import screenshotPointerOffset from 'backpack-android/docs/Flare/screenshots/pointer-offset.png';
-import screenshotPointerOffsetDm from 'backpack-android/docs/Flare/screenshots/pointer-offset_dm.png';
-import screenshotInsetPadding from 'backpack-android/docs/Flare/screenshots/inset-padding.png';
-import screenshotInsetPaddingDm from 'backpack-android/docs/Flare/screenshots/inset-padding_dm.png';
-import screenshotPointingUp from 'backpack-android/docs/Flare/screenshots/pointing-up.png';
-import screenshotPointingUpDm from 'backpack-android/docs/Flare/screenshots/pointing-up_dm.png';
+import Readme from 'backpack-android/docs/view/Flare/README.md';
+import screenshotDefault from 'backpack-android/docs/view/Flare/screenshots/default.png';
+import screenshotDefaultDm from 'backpack-android/docs/view/Flare/screenshots/default_dm.png';
+import screenshotRounded from 'backpack-android/docs/view/Flare/screenshots/rounded.png';
+import screenshotRoundedDm from 'backpack-android/docs/view/Flare/screenshots/rounded_dm.png';
+import screenshotPointerOffset from 'backpack-android/docs/view/Flare/screenshots/pointer-offset.png';
+import screenshotPointerOffsetDm from 'backpack-android/docs/view/Flare/screenshots/pointer-offset_dm.png';
+import screenshotInsetPadding from 'backpack-android/docs/view/Flare/screenshots/inset-padding.png';
+import screenshotInsetPaddingDm from 'backpack-android/docs/view/Flare/screenshots/inset-padding_dm.png';
+import screenshotPointingUp from 'backpack-android/docs/view/Flare/screenshots/pointing-up.png';
+import screenshotPointingUpDm from 'backpack-android/docs/view/Flare/screenshots/pointing-up_dm.png';
 
 ## Table of contents
 

--- a/docs/src/pages/components/FloatingActionButton/AndroidFloatingActionButton.mdx
+++ b/docs/src/pages/components/FloatingActionButton/AndroidFloatingActionButton.mdx
@@ -8,9 +8,9 @@ githubPath: fab
 
 import AndroidComponentScreenshots from 'components/Screenshots/AndroidComponentScreenshots';
 
-import Readme from 'backpack-android/docs/FloatingActionButton/README.md';
-import screenshotDefault from 'backpack-android/docs/FloatingActionButton/screenshots/default.png';
-import screenshotDefaultDm from 'backpack-android/docs/FloatingActionButton/screenshots/default_dm.png';
+import Readme from 'backpack-android/docs/view/FloatingActionButton/README.md';
+import screenshotDefault from 'backpack-android/docs/view/FloatingActionButton/screenshots/default.png';
+import screenshotDefaultDm from 'backpack-android/docs/view/FloatingActionButton/screenshots/default_dm.png';
 
 ## Table of contents
 

--- a/docs/src/pages/components/HorizontalNav/AndroidHorizontalNav.mdx
+++ b/docs/src/pages/components/HorizontalNav/AndroidHorizontalNav.mdx
@@ -8,9 +8,9 @@ githubPath: horisontalnav
 
 import AndroidComponentScreenshots from 'components/Screenshots/AndroidComponentScreenshots';
 
-import Readme from 'backpack-android/docs/HorizontalNav/README.md';
-import screenshotDefault from 'backpack-android/docs/HorizontalNav/screenshots/default.png';
-import screenshotDefaultDm from 'backpack-android/docs/HorizontalNav/screenshots/default_dm.png';
+import Readme from 'backpack-android/docs/view/HorizontalNav/README.md';
+import screenshotDefault from 'backpack-android/docs/view/HorizontalNav/screenshots/default.png';
+import screenshotDefaultDm from 'backpack-android/docs/view/HorizontalNav/screenshots/default_dm.png';
 
 ## Table of contents
 

--- a/docs/src/pages/components/Icon/AndroidIcon.mdx
+++ b/docs/src/pages/components/Icon/AndroidIcon.mdx
@@ -6,9 +6,9 @@ platform: android
 
 import AndroidComponentScreenshots from 'components/Screenshots/AndroidComponentScreenshots';
 
-import Readme from 'backpack-android/docs/Icon/README.md';
-import screenshotAll from 'backpack-android/docs/Icon/screenshots/all.png';
-import screenshotAllDm from 'backpack-android/docs/Icon/screenshots/all_dm.png';
+import Readme from 'backpack-android/docs/view/Icon/README.md';
+import screenshotAll from 'backpack-android/docs/view/Icon/screenshots/all.png';
+import screenshotAllDm from 'backpack-android/docs/view/Icon/screenshots/all_dm.png';
 
 ## Table of contents
 

--- a/docs/src/pages/components/Map/AndroidMap.mdx
+++ b/docs/src/pages/components/Map/AndroidMap.mdx
@@ -8,13 +8,13 @@ githubPath: map
 
 import AndroidComponentScreenshots from 'components/Screenshots/AndroidComponentScreenshots';
 
-import Readme from 'backpack-android/docs/Maps/README.md';
-import screenshotPointers from 'backpack-android/docs/Maps/screenshots/pointers.png';
-import screenshotPointersDm from 'backpack-android/docs/Maps/screenshots/pointers_dm.png';
-import screenshotBadges from 'backpack-android/docs/Maps/screenshots/badges.png';
-import screenshotBadgesDm from 'backpack-android/docs/Maps/screenshots/badges_dm.png';
-import screenshotIcons from 'backpack-android/docs/Maps/screenshots/with_icons.png';
-import screenshotIconsDm from 'backpack-android/docs/Maps/screenshots/with_icons_dm.png';
+import Readme from 'backpack-android/docs/view/Maps/README.md';
+import screenshotPointers from 'backpack-android/docs/view/Maps/screenshots/pointers.png';
+import screenshotPointersDm from 'backpack-android/docs/view/Maps/screenshots/pointers_dm.png';
+import screenshotBadges from 'backpack-android/docs/view/Maps/screenshots/badges.png';
+import screenshotBadgesDm from 'backpack-android/docs/view/Maps/screenshots/badges_dm.png';
+import screenshotIcons from 'backpack-android/docs/view/Maps/screenshots/with_icons.png';
+import screenshotIconsDm from 'backpack-android/docs/view/Maps/screenshots/with_icons_dm.png';
 
 ## Table of contents
 

--- a/docs/src/pages/components/NavigationBar/AndroidNavBar.mdx
+++ b/docs/src/pages/components/NavigationBar/AndroidNavBar.mdx
@@ -8,13 +8,13 @@ githubPath: navbar
 
 import AndroidComponentScreenshots from 'components/Screenshots/AndroidComponentScreenshots';
 
-import Readme from 'backpack-android/docs/NavBar/README.md';
-import screenshotCollapsed from 'backpack-android/docs/NavBar/screenshots/collapsed.png';
-import screenshotCollapsedDm from 'backpack-android/docs/NavBar/screenshots/collapsed_dm.png';
-import screenshotExpanded from 'backpack-android/docs/NavBar/screenshots/expanded.png';
-import screenshotExpandedDm from 'backpack-android/docs/NavBar/screenshots/expanded_dm.png';
-import screenshotNavigation from 'backpack-android/docs/NavBar/screenshots/navigation.png';
-import screenshotNavigationDm from 'backpack-android/docs/NavBar/screenshots/navigation_dm.png';
+import Readme from 'backpack-android/docs/view/NavBar/README.md';
+import screenshotCollapsed from 'backpack-android/docs/view/NavBar/screenshots/collapsed.png';
+import screenshotCollapsedDm from 'backpack-android/docs/view/NavBar/screenshots/collapsed_dm.png';
+import screenshotExpanded from 'backpack-android/docs/view/NavBar/screenshots/expanded.png';
+import screenshotExpandedDm from 'backpack-android/docs/view/NavBar/screenshots/expanded_dm.png';
+import screenshotNavigation from 'backpack-android/docs/view/NavBar/screenshots/navigation.png';
+import screenshotNavigationDm from 'backpack-android/docs/view/NavBar/screenshots/navigation_dm.png';
 
 ## Table of contents
 

--- a/docs/src/pages/components/Nudger/AndroidNudger.mdx
+++ b/docs/src/pages/components/Nudger/AndroidNudger.mdx
@@ -7,9 +7,9 @@ githubPath: nudger
 
 import AndroidComponentScreenshots from 'components/Screenshots/AndroidComponentScreenshots';
 
-import Readme from 'backpack-android/docs/Nudger/README.md';
-import screenshotDefault from 'backpack-android/docs/Nudger/screenshots/all.png';
-import screenshotDefaultDm from 'backpack-android/docs/Nudger/screenshots/all_dm.png';
+import Readme from 'backpack-android/docs/view/Nudger/README.md';
+import screenshotDefault from 'backpack-android/docs/view/Nudger/screenshots/all.png';
+import screenshotDefaultDm from 'backpack-android/docs/view/Nudger/screenshots/all_dm.png';
 
 ## Table of contents
 

--- a/docs/src/pages/components/Overlay/AndroidOverlay.mdx
+++ b/docs/src/pages/components/Overlay/AndroidOverlay.mdx
@@ -8,9 +8,9 @@ githubPath: overlay
 
 import AndroidComponentScreenshots from 'components/Screenshots/AndroidComponentScreenshots';
 
-import Readme from 'backpack-android/docs/Overlay/README.md';
-import screenshotDefault from 'backpack-android/docs/Overlay/screenshots/all.png';
-import screenshotDefaultDm from 'backpack-android/docs/Overlay/screenshots/all_dm.png';
+import Readme from 'backpack-android/docs/view/Overlay/README.md';
+import screenshotDefault from 'backpack-android/docs/view/Overlay/screenshots/all.png';
+import screenshotDefaultDm from 'backpack-android/docs/view/Overlay/screenshots/all_dm.png';
 
 ## Table of contents
 

--- a/docs/src/pages/components/Panel/AndroidPanel.mdx
+++ b/docs/src/pages/components/Panel/AndroidPanel.mdx
@@ -8,9 +8,9 @@ githubPath: panel
 
 import AndroidComponentScreenshots from 'components/Screenshots/AndroidComponentScreenshots';
 
-import Readme from 'backpack-android/docs/Panel/README.md';
-import screenshotDefault from 'backpack-android/docs/Panel/screenshots/all.png';
-import screenshotDefaultDm from 'backpack-android/docs/Panel/screenshots/all_dm.png';
+import Readme from 'backpack-android/docs/view/Panel/README.md';
+import screenshotDefault from 'backpack-android/docs/view/Panel/screenshots/all.png';
+import screenshotDefaultDm from 'backpack-android/docs/view/Panel/screenshots/all_dm.png';
 
 ## Table of contents
 

--- a/docs/src/pages/components/RadioButton/AndroidRadioButton.mdx
+++ b/docs/src/pages/components/RadioButton/AndroidRadioButton.mdx
@@ -8,9 +8,9 @@ githubPath: radiobutton
 
 import AndroidComponentScreenshots from 'components/Screenshots/AndroidComponentScreenshots';
 
-import Readme from 'backpack-android/docs/RadioButton/README.md';
-import screenshotDefault from 'backpack-android/docs/RadioButton/screenshots/default.png';
-import screenshotDefaultDm from 'backpack-android/docs/RadioButton/screenshots/default_dm.png';
+import Readme from 'backpack-android/docs/view/RadioButton/README.md';
+import screenshotDefault from 'backpack-android/docs/view/RadioButton/screenshots/default.png';
+import screenshotDefaultDm from 'backpack-android/docs/view/RadioButton/screenshots/default_dm.png';
 
 ## Table of contents
 

--- a/docs/src/pages/components/Rating/AndroidRating.mdx
+++ b/docs/src/pages/components/Rating/AndroidRating.mdx
@@ -8,13 +8,13 @@ githubPath: rating
 
 import AndroidComponentScreenshots from 'components/Screenshots/AndroidComponentScreenshots';
 
-import Readme from 'backpack-android/docs/Rating/README.md';
-import screenshotDefault from 'backpack-android/docs/Rating/screenshots/default.png';
-import screenshotDefaultDm from 'backpack-android/docs/Rating/screenshots/default_dm.png';
-import screenshotSizes from 'backpack-android/docs/Rating/screenshots/sizes.png';
-import screenshotSizesDm from 'backpack-android/docs/Rating/screenshots/sizes_dm.png';
-import screenshotVertical from 'backpack-android/docs/Rating/screenshots/vertical.png';
-import screenshotVerticalDm from 'backpack-android/docs/Rating/screenshots/vertical_dm.png';
+import Readme from 'backpack-android/docs/view/Rating/README.md';
+import screenshotDefault from 'backpack-android/docs/view/Rating/screenshots/default.png';
+import screenshotDefaultDm from 'backpack-android/docs/view/Rating/screenshots/default_dm.png';
+import screenshotSizes from 'backpack-android/docs/view/Rating/screenshots/sizes.png';
+import screenshotSizesDm from 'backpack-android/docs/view/Rating/screenshots/sizes_dm.png';
+import screenshotVertical from 'backpack-android/docs/view/Rating/screenshots/vertical.png';
+import screenshotVerticalDm from 'backpack-android/docs/view/Rating/screenshots/vertical_dm.png';
 
 ## Table of contents
 

--- a/docs/src/pages/components/Sliders/AndroidSlidersPage.mdx
+++ b/docs/src/pages/components/Sliders/AndroidSlidersPage.mdx
@@ -8,9 +8,9 @@ githubPath: slider
 
 import AndroidComponentScreenshots from 'components/Screenshots/AndroidComponentScreenshots';
 
-import Readme from 'backpack-android/docs/Slider/README.md';
-import screenshotAll from 'backpack-android/docs/Slider/screenshots/all.png';
-import screenshotAllDm from 'backpack-android/docs/Slider/screenshots/all_dm.png';
+import Readme from 'backpack-android/docs/view/Slider/README.md';
+import screenshotAll from 'backpack-android/docs/view/Slider/screenshots/all.png';
+import screenshotAllDm from 'backpack-android/docs/view/Slider/screenshots/all_dm.png';
 
 ## Table of contents
 

--- a/docs/src/pages/components/Snackbar/AndroidSnackbar.mdx
+++ b/docs/src/pages/components/Snackbar/AndroidSnackbar.mdx
@@ -8,9 +8,9 @@ githubPath: snackbar
 
 import AndroidComponentScreenshots from 'components/Screenshots/AndroidComponentScreenshots';
 
-import Readme from 'backpack-android/docs/Snackbar/README.md';
-import screenshotDefault from 'backpack-android/docs/Snackbar/screenshots/default.png';
-import screenshotDefaultDm from 'backpack-android/docs/Snackbar/screenshots/default_dm.png';
+import Readme from 'backpack-android/docs/view/Snackbar/README.md';
+import screenshotDefault from 'backpack-android/docs/view/Snackbar/screenshots/default.png';
+import screenshotDefaultDm from 'backpack-android/docs/view/Snackbar/screenshots/default_dm.png';
 
 ## Table of contents
 

--- a/docs/src/pages/components/Spinner/AndroidSpinner.mdx
+++ b/docs/src/pages/components/Spinner/AndroidSpinner.mdx
@@ -8,11 +8,11 @@ githubPath: spinner
 
 import AndroidComponentScreenshots from 'components/Screenshots/AndroidComponentScreenshots';
 
-import Readme from 'backpack-android/docs/Spinner/README.md';
-import screenshotDefault from 'backpack-android/docs/Spinner/screenshots/default.png';
-import screenshotDefaultDm from 'backpack-android/docs/Spinner/screenshots/default_dm.png';
-import screenshotSmall from 'backpack-android/docs/Spinner/screenshots/small.png';
-import screenshotSmallDm from 'backpack-android/docs/Spinner/screenshots/small_dm.png';
+import Readme from 'backpack-android/docs/view/Spinner/README.md';
+import screenshotDefault from 'backpack-android/docs/view/Spinner/screenshots/default.png';
+import screenshotDefaultDm from 'backpack-android/docs/view/Spinner/screenshots/default_dm.png';
+import screenshotSmall from 'backpack-android/docs/view/Spinner/screenshots/small.png';
+import screenshotSmallDm from 'backpack-android/docs/view/Spinner/screenshots/small_dm.png';
 
 
 ## Table of contents

--- a/docs/src/pages/components/StarRating/AndroidStarRating.mdx
+++ b/docs/src/pages/components/StarRating/AndroidStarRating.mdx
@@ -8,12 +8,12 @@ githubPath: starrating
 
 import AndroidComponentScreenshots from 'components/Screenshots/AndroidComponentScreenshots';
 
-import Readme from 'backpack-android/docs/StarRating/README.md';
-import StarRatingInteractiveReadme from 'backpack-android/docs/InteractiveStarRating/README.md';
-import screenshotStarRating from 'backpack-android/docs/StarRating/screenshots/default.png';
-import screenshotStarRatingDm from 'backpack-android/docs/StarRating/screenshots/default_dm.png';
-import screenshotInteractive from 'backpack-android/docs/InteractiveStarRating/screenshots/default.png';
-import screenshotInteractiveDm from 'backpack-android/docs/InteractiveStarRating/screenshots/default_dm.png';
+import Readme from 'backpack-android/docs/view/StarRating/README.md';
+import StarRatingInteractiveReadme from 'backpack-android/docs/view/InteractiveStarRating/README.md';
+import screenshotStarRating from 'backpack-android/docs/view/StarRating/screenshots/default.png';
+import screenshotStarRatingDm from 'backpack-android/docs/view/StarRating/screenshots/default_dm.png';
+import screenshotInteractive from 'backpack-android/docs/view/InteractiveStarRating/screenshots/default.png';
+import screenshotInteractiveDm from 'backpack-android/docs/view/InteractiveStarRating/screenshots/default_dm.png';
 
 ## Table of contents
 

--- a/docs/src/pages/components/Switch/AndroidSwitch.mdx
+++ b/docs/src/pages/components/Switch/AndroidSwitch.mdx
@@ -8,9 +8,9 @@ githubPath: toggle
 
 import AndroidComponentScreenshots from 'components/Screenshots/AndroidComponentScreenshots';
 
-import Readme from 'backpack-android/docs/Switch/README.md';
-import screenshotDefault from 'backpack-android/docs/Switch/screenshots/default.png';
-import screenshotDefaultDm from 'backpack-android/docs/Switch/screenshots/default_dm.png';
+import Readme from 'backpack-android/docs/view/Switch/README.md';
+import screenshotDefault from 'backpack-android/docs/view/Switch/screenshots/default.png';
+import screenshotDefaultDm from 'backpack-android/docs/view/Switch/screenshots/default_dm.png';
 
 ## Table of contents
 

--- a/docs/src/pages/components/Text/AndroidText.mdx
+++ b/docs/src/pages/components/Text/AndroidText.mdx
@@ -8,18 +8,18 @@ githubPath: text
 
 import AndroidComponentScreenshots from 'components/Screenshots/AndroidComponentScreenshots';
 
-import TextReadme from 'backpack-android/docs/Text/README.md';
-import TextSpanReadme from 'backpack-android/docs/TextSpans/README.md';
+import TextReadme from 'backpack-android/docs/view/Text/README.md';
+import TextSpanReadme from 'backpack-android/docs/view/TextSpans/README.md';
 
-import TextDefault from 'backpack-android/docs/Text/screenshots/default.png';
-import TextDefaultDm from 'backpack-android/docs/Text/screenshots/default_dm.png'
-import TextEmphasized from 'backpack-android/docs/Text/screenshots/emphasized.png'
-import TextEmphasizedDm from 'backpack-android/docs/Text/screenshots/emphasized_dm.png'
-import TextHeavy from 'backpack-android/docs/Text/screenshots/heavy.png'
-import TextHeavyDm from 'backpack-android/docs/Text/screenshots/heavy_dm.png'
+import TextDefault from 'backpack-android/docs/view/Text/screenshots/default.png';
+import TextDefaultDm from 'backpack-android/docs/view/Text/screenshots/default_dm.png'
+import TextEmphasized from 'backpack-android/docs/view/Text/screenshots/emphasized.png'
+import TextEmphasizedDm from 'backpack-android/docs/view/Text/screenshots/emphasized_dm.png'
+import TextHeavy from 'backpack-android/docs/view/Text/screenshots/heavy.png'
+import TextHeavyDm from 'backpack-android/docs/view/Text/screenshots/heavy_dm.png'
 
-import TextSpan from 'backpack-android/docs/TextSpans/screenshots/default.png'
-import TextSpanDm from 'backpack-android/docs/TextSpans/screenshots/default_dm.png'
+import TextSpan from 'backpack-android/docs/view/TextSpans/screenshots/default.png'
+import TextSpanDm from 'backpack-android/docs/view/TextSpans/screenshots/default_dm.png'
 
 # Table of contents
 

--- a/docs/src/pages/components/Text/ComposeText.mdx
+++ b/docs/src/pages/components/Text/ComposeText.mdx
@@ -1,0 +1,46 @@
+---
+title: Text
+platform: compose
+documentationId: net.skyscanner.backpack.compose.text
+githubPath: text
+---
+
+
+import AndroidComponentScreenshots from 'components/Screenshots/AndroidComponentScreenshots';
+
+import TextReadme from 'backpack-android/docs/compose/Text/README.md';
+
+import TextBody from 'backpack-android/docs/compose/Text/screenshots/body.png';
+import TextBodyDm from 'backpack-android/docs/compose/Text/screenshots/body_dm.png'
+import TextHeading from 'backpack-android/docs/compose/Text/screenshots/heading.png';
+import TextHeadingDm from 'backpack-android/docs/compose/Text/screenshots/heading_dm.png'
+import TextHero from 'backpack-android/docs/compose/Text/screenshots/hero.png';
+import TextHeroDm from 'backpack-android/docs/compose/Text/screenshots/hero_dm.png'
+
+
+# Table of contents
+
+# Body
+
+<AndroidComponentScreenshots
+  lightMode={TextBody}
+  darkMode={TextBodyDm}
+  altText="Compose body text" />
+
+# Heading
+
+<AndroidComponentScreenshots
+  lightMode={TextHeading}
+  darkMode={TextHeadingDm}
+  altText="Compose heading text" />
+
+# Hero
+
+<AndroidComponentScreenshots
+  lightMode={TextHero}
+  darkMode={TextHeroDm}
+  altText="Compose hero text" />
+
+# Text Implementation
+
+<TextReadme />

--- a/docs/src/pages/components/Text/TextPage.js
+++ b/docs/src/pages/components/Text/TextPage.js
@@ -21,6 +21,7 @@
 import React from 'react';
 
 import Android, { metadata as androidMetadata } from './AndroidText.mdx';
+import Compose, { metadata as composeMetadata } from './ComposeText.mdx';
 import Native, { metadata as nativeMetadata } from './NativeText.mdx';
 import IOS, { metadata as iosMetadata } from './iOSText.mdx';
 import Web, { metadata as webMetadata } from './WebText.mdx';
@@ -41,6 +42,7 @@ const Page = () => (
       </IntroBlurb>,
     ]}
     androidSubpage={<MarkdownPage content={Android} {...androidMetadata} />}
+    composeSubpage={<MarkdownPage content={Compose} {...composeMetadata} />}
     iosSubpage={<MarkdownPage content={IOS} {...iosMetadata} />}
     nativeSubpage={<MarkdownPage content={Native} {...nativeMetadata} />}
     webSubpage={<MarkdownPage content={Web} {...webMetadata} />}

--- a/docs/src/pages/components/TextInput/AndroidTextInput.mdx
+++ b/docs/src/pages/components/TextInput/AndroidTextInput.mdx
@@ -8,11 +8,11 @@ githubPath: text
 
 import AndroidComponentScreenshots from 'components/Screenshots/AndroidComponentScreenshots';
 
-import Readme from 'backpack-android/docs/TextField/README.md';
-import screenshotDefault from 'backpack-android/docs/TextField/screenshots/default.png';
-import screenshotDefaultDm from 'backpack-android/docs/TextField/screenshots/default_dm.png';
-import screenshotLabels from 'backpack-android/docs/TextField/screenshots/labels.png';
-import screenshotLabelsDm from 'backpack-android/docs/TextField/screenshots/labels_dm.png';
+import Readme from 'backpack-android/docs/view/TextField/README.md';
+import screenshotDefault from 'backpack-android/docs/view/TextField/screenshots/default.png';
+import screenshotDefaultDm from 'backpack-android/docs/view/TextField/screenshots/default_dm.png';
+import screenshotLabels from 'backpack-android/docs/view/TextField/screenshots/labels.png';
+import screenshotLabelsDm from 'backpack-android/docs/view/TextField/screenshots/labels_dm.png';
 
 ## Table of contents
 

--- a/docs/src/pages/components/Theming/AndroidTheming.mdx
+++ b/docs/src/pages/components/Theming/AndroidTheming.mdx
@@ -7,7 +7,7 @@ githubPath: util/BpkTheme
 
 
 
-import Readme from 'backpack-android/docs/THEMING.md';
+import Readme from 'backpack-android/docs/view/THEMING.md';
 
 ## Table of contents
 

--- a/docs/src/pages/components/Toast/AndroidToast.mdx
+++ b/docs/src/pages/components/Toast/AndroidToast.mdx
@@ -8,9 +8,9 @@ githubPath: toast
 
 import AndroidComponentScreenshots from 'components/Screenshots/AndroidComponentScreenshots';
 
-import Readme from 'backpack-android/docs/Toast/README.md';
-import screenshotDefault from 'backpack-android/docs/Toast/screenshots/default.png';
-import screenshotDefaultDm from 'backpack-android/docs/Toast/screenshots/default_dm.png';
+import Readme from 'backpack-android/docs/view/Toast/README.md';
+import screenshotDefault from 'backpack-android/docs/view/Toast/screenshots/default.png';
+import screenshotDefaultDm from 'backpack-android/docs/view/Toast/screenshots/default_dm.png';
 
 ## Table of contents
 

--- a/docs/src/static-pages/status.mdx
+++ b/docs/src/static-pages/status.mdx
@@ -44,8 +44,10 @@ category: using
 
 [![Build Status](https://github.com/Skyscanner/backpack-android/workflows/CI/badge.svg)](https://github.com/Skyscanner/backpack-android/actions)
 [![Snyk](https://snyk.io/test/github/skyscanner/backpack-android/badge.svg)](https://snyk.io/test/github/skyscanner/backpack-android)
-[![Maven Central](https://img.shields.io/maven-central/v/net.skyscanner.backpack/backpack-android)](https://search.maven.org/artifact/net.skyscanner.backpack/backpack-android)
-[![Platform](https://img.shields.io/badge/platform-android-green.svg)](https://search.maven.org/artifact/net.skyscanner.backpack/backpack-android)
+[![View Maven Central](https://img.shields.io/maven-central/v/net.skyscanner.backpack/backpack-android)](https://search.maven.org/artifact/net.skyscanner.backpack/backpack-android)
+[![Compose Maven Central](https://img.shields.io/maven-central/v/net.skyscanner.backpack/backpack-compose)](https://search.maven.org/artifact/net.skyscanner.backpack/backpack-compose)
+[![View Platform](https://img.shields.io/badge/platform-android-green.svg)](https://search.maven.org/artifact/net.skyscanner.backpack/backpack-android)
+[![Compose Platform](https://img.shields.io/badge/platform-compose-green.svg)](https://search.maven.org/artifact/net.skyscanner.backpack/backpack-compose)
 [![License](https://img.shields.io/github/license/Skyscanner/backpack-android.svg)](https://github.com/Skyscanner/backpack-android/blob/main/LICENSE.txt)
 
 [Changelog](https://github.com/Skyscanner/backpack-android/blob/main/CHANGELOG.md)


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:
Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

In preparation for releasing compose add support for displaying compose docs. The first compose docs (Text) are available:
![screencapture-0-0-0-0-8080-components-text-2021-12-15-10_44_09](https://user-images.githubusercontent.com/1529791/146181290-a76afcf4-fdc8-459a-85d9-ebcb2a0528ca.png)

The maven central link doesn't work yet, as we haven't published yet, but once we have it'll work.

Remember to include the following changes:
+ [x] [Links platform metadata](https://github.com/Skyscanner/backpack-docs/blob/main/docs/src/layouts/links.js)
