### PR TITLE
[no jira]: Fixing Web nudger page after recent component change

### DIFF
--- a/docs/src/pages/components/Nudger/WebNudger.mdx
+++ b/docs/src/pages/components/Nudger/WebNudger.mdx
@@ -7,7 +7,7 @@ githubPath: bpk-component-nudger
 
 import PresentationBlock from 'components/PresentationBlock';
 
-import { StatefulExample, OutlineExample, ConfigurableExample } from 'backpack/examples/bpk-component-nudger/examples';
+import { StatefulExample, OnDarkExample, ConfigurableExample } from 'backpack/examples/bpk-component-nudger/examples';
 import Readme from 'backpack/packages/bpk-component-nudger/README.md';
 
 ## Table of contents
@@ -20,12 +20,12 @@ Nudgers come with decrease and increase buttons on either side of the selected v
   <StatefulExample />
 </PresentationBlock>
 
-## Outline
+## On Dark
 
-Outline version allows for the nudger to be used on dark backgrounds.
+On Dark version allows for the nudger to be used on dark backgrounds.
 
 <PresentationBlock darkBackground>
-  <OutlineExample />
+  <OnDarkExample />
 </PresentationBlock>
 
 ## Configurable


### PR DESCRIPTION
We recently removed the outline nudger from Backpack web however I forgot to remove this and update the docs site after removing it! 

This PR fixes that