### PR TITLE
[NO JIRA]: Fix example crashes

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "start": "npm run docs",
     "docs": "npm run submodules:pull && npm run build-backpack && npm run generate-markdown-pages && BPK_BUILT_AT=$( date -u +%s ) webpack-dev-server --open",
     "docs:dist": "npm run submodules:pull && npm run clean:dist && npm run build-backpack && npm run generate-markdown-pages && NODE_ENV=production BPK_BUILT_AT=$( date -u +%s ) webpack --progress --display=minimal --bail",
-    "build-backpack": "(cd backpack && npm ci && npm run build && npm uninstall react react-dom)",
+    "build-backpack": "(cd backpack && npm ci && npm run build && npm uninstall react react-dom @storybook/addon-actions)",
     "test": "npm run lint && npm run flow && npm run spellcheck && npm run jest",
     "jest": "jest",
     "jest:coverage": "jest --coverage",


### PR DESCRIPTION
Fix issue where installed storybook lib inside Backpack causes a crash when used outside storybook in examples.

Our storybook-utils was created as a way to allow `action` to be used as in storybook and print to storybook when an element is interacted with and then when outside of storybook/the actions lib not installed to fallback to console.log

However because we are using submodules this library would be installed and so the function would think that the lib is available and running in storybook which then when interacted with will crash as it emits a result that can't be consumed as storybook is not running, resulting in a crash
