### PR TITLE
Remove screenshots and badges from docs

### DIFF
--- a/docs/src/components/MarkdownPage/AdditionalLinks.js
+++ b/docs/src/components/MarkdownPage/AdditionalLinks.js
@@ -63,34 +63,6 @@ const AdditionalLinks = (props: Props) => {
   return (
     <div className={getClassName('bpkdocs-markdown-page__additional-links')}>
       <div>
-        {/* Android view Maven Central link */}
-        {platform && platform === PLATFORMS.android && (
-          <BpkLink
-            href="https://search.maven.org/artifact/net.skyscanner.backpack/backpack-android"
-            blank
-            className={getClassName('bpkdocs-markdown-page__link')}
-          >
-            <img
-              src="https://img.shields.io/maven-central/v/net.skyscanner.backpack/backpack-android"
-              alt="View on Maven Central"
-            />
-          </BpkLink>
-        )}
-
-        {/* Android compose Maven Central link */}
-        {platform && platform === PLATFORMS.compose && (
-          <BpkLink
-            href="https://search.maven.org/artifact/net.skyscanner.backpack/backpack-compose"
-            blank
-            className={getClassName('bpkdocs-markdown-page__link')}
-          >
-            <img
-              src="https://img.shields.io/maven-central/v/net.skyscanner.backpack/backpack-compose"
-              alt="View on Maven Central"
-            />
-          </BpkLink>
-        )}
-
         {/* UIKit CocoaPod link */}
         {platform && platform === PLATFORMS.ios && (
           <BpkLink
@@ -162,34 +134,6 @@ const AdditionalLinks = (props: Props) => {
           </BpkLink>
         )}
 
-        {/* Android view documentation link */}
-        {platform && platform === PLATFORMS.android && documentationId && (
-          <BpkLink
-            href={`/android/Backpack/${documentationId}`}
-            blank
-            className={getClassName('bpkdocs-markdown-page__link')}
-          >
-            <img
-              src="https://img.shields.io/badge/Class%20reference-Android-blue"
-              alt="View class reference"
-            />
-          </BpkLink>
-        )}
-
-        {/* Android compose documentation link */}
-        {platform && platform === PLATFORMS.compose && documentationId && (
-          <BpkLink
-            href={`/android/backpack-compose/${documentationId}`}
-            blank
-            className={getClassName('bpkdocs-markdown-page__link')}
-          >
-            <img
-              src="https://img.shields.io/badge/Class%20reference-Android-blue"
-              alt="View class reference"
-            />
-          </BpkLink>
-        )}
-
         {/* iOS UIKit documentation link */}
         {platform && platform === PLATFORMS.ios && documentationId && (
           <BpkLink
@@ -214,34 +158,6 @@ const AdditionalLinks = (props: Props) => {
             <img
               src="https://img.shields.io/badge/Class%20reference-iOS-blue"
               alt="View class reference"
-            />
-          </BpkLink>
-        )}
-
-        {/* Android view GitHub link */}
-        {platform && platform === PLATFORMS.android && githubPath && (
-          <BpkLink
-            href={`https://github.com/Skyscanner/backpack-android/tree/main/Backpack/src/main/java/net/skyscanner/backpack/${githubPath}`}
-            blank
-            className={getClassName('bpkdocs-markdown-page__link')}
-          >
-            <img
-              src="https://img.shields.io/badge/Source%20code-GitHub-lightgrey"
-              alt="View source code on GitHub"
-            />
-          </BpkLink>
-        )}
-
-        {/* Android compose GitHub link */}
-        {platform && platform === PLATFORMS.compose && githubPath && (
-          <BpkLink
-            href={`https://github.com/Skyscanner/backpack-android/tree/main/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/${githubPath}`}
-            blank
-            className={getClassName('bpkdocs-markdown-page__link')}
-          >
-            <img
-              src="https://img.shields.io/badge/Source%20code-GitHub-lightgrey"
-              alt="View source code on GitHub"
             />
           </BpkLink>
         )}

--- a/docs/src/pages/components/Badge/AndroidBadge.mdx
+++ b/docs/src/pages/components/Badge/AndroidBadge.mdx
@@ -1,26 +1,11 @@
 ---
 title: Badge
 platform: android
-documentationId: net.skyscanner.backpack.badge
-githubPath: badge
 ---
 
 
-import AndroidComponentScreenshots from 'components/Screenshots/AndroidComponentScreenshots';
-
 import Readme from 'backpack-android/docs/view/Badge/README.md';
-import screenshotAll from 'backpack-android/docs/view/Badge/screenshots/all.png';
-import screenshotAllDm from 'backpack-android/docs/view/Badge/screenshots/all_dm.png';
 
 ## Table of contents
-
-## Default
-
-<AndroidComponentScreenshots
-  lightMode={screenshotAll}
-  darkMode={screenshotAllDm}
-  altText="Android badges" />
-
-## Implementation
 
 <Readme />

--- a/docs/src/pages/components/Badge/ComposeBadge.mdx
+++ b/docs/src/pages/components/Badge/ComposeBadge.mdx
@@ -1,28 +1,10 @@
 ---
 title: Badge
 platform: compose
-documentationId: net.skyscanner.backpack.compose.badge
-githubPath: badge
 ---
-
-
-import AndroidComponentScreenshots from 'components/Screenshots/AndroidComponentScreenshots';
 
 import BadgeReadme from 'backpack-android/docs/compose/Badge/README.md';
 
-import Default from 'backpack-android/docs/compose/Badge/screenshots/default.png';
-import DefaultDm from 'backpack-android/docs/compose/Badge/screenshots/default_dm.png';
-
-
 # Table of contents
-
-# Default
-
-<AndroidComponentScreenshots
-  lightMode={Default}
-  darkMode={DefaultDm}
-  altText="Badge" />
-
-# Implementation
 
 <BadgeReadme />

--- a/docs/src/pages/components/Barcharts/AndroidBarChart.mdx
+++ b/docs/src/pages/components/Barcharts/AndroidBarChart.mdx
@@ -1,28 +1,11 @@
 ---
 title: Bar chart
 platform: android
-documentationId: net.skyscanner.backpack.barchart
-githubPath: barchart
 ---
 
 
-import AndroidComponentScreenshots from 'components/Screenshots/AndroidComponentScreenshots';
-
 import Readme from 'backpack-android/docs/view/BarChart/README.md';
 
-import screenshotDefault from 'backpack-android/docs/view/BarChart/screenshots/default.png';
-import screenshotDefaultDm from 'backpack-android/docs/view/BarChart/screenshots/default_dm.png';
-
-
 ## Table of contents
-
-## Default
-
-<AndroidComponentScreenshots
-  lightMode={screenshotDefault}
-  darkMode={screenshotDefaultDm}
-  altText="Android barchart component" />
-
-## Implementation
 
 <Readme />

--- a/docs/src/pages/components/BottomNav/AndroidBottomNav.mdx
+++ b/docs/src/pages/components/BottomNav/AndroidBottomNav.mdx
@@ -1,27 +1,11 @@
 ---
 title: Bottom Nav
 platform: android
-documentationId: net.skyscanner.backpack.bottomnav
-githubPath: bottomnav
 ---
 
 
-import AndroidComponentScreenshots from 'components/Screenshots/AndroidComponentScreenshots';
-
 import Readme from 'backpack-android/docs/view/BottomNav/README.md';
 
-import screenshotDefault from 'backpack-android/docs/view/BottomNav/screenshots/default.png';
-import screenshotDefaultDm from 'backpack-android/docs/view/BottomNav/screenshots/default_dm.png';
-
 ## Table of contents
-
-## Default
-
-<AndroidComponentScreenshots
-  lightMode={screenshotDefault}
-  darkMode={screenshotDefaultDm}
-  altText="Android bottom nav" />
-
-## Implementation
 
 <Readme />

--- a/docs/src/pages/components/BottomSheet/AndroidBottomSheet.mdx
+++ b/docs/src/pages/components/BottomSheet/AndroidBottomSheet.mdx
@@ -1,27 +1,10 @@
 ---
 title: Bottom Sheet
 platform: android
-documentationId: net.skyscanner.backpack.bottomsheet
-githubPath: BottomNav
 ---
-
-
-import AndroidComponentScreenshots from 'components/Screenshots/AndroidComponentScreenshots';
 
 import Readme from 'backpack-android/docs/view/BottomSheet/README.md';
 
-import screenshotDefault from 'backpack-android/docs/view/BottomSheet/screenshots/default.png';
-import screenshotDefaultDm from 'backpack-android/docs/view/BottomSheet/screenshots/default_dm.png';
-
 ## Table of contents
-
-## Default
-
-<AndroidComponentScreenshots
-  lightMode={screenshotDefault}
-  darkMode={screenshotDefaultDm}
-  altText="Android bottom sheet" />
-
-## Implementation
 
 <Readme />

--- a/docs/src/pages/components/Button/AndroidButton.mdx
+++ b/docs/src/pages/components/Button/AndroidButton.mdx
@@ -1,44 +1,12 @@
 ---
 title: Button
 platform: android
-documentationId: net.skyscanner.backpack.button
-githubPath: button
 ---
 
 
-import AndroidComponentScreenshots from 'components/Screenshots/AndroidComponentScreenshots';
-
 import ButtonReadme from 'backpack-android/docs/view/Button/README.md';
 
-import Default from 'backpack-android/docs/view/Button/screenshots/standard.png';
-import DefaultDm from 'backpack-android/docs/view/Button/screenshots/standard_dm.png';
-import Large from 'backpack-android/docs/view/Button/screenshots/large.png';
-import LargeDm from 'backpack-android/docs/view/Button/screenshots/large_dm.png';
-import Link from 'backpack-android/docs/view/Button/screenshots/link.png';
-import LinkDm from 'backpack-android/docs/view/Button/screenshots/link_dm.png';
-
 ## Table of contents
-
-## Default
-
-<AndroidComponentScreenshots
-  lightMode={Default}
-  darkMode={DefaultDm}
-  altText="Button (default size)" />
-
-## Large
-
-<AndroidComponentScreenshots
-  lightMode={Large}
-  darkMode={LargeDm}
-  altText="Button (large size)" />
-
-## Link
-
-<AndroidComponentScreenshots
-  lightMode={Link}
-  darkMode={LinkDm}
-  altText="Button (link buttons)" />
 
  ## Accessibility considerations
 

--- a/docs/src/pages/components/Button/ComposeButton.mdx
+++ b/docs/src/pages/components/Button/ComposeButton.mdx
@@ -1,46 +1,12 @@
 ---
 title: Button
 platform: compose
-documentationId: net.skyscanner.backpack.compose.button
-githubPath: button
 ---
 
 
-import AndroidComponentScreenshots from 'components/Screenshots/AndroidComponentScreenshots';
-
 import ButtonReadme from 'backpack-android/docs/compose/Button/README.md';
-
-import Default from 'backpack-android/docs/compose/Button/screenshots/default.png';
-import DefaultDm from 'backpack-android/docs/compose/Button/screenshots/default_dm.png';
-import Large from 'backpack-android/docs/compose/Button/screenshots/large.png';
-import LargeDm from 'backpack-android/docs/compose/Button/screenshots/large_dm.png';
-import Link from 'backpack-android/docs/compose/Button/screenshots/link.png';
-import LinkDm from 'backpack-android/docs/compose/Button/screenshots/link_dm.png';
 
 
 ## Table of contents
-
-## Default
-
-<AndroidComponentScreenshots
-  lightMode={Default}
-  darkMode={DefaultDm}
-  altText="Button (default size)" />
-
-## Large
-
-<AndroidComponentScreenshots
-  lightMode={Large}
-  darkMode={LargeDm}
-  altText="Button (large size)" />
-
-## Link
-
-<AndroidComponentScreenshots
-  lightMode={Link}
-  darkMode={LinkDm}
-  altText="Button (link buttons)" />
-
-# Implementation
 
 <ButtonReadme />

--- a/docs/src/pages/components/Calendar/AndroidCalendar.mdx
+++ b/docs/src/pages/components/Calendar/AndroidCalendar.mdx
@@ -1,35 +1,11 @@
 ---
 title: Calendar
 platform: android
-documentationId: net.skyscanner.backpack.calendar2
-githubPath: calendar2
 ---
 
 
-import AndroidComponentScreenshots from 'components/Screenshots/AndroidComponentScreenshots';
-
 import Readme from 'backpack-android/docs/view/Calendar2/README.md';
-import screenshotAll from 'backpack-android/docs/view/Calendar2/screenshots/range.png';
-import screenshotAllDm from 'backpack-android/docs/view/Calendar2/screenshots/range_dm.png';
-import screenshotColored from 'backpack-android/docs/view/Calendar2/screenshots/colored.png';
-import screenshotColoredDm from 'backpack-android/docs/view/Calendar2/screenshots/colored_dm.png';
 
 ## Table of contents
-
-## Range
-
-<AndroidComponentScreenshots
-  lightMode={screenshotAll}
-  darkMode={screenshotAllDm}
-  altText="Calendar with a range of dates" />
-
-## Custom colours
-
-<AndroidComponentScreenshots
-  lightMode={screenshotColored}
-  darkMode={screenshotColoredDm}
-  altText="Calendar with custom colours" />
-
-## Implementation
 
 <Readme />

--- a/docs/src/pages/components/Card/AndroidCard.mdx
+++ b/docs/src/pages/components/Card/AndroidCard.mdx
@@ -1,89 +1,11 @@
 ---
 title: Card
 platform: android
-documentationId: net.skyscanner.backpack.card
-githubPath: card
 ---
 
 
-import AndroidComponentScreenshots from 'components/Screenshots/AndroidComponentScreenshots';
-
 import Readme from 'backpack-android/docs/view/Card/README.md';
-import screenshotDefault from 'backpack-android/docs/view/Card/screenshots/default.png';
-import screenshotDefaultDm from 'backpack-android/docs/view/Card/screenshots/default_dm.png';
-import screenshotCornerStyleLarge from 'backpack-android/docs/view/Card/screenshots/corner-style-large.png';
-import screenshotCornerStyleLargeDm from 'backpack-android/docs/view/Card/screenshots/corner-style-large_dm.png';
-import screenshotSelected from 'backpack-android/docs/view/Card/screenshots/selected.png';
-import screenshotSelectedDm from 'backpack-android/docs/view/Card/screenshots/selected_dm.png';
-import screenshotWithoutPadding from 'backpack-android/docs/view/Card/screenshots/without-padding.png';
-import screenshotWithoutPaddingDm from 'backpack-android/docs/view/Card/screenshots/without-padding_dm.png';
-import screenshotWithDivider from 'backpack-android/docs/view/Card/screenshots/with-divider.png';
-import screenshotWithDividerDm from 'backpack-android/docs/view/Card/screenshots/with-divider_dm.png';
-import screenshotWithDividerArrangedVertically from 'backpack-android/docs/view/Card/screenshots/with-divider-arranged-vertically.png';
-import screenshotWithDividerArrangedVerticallyDm from 'backpack-android/docs/view/Card/screenshots/with-divider-arranged-vertically_dm.png';
-import screenshotWithDividerCornerStyleLarge from 'backpack-android/docs/view/Card/screenshots/with-divider-and-corner-style-large.png';
-import screenshotWithDividerCornerStyleLargeDm from 'backpack-android/docs/view/Card/screenshots/with-divider-and-corner-style-large_dm.png';
-import screenshotWithDividerWithoutPadding from 'backpack-android/docs/view/Card/screenshots/with-divider-without-padding.png';
-import screenshotWithDividerWithoutPaddingDm from 'backpack-android/docs/view/Card/screenshots/with-divider-without-padding_dm.png';
 
 ## Table of contents
-
-## Default
-
-<AndroidComponentScreenshots
-  lightMode={screenshotDefault}
-  darkMode={screenshotDefaultDm}
-  altText="Default card" />
-
-## Selected
-
-<AndroidComponentScreenshots
-  lightMode={screenshotSelected}
-  darkMode={screenshotSelectedDm}
-  altText="Selected card" />
-
-## Large corner style
-
-<AndroidComponentScreenshots
-  lightMode={screenshotCornerStyleLarge}
-  darkMode={screenshotCornerStyleLargeDm}
-  altText="Card with large corner style" />
-
-## Without padding
-
-<AndroidComponentScreenshots
-  lightMode={screenshotWithoutPadding}
-  darkMode={screenshotWithoutPaddingDm}
-  altText="Card without padding" />
-
-## With divider
-
-<AndroidComponentScreenshots
-  lightMode={screenshotWithDivider}
-  darkMode={screenshotWithDividerDm}
-  altText="Card with divider" />
-
-## With divider arranged vertically
-
-<AndroidComponentScreenshots
-  lightMode={screenshotWithDividerArrangedVertically}
-  darkMode={screenshotWithDividerArrangedVerticallyDm}
-  altText="Card with divider arranged vertically" />
-
-## With divider and without padding
-
-<AndroidComponentScreenshots
-  lightMode={screenshotWithDividerWithoutPadding}
-  darkMode={screenshotWithDividerWithoutPaddingDm}
-  altText="Card with divider and without padding" />
-
-## With divider and with large corner style
-
-<AndroidComponentScreenshots
-  lightMode={screenshotWithDividerCornerStyleLarge}
-  darkMode={screenshotWithDividerCornerStyleLargeDm}
-  altText="Card with divider and large corner style" />
-
-## Implementation
 
 <Readme />

--- a/docs/src/pages/components/Card/ComposeCard.mdx
+++ b/docs/src/pages/components/Card/ComposeCard.mdx
@@ -1,28 +1,12 @@
 ---
 title: Card
 platform: compose
-documentationId: net.skyscanner.backpack.compose.card
-githubPath: card
 ---
 
 
-import AndroidComponentScreenshots from 'components/Screenshots/AndroidComponentScreenshots';
-
 import CardReadme from 'backpack-android/docs/compose/Card/README.md';
-
-import Default from 'backpack-android/docs/compose/Card/screenshots/default.png';
-import DefaultDm from 'backpack-android/docs/compose/Card/screenshots/default_dm.png';
 
 
 # Table of contents
-
-# Default
-
-<AndroidComponentScreenshots
-  lightMode={Default}
-  darkMode={DefaultDm}
-  altText="Card" />
-
-# Implementation
 
 <CardReadme />

--- a/docs/src/pages/components/Checkbox/AndroidCheckbox.mdx
+++ b/docs/src/pages/components/Checkbox/AndroidCheckbox.mdx
@@ -1,26 +1,11 @@
 ---
 title: Checkbox
 platform: android
-documentationId: net.skyscanner.backpack.checkbox
-githubPath: checkbox
 ---
 
 
-import AndroidComponentScreenshots from 'components/Screenshots/AndroidComponentScreenshots';
-
 import Readme from 'backpack-android/docs/view/Checkbox/README.md';
-import screenshotDefault from 'backpack-android/docs/view/Checkbox/screenshots/default.png';
-import screenshotDefaultDm from 'backpack-android/docs/view/Checkbox/screenshots/default_dm.png';
 
 ## Table of contents
-
-## Default
-
-<AndroidComponentScreenshots
-  lightMode={screenshotDefault}
-  darkMode={screenshotDefaultDm}
-  altText="Android checkbox component" />
-
-## Implementation
 
 <Readme />

--- a/docs/src/pages/components/Checkbox/ComposeCheckbox.mdx
+++ b/docs/src/pages/components/Checkbox/ComposeCheckbox.mdx
@@ -1,28 +1,12 @@
 ---
 title: Checkbox
 platform: compose
-documentationId: net.skyscanner.backpack.compose.checkbox
-githubPath: checkbox
 ---
 
 
-import AndroidComponentScreenshots from 'components/Screenshots/AndroidComponentScreenshots';
-
 import CheckboxReadme from 'backpack-android/docs/compose/Checkbox/README.md';
-
-import Default from 'backpack-android/docs/compose/Checkbox/screenshots/default.png';
-import DefaultDm from 'backpack-android/docs/compose/Checkbox/screenshots/default_dm.png';
 
 
 ## Table of contents
-
-## Default
-
-<AndroidComponentScreenshots
-  lightMode={Default}
-  darkMode={DefaultDm}
-  altText="Checkbox" />
-
-## Implementation
 
 <CheckboxReadme />

--- a/docs/src/pages/components/Chips/AndroidChip.mdx
+++ b/docs/src/pages/components/Chips/AndroidChip.mdx
@@ -1,44 +1,11 @@
 ---
 title: Chip
 platform: android
-documentationId: net.skyscanner.backpack.chip
-githubPath: chip
 ---
 
 
-import AndroidComponentScreenshots from 'components/Screenshots/AndroidComponentScreenshots';
-
 import Readme from 'backpack-android/docs/view/Chip/README.md';
-import screenshotAll from 'backpack-android/docs/view/Chip/screenshots/all.png';
-import screenshotAllDm from 'backpack-android/docs/view/Chip/screenshots/all_dm.png';
-import screenshotOnDark from 'backpack-android/docs/view/Chip/screenshots/on-dark.png';
-import screenshotOnDarkDm from 'backpack-android/docs/view/Chip/screenshots/on-dark_dm.png';
-import screenshotIcon from 'backpack-android/docs/view/Chip/screenshots/with-icon.png';
-import screenshotIconDm from 'backpack-android/docs/view/Chip/screenshots/with-icon_dm.png';
 
 ## Table of contents
-
-## Default
-
-<AndroidComponentScreenshots
-  lightMode={screenshotAll}
-  darkMode={screenshotAllDm}
-  altText="Android default chip" />
-
-## On Dark
-
-<AndroidComponentScreenshots
-  lightMode={screenshotOnDark}
-  darkMode={screenshotOnDarkDm}
-  altText="Android On Dark chip" />
-
-## With icon
-
-<AndroidComponentScreenshots
-  lightMode={screenshotIcon}
-  darkMode={screenshotIconDm}
-  altText="Android chip with icon" />
-
-## Implementation
 
 <Readme />

--- a/docs/src/pages/components/Chips/ComposeChip.mdx
+++ b/docs/src/pages/components/Chips/ComposeChip.mdx
@@ -1,28 +1,12 @@
 ---
 title: Chip
 platform: compose
-documentationId: net.skyscanner.backpack.compose.chip
-githubPath: chip
 ---
 
 
-import AndroidComponentScreenshots from 'components/Screenshots/AndroidComponentScreenshots';
-
 import ChipReadme from 'backpack-android/docs/compose/Chip/README.md';
-
-import Default from 'backpack-android/docs/compose/Chip/screenshots/default.png';
-import DefaultDm from 'backpack-android/docs/compose/Chip/screenshots/default_dm.png';
 
 
 # Table of contents
-
-# Default
-
-<AndroidComponentScreenshots
-  lightMode={Default}
-  darkMode={DefaultDm}
-  altText="Chip" />
-
-# Implementation
 
 <ChipReadme />

--- a/docs/src/pages/components/Dialogs/AndroidDialog.mdx
+++ b/docs/src/pages/components/Dialogs/AndroidDialog.mdx
@@ -1,39 +1,11 @@
 ---
 title: Dialog
 platform: android
-documentationId: net.skyscanner.backpack.dialog
-githubPath: dialog
 ---
 
 
-import AndroidComponentScreenshots from 'components/Screenshots/AndroidComponentScreenshots';
-
 import Readme from 'backpack-android/docs/view/Dialog/README.md';
-import screenshotAlert from 'backpack-android/docs/view/Dialog/screenshots/with-cta.png';
-import screenshotAlertDm from 'backpack-android/docs/view/Dialog/screenshots/with-cta_dm.png';
-import screenshotBottomSheet from 'backpack-android/docs/view/Dialog/screenshots/delete-confirmation.png';
-import screenshotBottomSheetDm from 'backpack-android/docs/view/Dialog/screenshots/delete-confirmation_dm.png';
 
 ## Table of contents
-
-## Alert
-
-Alert dialogs fade in to the centre of the screen and can contain zero or more buttons. Used as a call to action.
-
-<AndroidComponentScreenshots
-  lightMode={screenshotAlert}
-  darkMode={screenshotAlertDm}
-  altText="Android dialog with a call to action" />
-
-## Bottom sheet
-
-Bottom sheet dialogs slide up from the bottom of the screen and can contain zero or more buttons. Used for confirmation
-
-<AndroidComponentScreenshots
-  lightMode={screenshotBottomSheet}
-  darkMode={screenshotBottomSheetDm}
-  altText="Android bottom sheet dialog used for confirmation" />
-
-## Implementation
 
 <Readme />

--- a/docs/src/pages/components/Dialogs/ComposeDialog.mdx
+++ b/docs/src/pages/components/Dialogs/ComposeDialog.mdx
@@ -1,54 +1,11 @@
 ---
 title: Dialog
 platform: compose
-documentationId: net.skyscanner.backpack.compose.dialog
-githubPath: dialog
 ---
 
 
-import AndroidComponentScreenshots from 'components/Screenshots/AndroidComponentScreenshots';
-
 import DialogReadme from 'backpack-android/docs/compose/Dialog/README.md';
 
-import Success from 'backpack-android/docs/compose/Dialog/screenshots/success.png';
-import SuccessDm from 'backpack-android/docs/compose/Dialog/screenshots/success_dm.png';
-import Warning from 'backpack-android/docs/compose/Dialog/screenshots/warning.png';
-import WarningDm from 'backpack-android/docs/compose/Dialog/screenshots/warning_dm.png';
-import Destructive from 'backpack-android/docs/compose/Dialog/screenshots/destructive.png';
-import DestructiveDm from 'backpack-android/docs/compose/Dialog/screenshots/destructive_dm.png';
-import Flare from 'backpack-android/docs/compose/Dialog/screenshots/flare.png';
-import FlareDm from 'backpack-android/docs/compose/Dialog/screenshots/flare_dm.png';
-
 ## Table of contents
-
-## Success
-
-<AndroidComponentScreenshots
-  lightMode={Success}
-  darkMode={SuccessDm}
-  altText="Success Dialog" />
-
-## Warning
-
-<AndroidComponentScreenshots
-  lightMode={Warning}
-  darkMode={WarningDm}
-  altText="Warning Dialog" />
-
-## Destructive
-
-<AndroidComponentScreenshots
-  lightMode={Destructive}
-  darkMode={DestructiveDm}
-  altText="Destructive Dialog" />
-
-## Flare
-
-<AndroidComponentScreenshots
-  lightMode={Flare}
-  darkMode={FlareDm}
-  altText="Flare Dialog" />
-
-# Implementation
 
 <DialogReadme />

--- a/docs/src/pages/components/Fieldsets/ComposeFieldsets.mdx
+++ b/docs/src/pages/components/Fieldsets/ComposeFieldsets.mdx
@@ -1,53 +1,11 @@
 ---
 title: Field Set
 platform: compose
-documentationId: net.skyscanner.backpack.compose.fieldset
-githubPath: fieldset
 ---
 
 
-import AndroidComponentScreenshots from 'components/Screenshots/AndroidComponentScreenshots';
-
 import Readme from 'backpack-android/docs/compose/FieldSet/README.md';
-import screenshotDefault from 'backpack-android/docs/compose/FieldSet/screenshots/default.png';
-import screenshotDefaultDm from 'backpack-android/docs/compose/FieldSet/screenshots/default_dm.png';
-import screenshotDisabled from 'backpack-android/docs/compose/FieldSet/screenshots/disabled.png';
-import screenshotDisabledDm from 'backpack-android/docs/compose/FieldSet/screenshots/disabled_dm.png';
-import screenshotError from 'backpack-android/docs/compose/FieldSet/screenshots/error.png';
-import screenshotErrorDm from 'backpack-android/docs/compose/FieldSet/screenshots/error_dm.png';
-import screenshotValidated from 'backpack-android/docs/compose/FieldSet/screenshots/validated.png';
-import screenshotValidatedDm from 'backpack-android/docs/compose/FieldSet/screenshots/validated_dm.png';
 
 ## Table of contents
-
-## Default
-
-<AndroidComponentScreenshots
-  lightMode={screenshotDefault}
-  darkMode={screenshotDefaultDm}
-  altText="Compose field set component" />
-
-## Disabled
-
-<AndroidComponentScreenshots
-  lightMode={screenshotDisabled}
-  darkMode={screenshotDisabledDm}
-  altText="Compose field set disabled component" />
-
-## Error
-
-<AndroidComponentScreenshots
-  lightMode={screenshotError}
-  darkMode={screenshotErrorDm}
-  altText="Compose field set error component" />
-
-## Validated
-
-<AndroidComponentScreenshots
-  lightMode={screenshotValidated}
-  darkMode={screenshotValidatedDm}
-  altText="Compose field set validated component" />
-
-## Implementation
 
 <Readme />

--- a/docs/src/pages/components/Flare/AndroidFlare.mdx
+++ b/docs/src/pages/components/Flare/AndroidFlare.mdx
@@ -1,62 +1,11 @@
 ---
 title: Flare
 platform: android
-documentationId: net.skyscanner.backpack.flare
-githubPath: flare
 ---
 
 
-import AndroidComponentScreenshots from 'components/Screenshots/AndroidComponentScreenshots';
-
 import Readme from 'backpack-android/docs/view/Flare/README.md';
-import screenshotDefault from 'backpack-android/docs/view/Flare/screenshots/default.png';
-import screenshotDefaultDm from 'backpack-android/docs/view/Flare/screenshots/default_dm.png';
-import screenshotRounded from 'backpack-android/docs/view/Flare/screenshots/rounded.png';
-import screenshotRoundedDm from 'backpack-android/docs/view/Flare/screenshots/rounded_dm.png';
-import screenshotPointerOffset from 'backpack-android/docs/view/Flare/screenshots/pointer-offset.png';
-import screenshotPointerOffsetDm from 'backpack-android/docs/view/Flare/screenshots/pointer-offset_dm.png';
-import screenshotInsetPadding from 'backpack-android/docs/view/Flare/screenshots/inset-padding.png';
-import screenshotInsetPaddingDm from 'backpack-android/docs/view/Flare/screenshots/inset-padding_dm.png';
-import screenshotPointingUp from 'backpack-android/docs/view/Flare/screenshots/pointing-up.png';
-import screenshotPointingUpDm from 'backpack-android/docs/view/Flare/screenshots/pointing-up_dm.png';
 
 ## Table of contents
-
-## Default
-
-<AndroidComponentScreenshots
-  lightMode={screenshotDefault}
-  darkMode={screenshotDefaultDm}
-  altText="Android flare component" />
-
-## Rounded
-
-<AndroidComponentScreenshots
-  lightMode={screenshotRounded}
-  darkMode={screenshotRoundedDm}
-  altText="Android flare with rounded corners" />
-
-## With the pointer offset
-
-<AndroidComponentScreenshots
-  lightMode={screenshotPointerOffset}
-  darkMode={screenshotPointerOffsetDm}
-  altText="Android flare with offset pointer" />
-
-## With padding
-
-<AndroidComponentScreenshots
-  lightMode={screenshotInsetPadding}
-  darkMode={screenshotInsetPaddingDm}
-  altText="Android flare with padding" />
-
-## Pointing up
-
-<AndroidComponentScreenshots
-  lightMode={screenshotPointingUp}
-  darkMode={screenshotPointingUpDm}
-  altText="Android flare with flare pointing upwards" />
-
-## Implementation
 
 <Readme />

--- a/docs/src/pages/components/Flare/ComposeFlare.mdx
+++ b/docs/src/pages/components/Flare/ComposeFlare.mdx
@@ -1,28 +1,12 @@
 ---
 title: Flare
 platform: compose
-documentationId: net.skyscanner.backpack.compose.flare
-githubPath: flare
 ---
 
 
-import AndroidComponentScreenshots from 'components/Screenshots/AndroidComponentScreenshots';
-
 import FlareReadme from 'backpack-android/docs/compose/Flare/README.md';
-
-import Default from 'backpack-android/docs/compose/Flare/screenshots/default.png';
-import DefaultDm from 'backpack-android/docs/compose/Flare/screenshots/default_dm.png';
 
 
 # Table of contents
-
-# Default
-
-<AndroidComponentScreenshots
-  lightMode={Default}
-  darkMode={DefaultDm}
-  altText="Flare" />
-
-# Implementation
 
 <FlareReadme />

--- a/docs/src/pages/components/FloatingActionButton/AndroidFloatingActionButton.mdx
+++ b/docs/src/pages/components/FloatingActionButton/AndroidFloatingActionButton.mdx
@@ -1,26 +1,11 @@
 ---
 title: Floating action button
 platform: android
-documentationId: net.skyscanner.backpack.fab
-githubPath: fab
 ---
 
 
 import AndroidComponentScreenshots from 'components/Screenshots/AndroidComponentScreenshots';
 
-import Readme from 'backpack-android/docs/view/FloatingActionButton/README.md';
-import screenshotDefault from 'backpack-android/docs/view/FloatingActionButton/screenshots/default.png';
-import screenshotDefaultDm from 'backpack-android/docs/view/FloatingActionButton/screenshots/default_dm.png';
-
 ## Table of contents
-
-## Default
-
-<AndroidComponentScreenshots
-  lightMode={screenshotDefault}
-  darkMode={screenshotDefaultDm}
-  altText="Android floating action button" />
-
-## Implementation
 
 <Readme />

--- a/docs/src/pages/components/HorizontalNav/AndroidHorizontalNav.mdx
+++ b/docs/src/pages/components/HorizontalNav/AndroidHorizontalNav.mdx
@@ -1,26 +1,11 @@
 ---
 title: Horizontal nav
 platform: android
-documentationId: net.skyscanner.backpack.horisontalnav
-githubPath: horisontalnav
 ---
 
 
-import AndroidComponentScreenshots from 'components/Screenshots/AndroidComponentScreenshots';
-
 import Readme from 'backpack-android/docs/view/HorizontalNav/README.md';
-import screenshotDefault from 'backpack-android/docs/view/HorizontalNav/screenshots/default.png';
-import screenshotDefaultDm from 'backpack-android/docs/view/HorizontalNav/screenshots/default_dm.png';
 
 ## Table of contents
-
-## Default
-
-<AndroidComponentScreenshots
-  lightMode={screenshotDefault}
-  darkMode={screenshotDefaultDm}
-  altText="Android horizontal navigation component" />
-
-## Implementation
 
 <Readme />

--- a/docs/src/pages/components/HorizontalNav/ComposeHorizontalNav.mdx
+++ b/docs/src/pages/components/HorizontalNav/ComposeHorizontalNav.mdx
@@ -1,26 +1,11 @@
 ---
-title: Horizontal NAv
+title: Horizontal Nav
 platform: compose
-documentationId: net.skyscanner.backpack.compose.horizontalnav
-githubPath: horizontalnav
 ---
 
 
-import AndroidComponentScreenshots from 'components/Screenshots/AndroidComponentScreenshots';
-
 import Readme from 'backpack-android/docs/compose/HorizontalNav/README.md';
-import screenshotDefault from 'backpack-android/docs/compose/HorizontalNav/screenshots/default.png';
-import screenshotDefaultDm from 'backpack-android/docs/compose/HorizontalNav/screenshots/default_dm.png';
 
 ## Table of contents
-
-## Default
-
-<AndroidComponentScreenshots
-  lightMode={screenshotDefault}
-  darkMode={screenshotDefaultDm}
-  altText="Compose field set component" />
-
-## Implementation
 
 <Readme />

--- a/docs/src/pages/components/Icon/AndroidIcon.mdx
+++ b/docs/src/pages/components/Icon/AndroidIcon.mdx
@@ -4,21 +4,8 @@ platform: android
 ---
 
 
-import AndroidComponentScreenshots from 'components/Screenshots/AndroidComponentScreenshots';
-
 import Readme from 'backpack-android/docs/view/Icon/README.md';
-import screenshotAll from 'backpack-android/docs/view/Icon/screenshots/all.png';
-import screenshotAllDm from 'backpack-android/docs/view/Icon/screenshots/all_dm.png';
 
 ## Table of contents
-
-## Default
-
-<AndroidComponentScreenshots
-  lightMode={screenshotAll}
-  darkMode={screenshotAllDm}
-  altText="Android icons" />
-
-## Implementation
 
 <Readme />

--- a/docs/src/pages/components/Icon/ComposeIcon.mdx
+++ b/docs/src/pages/components/Icon/ComposeIcon.mdx
@@ -1,28 +1,12 @@
 ---
 title: Icon
 platform: compose
-documentationId: net.skyscanner.backpack.compose.icon
-githubPath: icon
 ---
 
 
-import AndroidComponentScreenshots from 'components/Screenshots/AndroidComponentScreenshots';
-
 import IconReadme from 'backpack-android/docs/compose/Icon/README.md';
-
-import Default from 'backpack-android/docs/compose/AllIcons/screenshots/default.png';
-import DefaultDm from 'backpack-android/docs/compose/AllIcons/screenshots/default_dm.png';
 
 
 # Table of contents
-
-# Default
-
-<AndroidComponentScreenshots
-  lightMode={Default}
-  darkMode={DefaultDm}
-  altText="Icon" />
-
-# Implementation
 
 <IconReadme />

--- a/docs/src/pages/components/Map/AndroidMap.mdx
+++ b/docs/src/pages/components/Map/AndroidMap.mdx
@@ -1,44 +1,11 @@
 ---
 title: Map markers
 platform: android
-documentationId: net.skyscanner.backpack.map
-githubPath: map
 ---
 
 
-import AndroidComponentScreenshots from 'components/Screenshots/AndroidComponentScreenshots';
-
 import Readme from 'backpack-android/docs/view/Maps/README.md';
-import screenshotPointers from 'backpack-android/docs/view/Maps/screenshots/pointers.png';
-import screenshotPointersDm from 'backpack-android/docs/view/Maps/screenshots/pointers_dm.png';
-import screenshotBadges from 'backpack-android/docs/view/Maps/screenshots/badges.png';
-import screenshotBadgesDm from 'backpack-android/docs/view/Maps/screenshots/badges_dm.png';
-import screenshotIcons from 'backpack-android/docs/view/Maps/screenshots/with_icons.png';
-import screenshotIconsDm from 'backpack-android/docs/view/Maps/screenshots/with_icons_dm.png';
 
 ## Table of contents
-
-## Pointers
-
-<AndroidComponentScreenshots
-  lightMode={screenshotPointers}
-  darkMode={screenshotPointersDm}
-  altText="Android map markers - pointers" />
-
-## Badges
-
-<AndroidComponentScreenshots
-  lightMode={screenshotBadges}
-  darkMode={screenshotBadgesDm}
-  altText="Android map markers - badges" />
-
-## With icons
-
-<AndroidComponentScreenshots
-  lightMode={screenshotIcons}
-  darkMode={screenshotIconsDm}
-  altText="Android map markers - with icons" />
-
-## Implementation
 
 <Readme />

--- a/docs/src/pages/components/NavigationBar/AndroidNavBar.mdx
+++ b/docs/src/pages/components/NavigationBar/AndroidNavBar.mdx
@@ -1,44 +1,11 @@
 ---
 title: Navigation bar
 platform: android
-documentationId: net.skyscanner.backpack.navbar
-githubPath: navbar
 ---
 
 
-import AndroidComponentScreenshots from 'components/Screenshots/AndroidComponentScreenshots';
-
 import Readme from 'backpack-android/docs/view/NavBar/README.md';
-import screenshotCollapsed from 'backpack-android/docs/view/NavBar/screenshots/collapsed.png';
-import screenshotCollapsedDm from 'backpack-android/docs/view/NavBar/screenshots/collapsed_dm.png';
-import screenshotExpanded from 'backpack-android/docs/view/NavBar/screenshots/expanded.png';
-import screenshotExpandedDm from 'backpack-android/docs/view/NavBar/screenshots/expanded_dm.png';
-import screenshotNavigation from 'backpack-android/docs/view/NavBar/screenshots/navigation.png';
-import screenshotNavigationDm from 'backpack-android/docs/view/NavBar/screenshots/navigation_dm.png';
 
 ## Table of contents
-
-## Expanded
-
-<AndroidComponentScreenshots
-  lightMode={screenshotExpanded}
-  darkMode={screenshotExpandedDm}
-  altText="Android nav bar when expanded" />
-
-## Collapsed
-
-<AndroidComponentScreenshots
-  lightMode={screenshotCollapsed}
-  darkMode={screenshotCollapsedDm}
-  altText="Android nav bar when collapsed" />
-
-## With navigation elements
-
-<AndroidComponentScreenshots
-  lightMode={screenshotNavigation}
-  darkMode={screenshotNavigationDm}
-  altText="Android nav bar with navigation elements" />
-
-## Implementation
 
 <Readme />

--- a/docs/src/pages/components/NavigationBar/ComposeNavBar.mdx
+++ b/docs/src/pages/components/NavigationBar/ComposeNavBar.mdx
@@ -1,28 +1,12 @@
 ---
 title: Navigation bar
 platform: compose
-documentationId: net.skyscanner.backpack.compose.navigationbar
-githubPath: navigationbar
 ---
 
 
-import AndroidComponentScreenshots from 'components/Screenshots/AndroidComponentScreenshots';
-
 import NavigationBarReadme from 'backpack-android/docs/compose/NavBar/README.md';
-
-import Default from 'backpack-android/docs/compose/NavBar/screenshots/default.png';
-import DefaultDm from 'backpack-android/docs/compose/NavBar/screenshots/default_dm.png';
 
 
 # Table of contents
-
-# Default
-
-<AndroidComponentScreenshots
-  lightMode={Default}
-  darkMode={DefaultDm}
-  altText="NavigationBar" />
-
-# Implementation
 
 <NavigationBarReadme />

--- a/docs/src/pages/components/Nudger/AndroidNudger.mdx
+++ b/docs/src/pages/components/Nudger/AndroidNudger.mdx
@@ -1,25 +1,10 @@
 ---
 title: Nudger
 platform: android
-documentationId: net.skyscanner.backpack.nudger
-githubPath: nudger
 ---
 
-import AndroidComponentScreenshots from 'components/Screenshots/AndroidComponentScreenshots';
-
 import Readme from 'backpack-android/docs/view/Nudger/README.md';
-import screenshotDefault from 'backpack-android/docs/view/Nudger/screenshots/all.png';
-import screenshotDefaultDm from 'backpack-android/docs/view/Nudger/screenshots/all_dm.png';
 
 ## Table of contents
-
-## Default
-
-<AndroidComponentScreenshots
-  lightMode={screenshotDefault}
-  darkMode={screenshotDefaultDm}
-  altText="Android nudger component" />
-
-## Implementation
 
 <Readme />

--- a/docs/src/pages/components/Overlay/AndroidOverlay.mdx
+++ b/docs/src/pages/components/Overlay/AndroidOverlay.mdx
@@ -1,26 +1,11 @@
 ---
 title: Overlay
 platform: android
-documentationId: net.skyscanner.backpack.overlay
-githubPath: overlay
 ---
 
 
-import AndroidComponentScreenshots from 'components/Screenshots/AndroidComponentScreenshots';
-
 import Readme from 'backpack-android/docs/view/Overlay/README.md';
-import screenshotDefault from 'backpack-android/docs/view/Overlay/screenshots/all.png';
-import screenshotDefaultDm from 'backpack-android/docs/view/Overlay/screenshots/all_dm.png';
 
 ## Table of contents
-
-## Default
-
-<AndroidComponentScreenshots
-  lightMode={screenshotDefault}
-  darkMode={screenshotDefaultDm}
-  altText="Android overlay component" />
-
-## Implementation
 
 <Readme />

--- a/docs/src/pages/components/Panel/AndroidPanel.mdx
+++ b/docs/src/pages/components/Panel/AndroidPanel.mdx
@@ -1,26 +1,11 @@
 ---
 title: Panel
 platform: android
-documentationId: net.skyscanner.backpack.panel
-githubPath: panel
 ---
 
 
-import AndroidComponentScreenshots from 'components/Screenshots/AndroidComponentScreenshots';
-
 import Readme from 'backpack-android/docs/view/Panel/README.md';
-import screenshotDefault from 'backpack-android/docs/view/Panel/screenshots/all.png';
-import screenshotDefaultDm from 'backpack-android/docs/view/Panel/screenshots/all_dm.png';
 
 ## Table of contents
-
-## Default
-
-<AndroidComponentScreenshots
-  lightMode={screenshotDefault}
-  darkMode={screenshotDefaultDm}
-  altText="Android panel component" />
-
-## Implementation
 
 <Readme />

--- a/docs/src/pages/components/Panel/ComposePanel.mdx
+++ b/docs/src/pages/components/Panel/ComposePanel.mdx
@@ -1,28 +1,12 @@
 ---
 title: Panel
 platform: compose
-documentationId: net.skyscanner.backpack.compose.panel
-githubPath: panel
 ---
 
 
-import AndroidComponentScreenshots from 'components/Screenshots/AndroidComponentScreenshots';
-
 import PanelReadme from 'backpack-android/docs/compose/Panel/README.md';
-
-import Default from 'backpack-android/docs/compose/Panel/screenshots/all.png';
-import DefaultDm from 'backpack-android/docs/compose/Panel/screenshots/all_dm.png';
 
 
 ## Table of contents
-
-## Default
-
-<AndroidComponentScreenshots
-  lightMode={Default}
-  darkMode={DefaultDm}
-  altText="Panel" />
-
-## Implementation
 
 <PanelReadme />

--- a/docs/src/pages/components/RadioButton/AndroidRadioButton.mdx
+++ b/docs/src/pages/components/RadioButton/AndroidRadioButton.mdx
@@ -1,26 +1,11 @@
 ---
 title: Radio button
 platform: android
-documentationId: net.skyscanner.backpack.radiobutton
-githubPath: radiobutton
 ---
 
 
-import AndroidComponentScreenshots from 'components/Screenshots/AndroidComponentScreenshots';
-
 import Readme from 'backpack-android/docs/view/RadioButton/README.md';
-import screenshotDefault from 'backpack-android/docs/view/RadioButton/screenshots/default.png';
-import screenshotDefaultDm from 'backpack-android/docs/view/RadioButton/screenshots/default_dm.png';
 
 ## Table of contents
-
-## Default
-
-<AndroidComponentScreenshots
-  lightMode={screenshotDefault}
-  darkMode={screenshotDefaultDm}
-  altText="Android radio button" />
-
-## Implementation
 
 <Readme />

--- a/docs/src/pages/components/RadioButton/ComposeRadioButton.mdx
+++ b/docs/src/pages/components/RadioButton/ComposeRadioButton.mdx
@@ -1,28 +1,12 @@
 ---
 title: RadioButton
 platform: compose
-documentationId: net.skyscanner.backpack.compose.radiobutton
-githubPath: radiobutton
 ---
 
 
-import AndroidComponentScreenshots from 'components/Screenshots/AndroidComponentScreenshots';
-
 import RadioButtonReadme from 'backpack-android/docs/compose/RadioButton/README.md';
-
-import Default from 'backpack-android/docs/compose/RadioButton/screenshots/default.png';
-import DefaultDm from 'backpack-android/docs/compose/RadioButton/screenshots/default_dm.png';
 
 
 ## Table of contents
-
-## Default
-
-<AndroidComponentScreenshots
-  lightMode={Default}
-  darkMode={DefaultDm}
-  altText="RadioButton" />
-
-## Implementation
 
 <RadioButtonReadme />

--- a/docs/src/pages/components/Rating/AndroidRating.mdx
+++ b/docs/src/pages/components/Rating/AndroidRating.mdx
@@ -1,44 +1,11 @@
 ---
 title: Rating
 platform: android
-documentationId: net.skyscanner.backpack.rating
-githubPath: rating
 ---
 
 
-import AndroidComponentScreenshots from 'components/Screenshots/AndroidComponentScreenshots';
-
 import Readme from 'backpack-android/docs/view/Rating/README.md';
-import screenshotDefault from 'backpack-android/docs/view/Rating/screenshots/default.png';
-import screenshotDefaultDm from 'backpack-android/docs/view/Rating/screenshots/default_dm.png';
-import screenshotSizes from 'backpack-android/docs/view/Rating/screenshots/sizes.png';
-import screenshotSizesDm from 'backpack-android/docs/view/Rating/screenshots/sizes_dm.png';
-import screenshotVertical from 'backpack-android/docs/view/Rating/screenshots/vertical.png';
-import screenshotVerticalDm from 'backpack-android/docs/view/Rating/screenshots/vertical_dm.png';
 
 ## Table of contents
-
-## Default
-
-<AndroidComponentScreenshots
-  lightMode={screenshotDefault}
-  darkMode={screenshotDefaultDm}
-  altText="Android rating component" />
-
-## Sizes
-
-<AndroidComponentScreenshots
-  lightMode={screenshotSizes}
-  darkMode={screenshotSizesDm}
-  altText="Android rating in different sizes" />
-
-## Vertical
-
-<AndroidComponentScreenshots
-  lightMode={screenshotVertical}
-  darkMode={screenshotVerticalDm}
-  altText="Android rating in vertical orientation" />
-
-## Implementation
 
 <Readme />

--- a/docs/src/pages/components/Skeleton/AndroidSkeleton.mdx
+++ b/docs/src/pages/components/Skeleton/AndroidSkeleton.mdx
@@ -1,26 +1,11 @@
 ---
 title: Skeleton
 platform: android
-documentationId: net.skyscanner.backpack.skeleton
-githubPath: skeleton
 ---
 
 
-import AndroidComponentScreenshots from 'components/Screenshots/AndroidComponentScreenshots';
-
 import Readme from 'backpack-android/docs/view/Skeleton/README.md';
-import screenshot from 'backpack-android/docs/view/Skeleton/screenshots/default.png';
-import screenshotDm from 'backpack-android/docs/view/Skeleton/screenshots/default_dm.png';
 
 ## Table of contents
-
-## Snapshots
-
-<AndroidComponentScreenshots
-  lightMode={screenshot}
-  darkMode={screenshotDm}
-  altText="Android skeleton samples" />
-
-## Implementation
 
 <Readme />

--- a/docs/src/pages/components/Skeleton/ComposeSkeleton.mdx
+++ b/docs/src/pages/components/Skeleton/ComposeSkeleton.mdx
@@ -1,28 +1,12 @@
 ---
 title: Skeleton
 platform: compose
-documentationId: net.skyscanner.backpack.compose.skeleton
-githubPath: skeleton
 ---
 
 
-import AndroidComponentScreenshots from 'components/Screenshots/AndroidComponentScreenshots';
-
 import SkeletonReadme from 'backpack-android/docs/compose/Skeleton/README.md';
-
-import Default from 'backpack-android/docs/compose/Skeleton/screenshots/default.png';
-import DefaultDm from 'backpack-android/docs/compose/Skeleton/screenshots/default_dm.png';
 
 
 # Table of contents
-
-# Default
-
-<AndroidComponentScreenshots
-  lightMode={Default}
-  darkMode={DefaultDm}
-  altText="compose Skeleton samples" />
-
-# Implementation
 
 <SkeletonReadme />

--- a/docs/src/pages/components/Sliders/AndroidSlidersPage.mdx
+++ b/docs/src/pages/components/Sliders/AndroidSlidersPage.mdx
@@ -1,26 +1,11 @@
 ---
 title: Slider
 platform: android
-documentationId: net.skyscanner.backpack.slider
-githubPath: slider
 ---
 
 
-import AndroidComponentScreenshots from 'components/Screenshots/AndroidComponentScreenshots';
-
 import Readme from 'backpack-android/docs/view/Slider/README.md';
-import screenshotAll from 'backpack-android/docs/view/Slider/screenshots/all.png';
-import screenshotAllDm from 'backpack-android/docs/view/Slider/screenshots/all_dm.png';
 
 ## Table of contents
-
-## Default
-
-<AndroidComponentScreenshots
-  lightMode={screenshotAll}
-  darkMode={screenshotAllDm}
-  altText="Android slider component" />
-
-## Implementation
 
 <Readme />

--- a/docs/src/pages/components/Snackbar/AndroidSnackbar.mdx
+++ b/docs/src/pages/components/Snackbar/AndroidSnackbar.mdx
@@ -1,26 +1,11 @@
 ---
 title: Snackbar
 platform: android
-documentationId: net.skyscanner.backpack.snackbar
-githubPath: snackbar
 ---
 
 
-import AndroidComponentScreenshots from 'components/Screenshots/AndroidComponentScreenshots';
-
 import Readme from 'backpack-android/docs/view/Snackbar/README.md';
-import screenshotDefault from 'backpack-android/docs/view/Snackbar/screenshots/default.png';
-import screenshotDefaultDm from 'backpack-android/docs/view/Snackbar/screenshots/default_dm.png';
 
 ## Table of contents
-
-## Default
-
-<AndroidComponentScreenshots
-  lightMode={screenshotDefault}
-  darkMode={screenshotDefaultDm}
-  altText="Android snackbar component" />
-
-## Implementation
 
 <Readme />

--- a/docs/src/pages/components/Spinner/AndroidSpinner.mdx
+++ b/docs/src/pages/components/Spinner/AndroidSpinner.mdx
@@ -1,26 +1,11 @@
 ---
 title: Spinner
 platform: android
-documentationId: net.skyscanner.backpack.spinner
-githubPath: spinner
 ---
 
 
-import AndroidComponentScreenshots from 'components/Screenshots/AndroidComponentScreenshots';
-
 import Readme from 'backpack-android/docs/view/Spinner/README.md';
-import screenshotDefault from 'backpack-android/docs/view/Spinner/screenshots/default.png';
-import screenshotDefaultDm from 'backpack-android/docs/view/Spinner/screenshots/default_dm.png';
 
 ## Table of contents
-
-## Available options
-
-<AndroidComponentScreenshots
-  lightMode={screenshotDefault}
-  darkMode={screenshotDefaultDm}
-  altText="Android default spinner" />
-
-## Implementation
 
 <Readme />

--- a/docs/src/pages/components/Spinner/ComposeSpinner.mdx
+++ b/docs/src/pages/components/Spinner/ComposeSpinner.mdx
@@ -1,28 +1,12 @@
 ---
 title: Spinner
 platform: compose
-documentationId: net.skyscanner.backpack.compose.spinner
-githubPath: spinner
 ---
 
 
-import AndroidComponentScreenshots from 'components/Screenshots/AndroidComponentScreenshots';
-
 import SpinnerReadme from 'backpack-android/docs/compose/Spinner/README.md';
-
-import Default from 'backpack-android/docs/compose/Spinner/screenshots/default.png';
-import DefaultDm from 'backpack-android/docs/compose/Spinner/screenshots/default_dm.png';
 
 
 # Table of contents
-
-# Default
-
-<AndroidComponentScreenshots
-  lightMode={Default}
-  darkMode={DefaultDm}
-  altText="Spinner" />
-
-# Implementation
 
 <SpinnerReadme />

--- a/docs/src/pages/components/StarRating/AndroidStarRating.mdx
+++ b/docs/src/pages/components/StarRating/AndroidStarRating.mdx
@@ -1,42 +1,11 @@
 ---
 title: Star rating
 platform: android
-documentationId: net.skyscanner.backpack.starrating
-githubPath: starrating
 ---
 
 
-import AndroidComponentScreenshots from 'components/Screenshots/AndroidComponentScreenshots';
-
 import Readme from 'backpack-android/docs/view/StarRating/README.md';
-import StarRatingInteractiveReadme from 'backpack-android/docs/view/InteractiveStarRating/README.md';
-import screenshotStarRating from 'backpack-android/docs/view/StarRating/screenshots/default.png';
-import screenshotStarRatingDm from 'backpack-android/docs/view/StarRating/screenshots/default_dm.png';
-import screenshotInteractive from 'backpack-android/docs/view/InteractiveStarRating/screenshots/default.png';
-import screenshotInteractiveDm from 'backpack-android/docs/view/InteractiveStarRating/screenshots/default_dm.png';
 
 ## Table of contents
 
-## Star rating
-
-By default, star ratings are shown in a static form. These can be set at half star intervals.
-
-<AndroidComponentScreenshots
-  lightMode={screenshotStarRating}
-  darkMode={screenshotStarRatingDm}
-  altText="Android star rating" />
-
-## Interactive star rating
-
-This version allows users to leave feedback on a given feature or area by setting a rating. These can be set at half star intervals.
-
-<AndroidComponentScreenshots
-  lightMode={screenshotInteractive}
-  darkMode={screenshotInteractiveDm}
-  altText="Android interactive star rating" />
-
-## Implementation
-
 <Readme />
-
-<StarRatingInteractiveReadme />

--- a/docs/src/pages/components/Switch/AndroidSwitch.mdx
+++ b/docs/src/pages/components/Switch/AndroidSwitch.mdx
@@ -1,26 +1,11 @@
 ---
 title: Switch
 platform: android
-documentationId: net.skyscanner.backpack.toggle
-githubPath: toggle
 ---
 
 
-import AndroidComponentScreenshots from 'components/Screenshots/AndroidComponentScreenshots';
-
 import Readme from 'backpack-android/docs/view/Switch/README.md';
-import screenshotDefault from 'backpack-android/docs/view/Switch/screenshots/default.png';
-import screenshotDefaultDm from 'backpack-android/docs/view/Switch/screenshots/default_dm.png';
 
 ## Table of contents
-
-## Default
-
-<AndroidComponentScreenshots
-  lightMode={screenshotDefault}
-  darkMode={screenshotDefaultDm}
-  altText="Android switch component" />
-
-## Implementation
 
 <Readme />

--- a/docs/src/pages/components/Switch/ComposeSwitch.mdx
+++ b/docs/src/pages/components/Switch/ComposeSwitch.mdx
@@ -1,28 +1,12 @@
 ---
 title: Switch
 platform: compose
-documentationId: net.skyscanner.backpack.compose.switch
-githubPath: switch
 ---
 
 
-import AndroidComponentScreenshots from 'components/Screenshots/AndroidComponentScreenshots';
-
 import SwitchReadme from 'backpack-android/docs/compose/Switch/README.md';
-
-import Default from 'backpack-android/docs/compose/Switch/screenshots/default.png';
-import DefaultDm from 'backpack-android/docs/compose/Switch/screenshots/default_dm.png';
 
 
 ## Table of contents
-
-## Default
-
-<AndroidComponentScreenshots
-  lightMode={Default}
-  darkMode={DefaultDm}
-  altText="Switch" />
-
-## Implementation
 
 <SwitchReadme />

--- a/docs/src/pages/components/Text/AndroidText.mdx
+++ b/docs/src/pages/components/Text/AndroidText.mdx
@@ -1,63 +1,14 @@
 ---
 title: Text
 platform: android
-documentationId: net.skyscanner.backpack.text
-githubPath: text
 ---
 
-
-import AndroidComponentScreenshots from 'components/Screenshots/AndroidComponentScreenshots';
 
 import TextReadme from 'backpack-android/docs/view/Text/README.md';
 import TextSpanReadme from 'backpack-android/docs/view/TextSpans/README.md';
 
-import TextBody from 'backpack-android/docs/view/Text/screenshots/body.png';
-import TextBodyDm from 'backpack-android/docs/view/Text/screenshots/body_dm.png'
-import TextHeading from 'backpack-android/docs/view/Text/screenshots/heading.png';
-import TextHeadingDm from 'backpack-android/docs/view/Text/screenshots/heading_dm.png'
-import TextHero from 'backpack-android/docs/view/Text/screenshots/hero.png';
-import TextHeroDm from 'backpack-android/docs/view/Text/screenshots/hero_dm.png'
-
-
-import TextSpan from 'backpack-android/docs/view/TextSpans/screenshots/default.png'
-import TextSpanDm from 'backpack-android/docs/view/TextSpans/screenshots/default_dm.png'
-
 # Table of contents
 
-# Body
-
-<AndroidComponentScreenshots
-  lightMode={TextBody}
-  darkMode={TextBodyDm}
-  altText="Android body text" />
-
-# Heading
-
-<AndroidComponentScreenshots
-  lightMode={TextHeading}
-  darkMode={TextHeadingDm}
-  altText="Android heading text" />
-
-# Hero
-
-<AndroidComponentScreenshots
-  lightMode={TextHero}
-  darkMode={TextHeroDm}
-  altText="Android hero text" />
-
-# Text Implementation
-
 <TextReadme />
-
-# Text Span
-
-Text Spans are a set of styles to apply to characters sequence.
-
-<AndroidComponentScreenshots
-  lightMode={TextSpan}
-  darkMode={TextSpanDm}
-  altText="Android text spans" />
-
-# Text Span Implementation
 
 <TextSpanReadme />

--- a/docs/src/pages/components/Text/ComposeText.mdx
+++ b/docs/src/pages/components/Text/ComposeText.mdx
@@ -1,46 +1,12 @@
 ---
 title: Text
 platform: compose
-documentationId: net.skyscanner.backpack.compose.text
-githubPath: text
 ---
 
 
-import AndroidComponentScreenshots from 'components/Screenshots/AndroidComponentScreenshots';
-
 import TextReadme from 'backpack-android/docs/compose/Text/README.md';
-
-import TextBody from 'backpack-android/docs/compose/Text/screenshots/body.png';
-import TextBodyDm from 'backpack-android/docs/compose/Text/screenshots/body_dm.png'
-import TextHeading from 'backpack-android/docs/compose/Text/screenshots/heading.png';
-import TextHeadingDm from 'backpack-android/docs/compose/Text/screenshots/heading_dm.png'
-import TextHero from 'backpack-android/docs/compose/Text/screenshots/hero.png';
-import TextHeroDm from 'backpack-android/docs/compose/Text/screenshots/hero_dm.png'
 
 
 # Table of contents
-
-# Body
-
-<AndroidComponentScreenshots
-  lightMode={TextBody}
-  darkMode={TextBodyDm}
-  altText="Compose body text" />
-
-# Heading
-
-<AndroidComponentScreenshots
-  lightMode={TextHeading}
-  darkMode={TextHeadingDm}
-  altText="Compose heading text" />
-
-# Hero
-
-<AndroidComponentScreenshots
-  lightMode={TextHero}
-  darkMode={TextHeroDm}
-  altText="Compose hero text" />
-
-# Text Implementation
 
 <TextReadme />

--- a/docs/src/pages/components/TextInput/AndroidTextInput.mdx
+++ b/docs/src/pages/components/TextInput/AndroidTextInput.mdx
@@ -1,35 +1,11 @@
 ---
 title: Text input
 platform: android
-documentationId: net.skyscanner.backpack.text/-bpk-text-field
-githubPath: text
 ---
 
 
-import AndroidComponentScreenshots from 'components/Screenshots/AndroidComponentScreenshots';
-
 import Readme from 'backpack-android/docs/view/TextField/README.md';
-import screenshotDefault from 'backpack-android/docs/view/TextField/screenshots/default.png';
-import screenshotDefaultDm from 'backpack-android/docs/view/TextField/screenshots/default_dm.png';
-import screenshotLabels from 'backpack-android/docs/view/TextField/screenshots/labels.png';
-import screenshotLabelsDm from 'backpack-android/docs/view/TextField/screenshots/labels_dm.png';
 
 ## Table of contents
-
-## Default
-
-<AndroidComponentScreenshots
-  lightMode={screenshotDefault}
-  darkMode={screenshotDefaultDm}
-  altText="Android text field component" />
-
-## Labels
-
-<AndroidComponentScreenshots
-  lightMode={screenshotLabels}
-  darkMode={screenshotLabelsDm}
-  altText="Android text input layout component" />
-
-## Implementation
 
 <Readme />

--- a/docs/src/pages/components/TextInput/ComposeTextInput.mdx
+++ b/docs/src/pages/components/TextInput/ComposeTextInput.mdx
@@ -1,53 +1,11 @@
 ---
 title: Text input
 platform: compose
-documentationId: net.skyscanner.backpack.compose.textfield
-githubPath: textfield
 ---
 
 
-import AndroidComponentScreenshots from 'components/Screenshots/AndroidComponentScreenshots';
-
 import Readme from 'backpack-android/docs/compose/TextField/README.md';
-import screenshotDefault from 'backpack-android/docs/compose/TextField/screenshots/default.png';
-import screenshotDefaultDm from 'backpack-android/docs/compose/TextField/screenshots/default_dm.png';
-import screenshotDisabled from 'backpack-android/docs/compose/TextField/screenshots/disabled.png';
-import screenshotDisabledDm from 'backpack-android/docs/compose/TextField/screenshots/disabled_dm.png';
-import screenshotError from 'backpack-android/docs/compose/TextField/screenshots/error.png';
-import screenshotErrorDm from 'backpack-android/docs/compose/TextField/screenshots/error_dm.png';
-import screenshotValidated from 'backpack-android/docs/compose/TextField/screenshots/validated.png';
-import screenshotValidatedDm from 'backpack-android/docs/compose/TextField/screenshots/validated_dm.png';
 
 ## Table of contents
-
-## Default
-
-<AndroidComponentScreenshots
-  lightMode={screenshotDefault}
-  darkMode={screenshotDefaultDm}
-  altText="Compose text field component" />
-
-## Disabled
-
-<AndroidComponentScreenshots
-  lightMode={screenshotDisabled}
-  darkMode={screenshotDisabledDm}
-  altText="Compose text input disabled component" />
-
-## Error
-
-<AndroidComponentScreenshots
-  lightMode={screenshotError}
-  darkMode={screenshotErrorDm}
-  altText="Compose text input error component" />
-
-## Validated
-
-<AndroidComponentScreenshots
-  lightMode={screenshotValidated}
-  darkMode={screenshotValidatedDm}
-  altText="Compose text input validated component" />
-
-## Implementation
 
 <Readme />

--- a/docs/src/pages/components/Theming/AndroidTheming.mdx
+++ b/docs/src/pages/components/Theming/AndroidTheming.mdx
@@ -1,8 +1,6 @@
 ---
 title: Theming
 platform: android
-documentationId: net.skyscanner.backpack.util/-bpk-theme/
-githubPath: util/BpkTheme
 ---
 
 
@@ -10,7 +8,5 @@ githubPath: util/BpkTheme
 import Readme from 'backpack-android/docs/view/THEMING.md';
 
 ## Table of contents
-
-## Implementation
 
 <Readme />

--- a/docs/src/pages/components/Toast/AndroidToast.mdx
+++ b/docs/src/pages/components/Toast/AndroidToast.mdx
@@ -1,26 +1,11 @@
 ---
 title: Toast
 platform: android
-documentationId: net.skyscanner.backpack.toast
-githubPath: toast
 ---
 
 
-import AndroidComponentScreenshots from 'components/Screenshots/AndroidComponentScreenshots';
-
 import Readme from 'backpack-android/docs/view/Toast/README.md';
-import screenshotDefault from 'backpack-android/docs/view/Toast/screenshots/default.png';
-import screenshotDefaultDm from 'backpack-android/docs/view/Toast/screenshots/default_dm.png';
 
 ## Table of contents
-
-## Default
-
-<AndroidComponentScreenshots
-  lightMode={screenshotDefault}
-  darkMode={screenshotDefaultDm}
-  altText="Android toast component" />
-
-## Implementation
 
 <Readme />


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:
Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

Now that they're embedded in the Android docs we no longer need to include them here.

Remember to include the following changes:
+ [x] [Links platform metadata](https://github.com/Skyscanner/backpack-docs/blob/main/docs/src/layouts/links.js)
