### PR TITLE
[ST-4140] Added `bpk-component-graphic-promotion` to docs

### DIFF
--- a/docs/src/constants/routes.js
+++ b/docs/src/constants/routes.js
@@ -97,6 +97,7 @@ export const INFINITE_SCROLL = '/components/infinite-scroll';
 export const BREADCRUMB = '/components/breadcrumb';
 export const FLARE = '/components/flare';
 export const BOTTOM_NAV = '/components/bottom-nav';
+export const GRAPHIC_PROMOTION = '/components/graphic-promotion';
 
 export const ALIGNMENT = '/components/alignment';
 export const THEMING = '/components/theming';

--- a/docs/src/layouts/links.js
+++ b/docs/src/layouts/links.js
@@ -30,6 +30,13 @@ const ComponentsLinks = [
     sort: true,
     links: [
       {
+        id: 'GRAPHIC_PROMOTION',
+        route: routes.GRAPHIC_PROMOTION,
+        children: 'Graphic promotion',
+        tags: ['web'],
+        keywords: ['graphic promotion', 'advert'],
+      },
+      {
         id: 'SKIP_LINK',
         route: routes.SKIP_LINK,
         children: 'Skip link',

--- a/docs/src/pages/components/GraphicPromotion/GraphicPromotionPage.js
+++ b/docs/src/pages/components/GraphicPromotion/GraphicPromotionPage.js
@@ -1,0 +1,43 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2016 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* @flow strict */
+
+import React from 'react';
+
+import Web, { metadata as webMetadata } from './WebGraphicPromotion.mdx';
+
+import IntroBlurb from 'components/IntroBlurb';
+import DocsPageWrapper from 'components/DocsPageWrapper';
+import MarkdownPage from 'components/MarkdownPage';
+
+const Page = () => (
+  <DocsPageWrapper
+    title="Graphic promotion"
+    blurb={[
+      <IntroBlurb>
+        The graphic promotion component is used to show advertisements. It has
+        different configurations depending on the type of promotion, e.g.
+        sponsored, Skyscanner advertisement, etc.
+      </IntroBlurb>,
+    ]}
+    webSubpage={<MarkdownPage content={Web} {...webMetadata} />}
+  />
+);
+
+export default Page;

--- a/docs/src/pages/components/GraphicPromotion/GraphicPromotionPage.js
+++ b/docs/src/pages/components/GraphicPromotion/GraphicPromotionPage.js
@@ -33,7 +33,7 @@ const Page = () => (
       <IntroBlurb>
         The graphic promotion component is used to show advertisements. It has
         different configurations depending on the type of promotion, e.g.
-        sponsored, Skyscanner advertisement, etc.
+        sponsored, Skyscanner advertisement, layout, etc.
       </IntroBlurb>,
     ]}
     webSubpage={<MarkdownPage content={Web} {...webMetadata} />}

--- a/docs/src/pages/components/GraphicPromotion/WebGraphicPromotion.mdx
+++ b/docs/src/pages/components/GraphicPromotion/WebGraphicPromotion.mdx
@@ -1,0 +1,52 @@
+---
+title: Graphic promotion
+platform: web
+githubPath: bpk-component-graphic-promotion
+---
+
+
+import PresentationBlock from 'components/PresentationBlock';
+import Readme from 'bpk-component-graphic-promotion/README.md';
+import { DefaultExample } from 'bpk-component-graphic-promotion/examples';
+
+## Table of contents
+
+## Default
+
+<PresentationBlock>
+  <DefaultExample />
+</PresentationBlock>
+
+## Center Aligned Example
+
+<PresentationBlock>
+  <CenterAlignedExample />
+</PresentationBlock>
+
+## Right Aligned Example
+
+<PresentationBlock>
+  <RightAlignedExample />
+</PresentationBlock>
+
+## Inverted Portrait Example
+
+<PresentationBlock>
+  <InvertedPortraitExample />
+</PresentationBlock>
+
+## MinimalisticExample
+
+<PresentationBlock>
+  <MinimalisticExample />
+</PresentationBlock>
+
+## Non-Sponsored Example
+
+<PresentationBlock>
+  <NonSponsoredExample />
+</PresentationBlock>
+
+## Implementation
+
+<Readme />

--- a/docs/src/pages/components/GraphicPromotion/WebGraphicPromotion.mdx
+++ b/docs/src/pages/components/GraphicPromotion/WebGraphicPromotion.mdx
@@ -6,8 +6,8 @@ githubPath: bpk-component-graphic-promotion
 
 
 import PresentationBlock from 'components/PresentationBlock';
-import Readme from 'bpk-component-graphic-promotion/README.md';
-import { DefaultExample } from 'bpk-component-graphic-promotion/examples';
+import Readme from 'backpack/packages/bpk-component-graphic-promotion/README.md';
+import { DefaultExample, CenterAlignedExample, RightAlignedExample, InvertedPortraitExample, MinimalisticExample, NonSponsoredExample } from 'backpack/examples/bpk-component-graphic-promotion/examples';
 
 ## Table of contents
 
@@ -31,17 +31,23 @@ import { DefaultExample } from 'bpk-component-graphic-promotion/examples';
 
 ## Inverted Portrait Example
 
+View this page on a mobile device to see the sponsored text and title change locations. This configuration does not affect desktop users.
+
 <PresentationBlock>
   <InvertedPortraitExample />
 </PresentationBlock>
 
-## MinimalisticExample
+## Minimalistic Example
+
+This configuration does not include the `subheading` and `tagline` props.
 
 <PresentationBlock>
   <MinimalisticExample />
 </PresentationBlock>
 
 ## Non-Sponsored Example
+
+Omitting the `sponsor` prop will remove the sponsored label and sponsor logo.
 
 <PresentationBlock>
   <NonSponsoredExample />

--- a/docs/src/pages/components/GraphicPromotion/index.js
+++ b/docs/src/pages/components/GraphicPromotion/index.js
@@ -1,0 +1,23 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2016 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* @flow strict */
+
+import page from './GraphicPromotionPage';
+
+export default page;

--- a/docs/src/routes/Routes.js
+++ b/docs/src/routes/Routes.js
@@ -58,6 +58,7 @@ import RatingPage from '../pages/components/Rating';
 import FormsPage from '../pages/components/Forms';
 import FormLabelPage from '../pages/components/FormLabel';
 import FormValidationPage from '../pages/components/FormValidation';
+import GraphicPromotionPage from '../pages/components/GraphicPromotion';
 import HorizontalGridPage from '../pages/components/HorizontalGrid';
 import HorizontalNavPage from '../pages/components/HorizontalNav';
 import IconPage from '../pages/components/Icon';
@@ -211,6 +212,7 @@ export const ROUTES_MAPPINGS = [
       { path: ROUTES.FORM, component: FormsPage },
       { path: ROUTES.FORM_LABEL, component: FormLabelPage },
       { path: ROUTES.FORM_VALIDATION, component: FormValidationPage },
+      { path: ROUTES.GRAPHIC_PROMOTION, component: GraphicPromotionPage },
       {
         path: ROUTES.HORIZONTAL_GRID,
         component: HorizontalGridPage,


### PR DESCRIPTION
[ST-4140](https://gojira.skyscanner.net/browse/ST-4140)

# Context

Backpack#[2395](https://github.com/Skyscanner/backpack/pull/2395) adds the `bpk-component-graphic-promotion` for web. This PR adds the necessary docs.

# Changes

- Added `bpk-component-graphic-promotion`
- Added relevant links in necessary files

Remember to include the following changes:
+ [x] [Links platform metadata](https://github.com/Skyscanner/backpack-docs/blob/main/docs/src/layouts/links.js)
